### PR TITLE
feat: Improved Spelling guards

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${file}"
+            "program": "${workspaceFolder}/bin.js",
+            "args": ["trace", "hello"]
         }
     ]
 }

--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -364,12 +364,12 @@
           "$ref": "#/definitions/PatternId"
         },
         {
-          "$ref": "#/definitions/PreDefinedPatterns"
+          "$ref": "#/definitions/PredefinedPatterns"
         }
       ],
       "description": "A PatternRef is a Pattern or PatternId."
     },
-    "PreDefinedPatterns": {
+    "PredefinedPatterns": {
       "enum": [
         "Base64",
         "CStyleComment",
@@ -407,8 +407,18 @@
           "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value."
         },
         "pattern": {
-          "$ref": "#/definitions/Pattern",
-          "description": "RegExp pattern"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Pattern"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/Pattern"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "RegExp pattern or array of RegExp patterns"
         }
       },
       "required": [

--- a/packages/cspell-glob/tsconfig.json
+++ b/packages/cspell-glob/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-io/tsconfig.json
+++ b/packages/cspell-io/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "ES2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
@@ -240,17 +240,12 @@ export interface LanguageSettingFilterFields {
     local?: LocaleId | LocaleId[];
 }
 
-export type RegExpList = PatternRef[];
-
-/** A PatternRef is a Pattern or PatternId. */
-export type PatternRef = Pattern | PatternId | PreDefinedPatterns;
-
 /** @hidden */
 type InternalRegExp = RegExp
 
 export type Pattern = string | InternalRegExp;
 
-export type PreDefinedPatterns =
+export type PredefinedPatterns =
     'Base64' |
     'CStyleComment' |
     'Email' |
@@ -269,6 +264,10 @@ export type PreDefinedPatterns =
 
 /** This matches the name in a pattern definition */
 export type PatternId = string;
+
+/** A PatternRef is a Pattern or PatternId. */
+export type PatternRef = Pattern | PatternId | PredefinedPatterns;
+export type RegExpList = PatternRef[];
 
 /** This matches the name in a dictionary definition */
 export type DictionaryId = string;
@@ -297,9 +296,9 @@ export interface RegExpPatternDefinition {
      */
     name: PatternId;
     /**
-     * RegExp pattern
+     * RegExp pattern or array of RegExp patterns
      */
-    pattern: Pattern;
+    pattern: Pattern | Pattern[];
     /**
      * Description of the pattern.
      */

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -8,6 +8,7 @@ import {
     Source,
     LanguageSetting,
     CSpellSettingsWithSourceTrace,
+    Pattern,
 } from './CSpellSettingsDef';
 import * as path from 'path';
 import { normalizePathForDictDefs } from './DictionarySettings';
@@ -75,12 +76,11 @@ function importSettings(filename: string, defaultValues: CSpellSettings = defaul
     const id = [path.basename(path.dirname(filename)), path.basename(filename)].join('/');
     const finalizeSettings: CSpellSettingsWithSourceTrace = { id };
     cachedFiles.set(filename, finalizeSettings); // add an empty entry to prevent circular references.
-    const settings: CSpellSettings = {...defaultValues as CSpellSettings, id, ...readJsonFile(filename)};
+    const settings: CSpellSettings = {...defaultValues, id, ...readJsonFile(filename)};
     const pathToSettings = path.dirname(filename);
 
     Object.assign(finalizeSettings, normalizeSettings(settings, pathToSettings));
-    const finalizeSrc = finalizeSettings.source || {} as Source;
-    const name = finalizeSrc.name || path.basename(filename);
+    const finalizeSrc: Source = { name: path.basename(filename), ...finalizeSettings.source };
     finalizeSettings.source = { ...finalizeSrc, filename, name };
     cachedFiles.set(filename, finalizeSettings);
     return finalizeSettings;
@@ -233,12 +233,23 @@ export function finalizeSettings(settings: CSpellSettings): CSpellSettings {
     return finalized;
 }
 
-function applyPatterns(regExpList: (string | RegExp)[] = [], patterns: RegExpPatternDefinition[] = []): (string|RegExp)[] {
-    const patternMap = new Map(patterns
-        .map(def => [def.name.toLowerCase(), def.pattern] as [string, string|RegExp])
+function applyPatterns(regExpList: (string | RegExp)[] = [], patternDefinitions: RegExpPatternDefinition[] = []): (string|RegExp)[] {
+    const patternMap = new Map(patternDefinitions
+        .map(def => [def.name.toLowerCase(), def.pattern])
     );
 
-    return regExpList.map(p => patternMap.get(p.toString().toLowerCase()) || p);
+    function *flatten(patterns: (Pattern | Pattern[])[]): IterableIterator<Pattern> {
+        for (const pattern of patterns) {
+            if (Array.isArray(pattern)) {
+                yield *flatten(pattern);
+            } else {
+                yield pattern;
+            }
+        }
+    }
+    const patternList = regExpList.map(p => patternMap.get(p.toString().toLowerCase()) || p);
+
+    return [...flatten(patternList)];
 }
 
 const testNodeModules = /^node_modules\//;

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -81,7 +81,7 @@ function importSettings(filename: string, defaultValues: CSpellSettings = defaul
 
     Object.assign(finalizeSettings, normalizeSettings(settings, pathToSettings));
     const finalizeSrc: Source = { name: path.basename(filename), ...finalizeSettings.source };
-    finalizeSettings.source = { ...finalizeSrc, filename, name };
+    finalizeSettings.source = { ...finalizeSrc, filename };
     cachedFiles.set(filename, finalizeSettings);
     return finalizeSettings;
 }

--- a/packages/cspell-lib/src/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/Settings/DefaultSettings.ts
@@ -1,4 +1,4 @@
-import { CSpellSettings, RegExpPatternDefinition, DictionaryDefinition, CSpellSettingsWithSourceTrace } from './CSpellSettingsDef';
+import { CSpellSettings, RegExpPatternDefinition, DictionaryDefinition, CSpellSettingsWithSourceTrace, PredefinedPatterns } from './CSpellSettingsDef';
 import * as LanguageSettings from './LanguageSettings';
 import * as RegPat from './RegExpPatterns';
 import { readSettings } from './CSpellSettingsServer';
@@ -7,24 +7,16 @@ import { mergeSettings } from './index';
 
 // cspell:ignore filetypes
 
-const defaultRegExpExcludeList = [
-    'SpellCheckerDisable',
-    'Urls',
-    'Email',
-    'PublicKey',
-    'RsaCert',
-    'Base64',
-    'SHA',
-];
-
 const defaultConfigFile = Path.join(__dirname, '..', '..', 'config', 'cspell-default.json');
 
-const defaultRegExpPatterns: RegExpPatternDefinition[] = [
+const regExpSpellCheckerDisable = [ RegPat.regExSpellingGuardBlock, RegPat.regExSpellingGuardLine, RegPat.regExSpellingGuardNext ];
+
+const predefinedPatterns = [
     // Exclude patterns
     { name: 'Urls',                 pattern: RegPat.regExMatchUrls },
     { name: 'HexDigits',            pattern: RegPat.regExHexDigits },
     { name: 'HexValues',            pattern: RegPat.regExMatchCommonHexFormats },
-    { name: 'SpellCheckerDisable',  pattern: RegPat.regExSpellingGuard },
+    { name: 'SpellCheckerDisable',  pattern: regExpSpellCheckerDisable},
     { name: 'PublicKey',            pattern: RegPat.regExPublicKey },
     { name: 'RsaCert',              pattern: RegPat.regExCert },
     { name: 'EscapeCharacters',     pattern: RegPat.regExEscapeCharacters },
@@ -38,7 +30,28 @@ const defaultRegExpPatterns: RegExpPatternDefinition[] = [
     { name: 'string',               pattern: RegPat.regExString },
     { name: 'CStyleComment',        pattern: RegPat.regExCStyleComments },
     { name: 'Everything',           pattern: '.*' },
+] as const;
+
+type NameType<T> = T extends readonly ({ name: infer U })[] ? U : never;
+
+type ExtendsType<T, U> = T extends U ? T : never;
+
+type PredefinedPatternNames = ExtendsType<NameType<typeof predefinedPatterns>, PredefinedPatterns>;
+
+const defaultRegExpPatterns: RegExpPatternDefinition[] = [...predefinedPatterns];
+
+const definedDefaultRegExpExcludeList: PredefinedPatterns[] = [
+    'SpellCheckerDisable',
+    'Urls',
+    'Email',
+    'PublicKey',
+    'RsaCert',
+    'Base64',
+    'SHA',
 ];
+
+// This bit of copying is done to have the complier ensure that the defaults exist.
+const defaultRegExpExcludeList: PredefinedPatternNames[] = definedDefaultRegExpExcludeList;
 
 const defaultDictionaryDefs: DictionaryDefinition[] = [
     { name: 'css',            file: 'css.txt.gz',           type: 'S', description: 'CSS Keywords.' },
@@ -49,7 +62,6 @@ const defaultDictionaryDefs: DictionaryDefinition[] = [
     { name: 'node',           file: 'node.txt.gz',          type: 'S', description: 'List of NodeJS terms.' },
     { name: 'npm',            file: 'npm.txt.gz',           type: 'S', description: 'List of Top 500 NPM packages.' },
 ];
-
 
 export const _defaultSettings: CSpellSettingsWithSourceTrace = {
     id: 'static_defaults',

--- a/packages/cspell-lib/src/Settings/RegExpPatterns.test.ts
+++ b/packages/cspell-lib/src/Settings/RegExpPatterns.test.ts
@@ -8,14 +8,11 @@ const matchHexValues = regExMatchCommonHexFormats.source;
 
 describe('Validate InDocSettings', () => {
 
-    test('tests regExSpellingGuard', () => {
-        const m1 = sampleCode2LF.match(RegPat.regExSpellingGuard);
+    test('tests regExSpellingGuardBlock', () => {
+        const m1 = sampleCode2LF.match(RegPat.regExSpellingGuardBlock);
         expect(m1).not.toBeFalsy();
-        expect(m1).toHaveLength(5);
         // cspell:disable
         expect(m1).toEqual([
-            "const badspelling = 'disable'; // spell-checker:disable-line, yes all of it.",
-            "cspell:disable-next\nconst verybadspelling = 'disable';\n",
             "spell-checker:disable\nconst unicodeHexValue = '\\uBABC';\nconst unicodeHexValue2 = '\\x{abcd}';\n\n// spell-checker:enable",
             'spell-checker:disable */\n\n// nested disabled checker is not supported.\n\n// spell-checker:disable\n\n// nested spell-checker:enable',
             'cSpell:disable\n\nNot checked.\n\n',
@@ -23,17 +20,54 @@ describe('Validate InDocSettings', () => {
         // cspell:enable
     });
 
-    test('tests regExSpellingGuard CRLF', () => {
-        const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuard);
+    test('tests regExSpellingGuardBlock CRLF', () => {
+        const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuardBlock);
         expect(m1).not.toBeFalsy;
-        expect(m1).toHaveLength(5);
         // cspell:disable
         expect(m1).toEqual([
-            "const badspelling = 'disable'; // spell-checker:disable-line, yes all of it.",
-            "cspell:disable-next\nconst verybadspelling = 'disable';\n",
             "spell-checker:disable\nconst unicodeHexValue = '\\uBABC';\nconst unicodeHexValue2 = '\\x{abcd}';\n\n// spell-checker:enable",
             'spell-checker:disable */\n\n// nested disabled checker is not supported.\n\n// spell-checker:disable\n\n// nested spell-checker:enable',
             'cSpell:disable\n\nNot checked.\n\n',
+        ].map(a => a.replace(/\n/g, '\r\n')));
+        // cspell:enable
+    });
+
+    test('tests regExSpellingGuardLine', () => {
+        const m1 = sampleCode2LF.match(RegPat.regExSpellingGuardLine);
+        expect(m1).not.toBeFalsy();
+        // cspell:disable
+        expect(m1).toEqual([
+            "const badspelling = 'disable'; // spell-checker:disable-line, yes all of it.",
+        ]);
+        // cspell:enable
+    });
+
+    test('tests regExSpellingGuardLine CRLF', () => {
+        const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuardLine);
+        expect(m1).not.toBeFalsy;
+        // cspell:disable
+        expect(m1).toEqual([
+            "const badspelling = 'disable'; // spell-checker:disable-line, yes all of it.",
+        ].map(a => a.replace(/\n/g, '\r\n')));
+        // cspell:enable
+    });
+
+    test('tests regExSpellingGuardNext', () => {
+        const m1 = sampleCode2LF.match(RegPat.regExSpellingGuardNext);
+        expect(m1).not.toBeFalsy();
+        // cspell:disable
+        expect(m1).toEqual([
+            "cspell:disable-next\nconst verybadspelling = 'disable';",
+        ]);
+        // cspell:enable
+    });
+
+    test('tests regExSpellingGuardNext CRLF', () => {
+        const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuardNext);
+        expect(m1).not.toBeFalsy;
+        // cspell:disable
+        expect(m1).toEqual([
+            "cspell:disable-next\nconst verybadspelling = 'disable';",
         ].map(a => a.replace(/\n/g, '\r\n')));
         // cspell:enable
     });
@@ -42,7 +76,9 @@ describe('Validate InDocSettings', () => {
         const text = sampleCode2LF;
         const ranges = TextRange.findMatchingRangesForPatterns([
             RegPat.regExMatchUrls,
-            RegPat.regExSpellingGuard,
+            RegPat.regExSpellingGuardBlock,
+            RegPat.regExSpellingGuardLine,
+            RegPat.regExSpellingGuardNext,
             RegPat.regExMatchCommonHexFormats,
         ], text);
         expect(rangesToText(text, ranges)).toEqual([
@@ -52,7 +88,7 @@ describe('Validate InDocSettings', () => {
         ' 10: 19 0x5612abcd',
         ' 11: 28 0xbadc0ffee',
         " 13:  1 const badspelling = 'disable'; // spell-checker:disable-line, yes all of it.",
-        " 15:  4 cspell:disable-next\nconst verybadspelling = 'disable';\n",
+        " 15:  4 cspell:disable-next\nconst verybadspelling = 'disable';",
         " 19:  4 spell-checker:disable\nconst unicodeHexValue = '\\uBABC';\nconst unicodeHexValue2 = '\\x{abcd}';\n\n// spell-checker:enable",
         ' 29:  4 spell-checker:disable */\n\n// nested disabled checker is not supported.\n\n// spell-checker:disable\n\n// nested spell-checker:enable',
         ' 67:  4 cSpell:disable\n\nNot checked.\n\n'        ,
@@ -63,7 +99,9 @@ describe('Validate InDocSettings', () => {
         const text = sampleCode2CRLF;
         const ranges = TextRange.findMatchingRangesForPatterns([
             RegPat.regExMatchUrls,
-            RegPat.regExSpellingGuard,
+            RegPat.regExSpellingGuardBlock,
+            RegPat.regExSpellingGuardLine,
+            RegPat.regExSpellingGuardNext,
             RegPat.regExMatchCommonHexFormats,
         ], text);
         expect(rangesToText(text, ranges)).toEqual([
@@ -73,7 +111,7 @@ describe('Validate InDocSettings', () => {
         ' 10: 19 0x5612abcd',
         ' 11: 28 0xbadc0ffee',
         " 13:  1 const badspelling = 'disable'; // spell-checker:disable-line, yes all of it.",
-        " 15:  4 cspell:disable-next\r\nconst verybadspelling = 'disable';\r\n",
+        " 15:  4 cspell:disable-next\r\nconst verybadspelling = 'disable';",
         " 19:  4 spell-checker:disable\r\nconst unicodeHexValue = '\\uBABC';\r\nconst unicodeHexValue2 = '\\x{abcd}';\r\n\r\n// spell-checker:enable",
         ' 29:  4 spell-checker:disable */\r\n\r\n// nested disabled checker is not supported.\r\n\r\n'
         + '// spell-checker:disable\r\n\r\n// nested spell-checker:enable',
@@ -91,7 +129,9 @@ describe('Validate InDocSettings', () => {
                 RegPat.regExCStyleComments,
             ], text);
             const excludeRanges = TextRange.findMatchingRangesForPatterns([
-                RegPat.regExSpellingGuard,
+                RegPat.regExSpellingGuardBlock,
+                RegPat.regExSpellingGuardLine,
+                RegPat.regExSpellingGuardNext,
                 RegPat.regExMatchUrls,
                 RegPat.regExMatchCommonHexFormats,
             ], text);
@@ -136,7 +176,9 @@ describe('Validate InDocSettings', () => {
                 RegPat.regExCStyleComments,
             ], text);
             const excludeRanges = TextRange.findMatchingRangesForPatterns([
-                RegPat.regExSpellingGuard,
+                RegPat.regExSpellingGuardBlock,
+                RegPat.regExSpellingGuardLine,
+                RegPat.regExSpellingGuardNext,
                 RegPat.regExMatchUrls,
                 RegPat.regExMatchCommonHexFormats,
             ], text);
@@ -184,7 +226,11 @@ describe('Validate InDocSettings', () => {
         expect(hexRanges.length).toBe(5);
         expect(hexRanges[2].startPos).toBe(text.indexOf('0xbadc0ffee'));
 
-        const disableChecker = TextRange.findMatchingRanges(RegPat.regExSpellingGuard, text);
+        const disableChecker = TextRange.findMatchingRangesForPatterns([
+            RegPat.regExSpellingGuardBlock,
+            RegPat.regExSpellingGuardLine,
+            RegPat.regExSpellingGuardNext,
+        ], text);
         expect(disableChecker.length).toBe(5);
 
         const hereDocs = TextRange.findMatchingRanges(RegPat.regExPhpHereDoc, text);
@@ -219,7 +265,11 @@ describe('Validate InDocSettings', () => {
         expect(hexRanges.length).toBe(5);
         expect(hexRanges[2].startPos).toBe(text.indexOf('0xbadc0ffee'));
 
-        const disableChecker = TextRange.findMatchingRanges(RegPat.regExSpellingGuard, text);
+        const disableChecker = TextRange.findMatchingRangesForPatterns([
+            RegPat.regExSpellingGuardBlock,
+            RegPat.regExSpellingGuardLine,
+            RegPat.regExSpellingGuardNext,
+        ], text);
         expect(disableChecker.length).toBe(5);
 
         const hereDocs = TextRange.findMatchingRanges(RegPat.regExPhpHereDoc, text);

--- a/packages/cspell-lib/src/Settings/RegExpPatterns.ts
+++ b/packages/cspell-lib/src/Settings/RegExpPatterns.ts
@@ -4,10 +4,8 @@ export const regExMatchUrls = /(?:https?|ftp):\/\/[^\s"]+/gi;
 export const regExHRef = /\bhref\s*=\s*".*?"/gi;
 export const regExHexDigits = /^x?[0-1a-f]+$/i;
 export const regExMatchCommonHexFormats = /(?:#[0-9a-f]{3,8})|(?:0x[0-9a-f]+)|(?:\\u[0-9a-f]{4})|(?:\\x\{[0-9a-f]{4}\})/gi;
-// tslint:disable-next-line
-export const regExSpellingGuard = /(?:(?:spell-?checker|cSpell)::?\s*disable(?!-line|-next)\b[\s\S]*?(?:(?:spell-?checker|cSpell)::?\s*enable\b|$))|(?:.*(?:spell-?checker|cSpell)::?\s*disable-line\b.*)|(?:(?:spell-?checker|cSpell)::?\s*disable-next\b.*\r?\n.*\r?\n)/gi;
 export const regExSpellingGuardBlock = /(\bc?spell(?:-?checker)?::?)\s*disable(?!-line|-next)\b[\s\S]*?((?:\1\s*enable\b)|$)/gi;
-export const regExSpellingGuardNext = /\bc?spell(?:-?checker)?::?\s*disable-next\b.*\s.*/gi;
+export const regExSpellingGuardNext = /\bc?spell(?:-?checker)?::?\s*disable-next\b.*\s\s?.*/gi;
 export const regExSpellingGuardLine = /^.*\bc?spell(?:-?checker)?::?\s*disable-line\b.*/gim;
 export const regExPublicKey = /BEGIN\s+((?:RSA\s+)?PUBLIC)\s+KEY(?:[\w=+\-\/]*\r?\n)+?-*END\s+\1/g;
 export const regExCert = /BEGIN\s+(CERTIFICATE|RSA\s+(?:PRIVATE|PUBLIC)\s+KEY)(?:[\w=+\-\/]*\r?\n)+?-*END\s+\1/g;

--- a/packages/cspell-lib/tsconfig.json
+++ b/packages/cspell-lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-tools/tsconfig.json
+++ b/packages/cspell-tools/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "ES2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-trie-lib/tsconfig.json
+++ b/packages/cspell-trie-lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-trie/tsconfig.json
+++ b/packages/cspell-trie/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-trie2-lib/tsconfig.json
+++ b/packages/cspell-trie2-lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell-util-bundle/tsconfig.json
+++ b/packages/cspell-util-bundle/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "ES2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,

--- a/packages/cspell/tsconfig.json
+++ b/packages/cspell/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "es2017",
+		"target": "es2018",
+		"lib": ["es2018"],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,


### PR DESCRIPTION
- feat: Add ability to have multiple expressions in a pattern
- fix: Improve the speed of the cspell disable tests

It is now possible to use an array of regexp when defining a pattern:

```json
"patterns": [
  { "name": "strings", "pattern": ["'.*?'", "\".*\""] }
]
```
