### PR TITLE
Add repo to software terms dictionary

### DIFF
--- a/packages/cspell-lib/dictionaries/softwareTerms.txt
+++ b/packages/cspell-lib/dictionaries/softwareTerms.txt
@@ -337,6 +337,7 @@ refactored
 refactoring
 regex
 regexp
+repo
 requeue
 requeued
 requeueing


### PR DESCRIPTION
I've added "repo" (the short form of repository) to the software terms dictionary, hopefully this is the appropriate dictionary to include the term 🙂

Thanks!