### PR TITLE
Adds a ? to the HintedWalkerIterator interface for TS 3.6

### DIFF
--- a/packages/cspell-trie-lib/src/lib/walker.ts
+++ b/packages/cspell-trie-lib/src/lib/walker.ts
@@ -88,7 +88,7 @@ export interface HintedWalkerIterator extends IterableIterator<YieldResult> {
      * goDeeper of true tells the walker to go deeper in the Trie if possible. Default is true.
      * This can be used to limit the walker's depth.
      */
-    next: (hinting: Hinting) => IteratorResult<YieldResult>;
+    next: (hinting?: Hinting) => IteratorResult<YieldResult>;
     [Symbol.iterator]: () => WalkerIterator;
 }
 


### PR DESCRIPTION
:wave: love the vscode extension. Just started moving it to my CI for the TypeScript website in https://github.com/orta/danger-plugin-spellcheck/pull/20  

This PR makes this library usable in a project using TypeScript 3.6. ( Because the d.ts files are shipped with types which don't pass ) very likely these changes to tighten the inference on iterators are what broke it - https://github.com/Microsoft/TypeScript/issues/11375

