### PR TITLE
Resolve paths beginning with tilde as $HOME

### DIFF
--- a/packages/cspell/src/Settings/DictionarySettings.test.ts
+++ b/packages/cspell/src/Settings/DictionarySettings.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import * as DictSettings from './DictionarySettings';
 import * as fsp from 'fs-extra';
+import * as path from 'path';
+import * as os from 'os';
 import { getDefaultSettings } from './DefaultSettings';
 
 const defaultSettings = getDefaultSettings();
@@ -50,6 +52,11 @@ describe('Validate DictionarySettings', () => {
         expect(dictionaryDefinitions).to.not.be.empty;
         const defs = DictSettings.normalizePathForDictDefs(dictionaryDefinitions!, '.');
         expect(defs.length).to.be.equal(dictionaryDefinitions!.length);
+
+        const basePath = path.join('some', 'dir');
+        dictionaryDefinitions![0].path = path.join('~', basePath);
+        const tildeDefs = DictSettings.normalizePathForDictDefs(dictionaryDefinitions!, '.');
+        expect(tildeDefs[0].path).to.be.equal(path.join(os.homedir(), basePath));
     });
 });
 

--- a/packages/cspell/src/Settings/DictionarySettings.ts
+++ b/packages/cspell/src/Settings/DictionarySettings.ts
@@ -1,5 +1,6 @@
 import { DictionaryDefinition, DictionaryId } from './CSpellSettingsDef';
 import * as path from 'path';
+import * as os from 'os';
 
 const dictionaryPath = () => path.join(__dirname, '..', '..', 'dist', 'dictionaries');
 
@@ -46,7 +47,7 @@ export function normalizePathForDictDef(def: DictionaryDefinition, defaultPath: 
         const absPath = relPath.match(/^\./) ? path.join(defaultPath, relPath) : relPath;
         return {
             ...def,
-            path:  absPath
+            path:  absPath.replace(/^~/, os.homedir())
         };
 }
 


### PR DESCRIPTION
This allows configuration files to be used across multiple machines where absolute paths may differ.

Please let me know if you have any objections to the test. It feels a bit weird to re-use the default settings that way, but it is less verbose than creating a new settings object just for this test.