### PR TITLE
fix: Correct the DictionaryDefinition to how it is actually used.

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -3,6 +3,16 @@
   "additionalProperties": false,
   "definitions": {
     "DictionaryDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DictionaryDefinitionPreferred"
+        },
+        {
+          "$ref": "#/definitions/DictionaryDefinitionLegacy"
+        }
+      ]
+    },
+    "DictionaryDefinitionLegacy": {
       "additionalProperties": false,
       "properties": {
         "description": {
@@ -10,16 +20,16 @@
           "type": "string"
         },
         "file": {
-          "description": "File name",
-          "type": "string"
+          "$ref": "#/definitions/FsPath",
+          "description": "File name @deprecated use path"
         },
         "name": {
           "$ref": "#/definitions/DictionaryId",
           "description": "The reference name of the dictionary, used with program language settings"
         },
         "path": {
-          "description": "Path to the file, if undefined the path to the extension dictionaries is assumed",
-          "type": "string"
+          "$ref": "#/definitions/FsPath",
+          "description": "Path to the file, if undefined the path to the extension dictionaries is assumed"
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -36,8 +46,38 @@
         }
       },
       "required": [
+        "file",
+        "name"
+      ],
+      "type": "object"
+    },
+    "DictionaryDefinitionPreferred": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "description": "Optional description",
+          "type": "string"
+        },
+        "name": {
+          "$ref": "#/definitions/DictionaryId",
+          "description": "The reference name of the dictionary, used with program language settings"
+        },
+        "path": {
+          "$ref": "#/definitions/FsPath",
+          "description": "Path to the file, if undefined the path to the extension dictionaries is assumed"
+        },
+        "repMap": {
+          "$ref": "#/definitions/ReplaceMap",
+          "description": "Replacement pairs"
+        },
+        "useCompounds": {
+          "description": "Use Compounds",
+          "type": "boolean"
+        }
+      },
+      "required": [
         "name",
-        "file"
+        "path"
       ],
       "type": "object"
     },
@@ -52,6 +92,10 @@
     },
     "DictionaryId": {
       "description": "This matches the name in a dictionary definition",
+      "type": "string"
+    },
+    "FsPath": {
+      "description": "A File System Path",
       "type": "string"
     },
     "Glob": {
@@ -490,11 +534,11 @@
     "import": {
       "anyOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/FsPath"
         },
         {
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FsPath"
           },
           "type": "array"
         }

--- a/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
@@ -28,7 +28,7 @@ export interface FileSettings extends ExtendableSettings {
     userWords?: string[];
 
     /** Other settings files to be included */
-    import?: string | string[];
+    import?: FsPath | FsPath[];
 }
 
 export interface ExtendableSettings extends Settings {
@@ -177,15 +177,32 @@ export interface BaseSetting {
 
 export type DictionaryFileTypes = 'S'|'W'|'C'|'T';
 
-export interface DictionaryDefinition {
+export type DictionaryDefinition = DictionaryDefinitionPreferred | DictionaryDefinitionLegacy;
+
+export interface DictionaryDefinitionBase {
     /** The reference name of the dictionary, used with program language settings */
     name: DictionaryId;
     /** Optional description */
     description?: string;
+    /** Replacement pairs */
+    repMap?: ReplaceMap;
+    /** Use Compounds */
+    useCompounds?: boolean;
+}
+
+export interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase {
     /** Path to the file, if undefined the path to the extension dictionaries is assumed */
-    path?: string;
-    /** File name */
-    file: string;
+    path: FsPath;
+}
+
+/**
+ * @deprecated
+ */
+export interface DictionaryDefinitionLegacy extends DictionaryDefinitionBase {
+    /** Path to the file, if undefined the path to the extension dictionaries is assumed */
+    path?: FsPath;
+    /** File name @deprecated use path */
+    file: FsPath;
     /**
      * Type of file:
      * S - single word per line,
@@ -196,10 +213,6 @@ export interface DictionaryDefinition {
      * @default "S"
      */
     type?: DictionaryFileTypes;
-    /** Replacement pairs */
-    repMap?: ReplaceMap;
-    /** Use Compounds */
-    useCompounds?: boolean;
 }
 
 export interface LanguageSetting extends LanguageSettingFilterFields, BaseSetting {
@@ -253,6 +266,9 @@ export type Glob = string;
 
 /** This can be '*', 'typescript', 'cpp', 'json', etc. */
 export type LanguageId = string;
+
+/** A File System Path */
+export type FsPath = string;
 
 export interface RegExpPatternDefinition {
     /**

--- a/packages/cspell-lib/src/Settings/DictionarySettings.ts
+++ b/packages/cspell-lib/src/Settings/DictionarySettings.ts
@@ -1,4 +1,4 @@
-import { DictionaryDefinition, DictionaryId } from './CSpellSettingsDef';
+import { DictionaryDefinition, DictionaryId, DictionaryDefinitionLegacy } from './CSpellSettingsDef';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -29,8 +29,8 @@ export function filterDictDefsToLoad(dictIds: DictionaryId[], defs: DictionaryDe
 }
 
 function getFullPathName(def: DictionaryDefinition) {
-    const { path: filePath = '', file = '' } = def;
-    if (filePath + file === '') {
+    const { path: filePath = '', file = '' } = def as DictionaryDefinitionLegacy;
+    if (!filePath && !file) {
         return '';
     }
     const dictPath = path.join(filePath || dictionaryPath(), file);
@@ -50,4 +50,3 @@ export function normalizePathForDictDef(def: DictionaryDefinition, defaultPath: 
             path:  absPath.replace(/^~/, os.homedir())
         };
 }
-


### PR DESCRIPTION
A dictionary definition only needs a path. The `file` property is no longer needed.