### PR TITLE
Add snackbar to softwareTerms dictionary

### DIFF
--- a/packages/cspell-lib/dictionaries/softwareTerms.txt
+++ b/packages/cspell-lib/dictionaries/softwareTerms.txt
@@ -366,6 +366,7 @@ short
 shortint
 sin
 smalltalk
+snackbar
 sort
 SQL
 src


### PR DESCRIPTION
"Snackbar" has become a common term used to refer to UI elements showing notifications and such. 

[Snackbars on Google's Material Design Website](https://material.io/design/components/snackbars.html#)

I've added snackbar to the software terms dictionary, hopefully this is the appropriate dictionary to include the term 🙂 

Thanks!