### PR TITLE
feat: add mdx support

### DIFF
--- a/packages/cspell-lib/config/cspell-default.json
+++ b/packages/cspell-lib/config/cspell-default.json
@@ -24,9 +24,9 @@
     "languageSettings": [
         { "languageId": "*",                                   "dictionaries": ["companies", "softwareTerms", "misc", "filetypes"] },
         { "languageId": "csharp", "allowCompoundWords": true,  "dictionaries": ["csharp", "dotnet", "npm"] },
-        { "languageId": "javascript,javascriptreact",          "dictionaries": ["typescript", "node", "npm"] },
-        { "languageId": "typescript,typescriptreact",          "dictionaries": ["typescript", "node", "npm"] },
-        { "languageId": "javascriptreact,typescriptreact",     "dictionaries": ["html", "css", "fonts"] },
+        { "languageId": "javascript,javascriptreact,mdx",      "dictionaries": ["typescript", "node", "npm"] },
+        { "languageId": "typescript,typescriptreact,mdx",      "dictionaries": ["typescript", "node", "npm"] },
+        { "languageId": "javascriptreact,typescriptreact,mdx", "dictionaries": ["html", "css", "fonts"] },
         { "languageId": "markdown,asciidoc",                   "dictionaries": ["npm", "html"] },
         { "languageId": "html,pug,jade",                       "dictionaries": ["html", "fonts", "typescript", "css", "npm"] },
         { "languageId": "handlebars",                          "dictionaries": ["html", "css", "fonts", "typescript"] },
@@ -37,7 +37,7 @@
         { "languageId": "image",  "enabled": false },
         { "languageId": "binary", "enabled": false },
 
-        { "languageId": "markdown,html",                       "ignoreRegExpList": ["/&[a-z]+;/g"] },
+        { "languageId": "markdown,html,mdx",                   "ignoreRegExpList": ["/&[a-z]+;/g"] },
         { "languageId": "html",                                "ignoreRegExpList": ["href"] },
         {
             "languageId": "markdown",

--- a/packages/cspell-lib/dictionaries/filetypes.txt
+++ b/packages/cspell-lib/dictionaries/filetypes.txt
@@ -111,6 +111,7 @@ markdown
 md
 mdoc
 mdown
+mdx
 menu
 mjs
 mk

--- a/packages/cspell-lib/dictionaries/miscTerms.txt
+++ b/packages/cspell-lib/dictionaries/miscTerms.txt
@@ -192,6 +192,7 @@ mapfn
 markdown
 maxptime
 mdn
+mdx
 mimetype
 memoize
 MERCHANTABLITY

--- a/packages/cspell-lib/src/LanguageIds.ts
+++ b/packages/cspell-lib/src/LanguageIds.ts
@@ -72,6 +72,7 @@ export const languageExtensionDefinitions: LanguageExtensionDefinitions = [
     { id: 'lua', extensions: ['.lua'], },
     { id: 'makefile', extensions: ['.mk'], },
     { id: 'markdown', extensions: ['.md', '.mdown', '.markdown', '.markdn'], },
+    { id: 'mdx', extensions: ['.mdx'], },
     { id: 'objective-c', extensions: ['.m'], },
     { id: 'perl', extensions: ['.pl', '.pm', '.pod', '.t', '.PL', '.psgi'], },
     { id: 'perl6', extensions: ['.p6', '.pl6', '.pm6', '.nqp'], },

--- a/packages/cspell-lib/src/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/Settings/DefaultSettings.ts
@@ -57,7 +57,7 @@ export const _defaultSettings: CSpellSettingsWithSourceTrace = {
     name: 'Static Defaults',
     enabled: true,
     enabledLanguageIds: [
-        'csharp', 'go', 'javascript', 'javascriptreact', 'json', 'markdown',
+        'csharp', 'go', 'javascript', 'javascriptreact', 'json', 'markdown', 'mdx',
         'php', 'plaintext', 'python', 'text', 'typescript', 'typescriptreact',
         'html', 'css', 'less', 'scss',
         'latex', 'ruby', 'rust', 'shellscript', 'toml'

--- a/packages/cspell-trie/samples/softwareTerms.txt
+++ b/packages/cspell-trie/samples/softwareTerms.txt
@@ -265,6 +265,7 @@ make
 manpage
 map
 map
+mdx
 member
 memcache
 memcached


### PR DESCRIPTION
[MDX][mdx] is a pretty useful extension of markdown that allows using JSX and imports directly within markdown files. It's been around for a few years now, but gaining more momentum from being used in projects such as Gatsby and Docz.

[mdx]: https://github.com/mdx-js/mdx