### PR TITLE
adds Ziltoid to miscTerms list

### DIFF
--- a/packages/cspell-lib/dictionaries/miscTerms.txt
+++ b/packages/cspell-lib/dictionaries/miscTerms.txt
@@ -361,5 +361,6 @@ xml
 xpath
 xsl
 yaml
+ziltoid
 zip
 zlib


### PR DESCRIPTION
I frequently use this term for tests ([e.g.](https://github.com/typescript-eslint/typescript-eslint/pull/2099/files#diff-609e45e04d808afd08830c4ae5224b31R112)), and I humbly request that it be added to `miscTerms`.  I cannot find any mispellings of other words that are proximate.  [context](https://en.wikipedia.org/wiki/Ziltoid_the_Omniscient)

Thank you for your consideration :)