### PR TITLE
fix(cspell): Fixes files getting skipped if there are multiple files listed in the command line.

### DIFF
--- a/packages/cspell/.vscode/launch.json
+++ b/packages/cspell/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "name": "cspell: Run",
             "program": "${workspaceRoot}/dist/app.js",
-			"args": ["--root=..", "-v", "**/*.ts" ],
+			"args": ["--root=..", "-v", "**/*.ts", "*.md" ],
             "cwd": "${workspaceRoot}",
 			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
             "sourceMaps": true

--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -483,28 +483,11 @@ function normalizePattern(pat: string, root: string): PatternRoot {
     };
 }
 
-function groupPatterns(patterns: PatternRoot[]): PatternRoot[] {
-    const groups = new Map<string, string[]>();
-    patterns.forEach(pat => {
-        const pats = groups.get(pat.root) || [];
-        pats.push(pat.pattern);
-        groups.set(pat.root, pats);
-    });
-    const resultPatterns: PatternRoot[] = [];
-    for (const [root, patterns] of groups) {
-        resultPatterns.push({
-            root,
-            pattern: patterns.join(','),
-        });
-    }
-    return resultPatterns;
-}
-
 async function globP(pattern: string | string[], options?: GlobOptions): Promise<string[]> {
     const root = options?.root || process.cwd();
     const opts = options || {};
     const rawPatterns = typeof pattern === 'string' ? [ pattern ] : pattern;
-    const normPatterns = groupPatterns(rawPatterns.map(pat => normalizePattern(pat, root)));
+    const normPatterns = rawPatterns.map(pat => normalizePattern(pat, root));
     const globResults = normPatterns.map(async pat => {
         const opt: GlobOptions = {...opts, root: pat.root, cwd: pat.root};
         const absolutePaths = (await _globP(pat.pattern, opt))
@@ -535,6 +518,5 @@ function _globP(pattern: string, options: GlobOptions): Promise<string[]> {
 export const _testing_ = {
     _globP,
     findFiles,
-    groupPatterns,
     normalizePattern,
 };

--- a/packages/cspell/test/mocha.opts
+++ b/packages/cspell/test/mocha.opts
@@ -1,2 +1,0 @@
---require ts-node/register/transpile-only
---require source-map-support/register


### PR DESCRIPTION
Fix #182
Might also fix #198 
