### PR TITLE
Enforce whitespace after language in-doc setting

### DIFF
--- a/packages/cspell-lib/src/Settings/InDocSettings.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.ts
@@ -30,7 +30,7 @@ function parseSettingMatch(possibleSetting: string): CSpellUserSettings[] {
         [ /^ignore(?:words?)?\s/i, parseIgnoreWords ],
         [ /^ignore_?Reg_?Exp\s+.+$/i, parseIgnoreRegExp ],
         [ /^include_?Reg_?Exp\s+.+$/i, parseIncludeRegExp ],
-        [ /^(?:local|language)/i, parseLocal ],
+        [ /^(?:local|language)\s/i, parseLocal ],
     ];
 
     return settingParsers


### PR DESCRIPTION
Without the whitespace added to the regex it was allowing things like `cspell:languagetoset fr` to be valid and take effect.