### PR TITLE
Adds apiblueprint to languageIds

### DIFF
--- a/packages/cspell-lib/dictionaries/filetypes.txt
+++ b/packages/cspell-lib/dictionaries/filetypes.txt
@@ -1,3 +1,5 @@
+apib
+apiblueprint
 ascx
 asp
 aspx

--- a/packages/cspell-lib/src/LanguageIds.ts
+++ b/packages/cspell-lib/src/LanguageIds.ts
@@ -166,6 +166,7 @@ export const languageExtensionDefinitions: LanguageExtensionDefinitions = [
     { id: 'map', extensions: ['.map'], },
     { id: 'image', extensions: ['.jpg', '.png', '.jpeg', '.tiff', '.bmp', '.gif']},
     { id: 'binary', extensions: ['.gz', '.exe', '.dll', '.lib', '.obj', '.o']},
+    { id: 'apiblueprint', extensions: ['.apib', '.apiblueprint']},
 ];
 
 export const languageIds: string[] = languageExtensionDefinitions.map(({id}) => id);


### PR DESCRIPTION
Adds `apiblueprint` language ID as specified in [vscode-apielements](https://github.com/XVincentX/vscode-apielements).