### PR TITLE
fix: import resolution adjustment to support npm v7 workspaces

### DIFF
--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -527,6 +527,11 @@
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -87,6 +87,7 @@
     "fs-extra": "^9.0.1",
     "gensequence": "^3.1.1",
     "minimatch": "^3.0.4",
+    "resolve-from": "^5.0.0",
     "vscode-uri": "^2.1.2"
   },
   "engines": {

--- a/packages/cspell-lib/samples/linked/cspell-import-missing.json
+++ b/packages/cspell-lib/samples/linked/cspell-import-missing.json
@@ -1,0 +1,6 @@
+{
+  "import": "../intentionally-missing-file.json",
+  "words": [
+      "import"
+  ]
+}

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -149,6 +149,11 @@ describe('Validate CSpellSettingsServer', () => {
         expect(settings.words).toEqual(expect.arrayContaining(['leuk']));
     });
 
+    test('tests loading a cSpell.json with a missing import file', () => {
+        const filename = path.join(__dirname, '..', '..', 'samples', 'linked', 'cspell-import-missing.json');
+        expect(() => readSettings(filename)).toThrow('Cannot find module \'../intentionally-missing-file.json\'');
+    });
+
     test('makes sure global settings is an object', () => {
         const settings = getGlobalSettings();
         expect(Object.keys(settings)).not.toHaveLength(0);

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -258,7 +258,7 @@ function resolveFilename(filename: string, relativeTo: string) {
             throw error;
         }
         // Try to resolve as a relative module
-        const normalizedFilename = path.sep === '/' ? filename  : filename.split(path.sep).join('/')
+        const normalizedFilename = path.sep === '/' ? filename  : filename.split(path.sep).join('/');
         return resolveFrom(relativeTo, `./${normalizedFilename}`);
     }
 }

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -258,7 +258,8 @@ function resolveFilename(filename: string, relativeTo: string) {
             throw error;
         }
         // Try to resolve as a relative module
-        return resolveFrom(relativeTo, `./${filename}`);
+        const normalizedFilename = path.sep === '/' ? filename  : filename.split(path.sep).join('/')
+        return resolveFrom(relativeTo, `./${normalizedFilename}`);
     }
 }
 


### PR DESCRIPTION
This change to the config import resolution is backwards compatible with the current resolution, so there are no breaking changes.

## Current behavior
When using npm 7 workspaces (or any monorepo structure that does not explicitly symlink every dependency) cspell fails to resolve shared configs that are installed at the workspace root.

## New behavior
cspell now uses a relative require which makes use of the Node.js resolution algorithm. This means that a sharable config may now also specify a "main" field in `package.json` instead of requiring users to explicitly use a complete filename.

So now instead of this with the explicit filename:
```json
{
  "import": ["node_modules/my-cspell-config-package/cspell.json"]
}
```

A user can do this, as long as `cspell.json` (or any other filename) is defined as the value for `main` or `exports` in `package.json`:
```json
{
  "import": ["my-cspell-config-package"]
}
```


