### PR TITLE
chore: Add eslint-plugin-jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ const config = {
         },
         {
             files: '**/*.test.{ts,js}',
+            extends: 'plugin:jest/recommended',
             env: {
                 jest: true,
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5518,6 +5518,15 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.0.tgz",
+      "integrity": "sha512-827YJ+E8B9PvXu/0eiVSNFfxxndbKv+qE/3GSMhdorCaeaOehtqHGX2YDW9B85TEOre9n/zscledkFW/KbnyGg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^4.0.1"
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "cspell-dict-nl-nl": "^1.0.25",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-jest": "^24.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.1",
     "lerna": "^3.22.1",

--- a/packages/cspell-io/src/file/fileReader.test.ts
+++ b/packages/cspell-io/src/file/fileReader.test.ts
@@ -27,14 +27,14 @@ describe('Validate the fileReader', () => {
         expect(a).toEqual(['a1', '2', '3', '45', '6', '']);
     });
 
-    test('test the file reader', async () => {
+    test('the file reader', async () => {
         const lines = await asyncIterable.toArray(fReader.streamFileLineByLineAsync(__filename));
         const actual = lines.join('\n');
         const expected = fs.readFileSync(__filename, 'utf8');
         expect(actual).toBe(expected);
     });
 
-    test('test the lineReaderAsync', async () => {
+    test('the lineReaderAsync', async () => {
         const lines = await asyncIterable.toArray(fReader.lineReaderAsync(__filename));
         const expected = fs.readFileSync(__filename, 'utf8').split('\n');
         expect(lines).toEqual(expected);
@@ -63,7 +63,7 @@ describe('Validate the fileReader', () => {
         expect(lines).toEqual(file.split('\n'));
     });
 
-    test('test missing file', async () => {
+    test('missing file', async () => {
         const result = asyncIterable.toArray(fReader.lineReaderAsync(__filename + 'not.found'));
         return result.then(
             () => {

--- a/packages/cspell-lib/src/LanguageIds.test.ts
+++ b/packages/cspell-lib/src/LanguageIds.test.ts
@@ -9,7 +9,7 @@ describe('Validate LanguageIds', () => {
         expect(LangId.getLanguagesForExt('hs')).toEqual(expect.arrayContaining(['haskell']));
     });
 
-    test('test that all extensions start with a .', () => {
+    test('that all extensions start with a .', () => {
         const ids = LangId.buildLanguageExtensionMap(LangId.languageExtensionDefinitions);
         const badExtensions = genSequence(ids.keys())
             .filter((ext) => ext[0] !== '.')

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 jest.mock('../util/logger');
 
 describe('Validate CSpellSettingsServer', () => {
-    test('tests mergeSettings', () => {
+    test('tests mergeSettings with conflicting "name"', () => {
         const left = { name: 'Left' };
         const right = { name: 'Right' };
         expect(mergeSettings(left, right)).toEqual({
@@ -35,7 +35,7 @@ describe('Validate CSpellSettingsServer', () => {
         });
     });
 
-    test('tests mergeSettings', () => {
+    test('tests mergeSettings with conflicting "id"', () => {
         const left = { id: 'left' };
         const enabled = { id: 'enabledId', name: 'enabledName', enabled: true };
         expect(mergeSettings(left, enabled)).toEqual({
@@ -56,7 +56,7 @@ describe('Validate CSpellSettingsServer', () => {
         });
     });
 
-    test('tests mergeSettings', () => {
+    test('tests mergeSettings with conflicting "enabled"', () => {
         const right = { id: 'right', enabled: false };
         const left = { id: 'left', enabled: true };
         expect(mergeSettings({}, right)).toEqual(right);
@@ -79,7 +79,7 @@ describe('Validate CSpellSettingsServer', () => {
         });
     });
 
-    test('tests mergeSettings', () => {
+    test('tests mergeSettings with inline object', () => {
         expect(mergeSettings({ enabled: true }, { enabled: false })).toEqual({
             enabled: false,
             name: '|',
@@ -168,7 +168,7 @@ describe('Validate CSpellSettingsServer', () => {
         expect(getCachedFileSize()).toBe(0);
     });
 
-    test('test the loaded defaults contain expected settings', () => {
+    test('the loaded defaults contain expected settings', () => {
         const settings = getDefaultSettings();
         const sources = getSources(settings);
         const sourceNames = sources.map((s) => s.name || '?');
@@ -195,7 +195,7 @@ describe('Validate Overrides', () => {
         ) => expect(checkFilenameMatchesGlob(f, g)).toBe(e));
     });
 
-    test('test calcOverrideSettings', () => {
+    test('calcOverrideSettings', () => {
         interface Test {
             f: string;
             e: [keyof CSpellUserSettings, string][];

--- a/packages/cspell-lib/src/Settings/DefaultSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/DefaultSettings.test.ts
@@ -1,7 +1,7 @@
 import * as DefaultSettings from './DefaultSettings';
 
 describe('Validate Default Settings', () => {
-    test('test the static default settings', () => {
+    test('the static default settings', () => {
         const df = DefaultSettings._defaultSettings;
         expect(df.name).toBe('Static Defaults');
     });

--- a/packages/cspell-lib/src/Settings/DictionarySettings.test.ts
+++ b/packages/cspell-lib/src/Settings/DictionarySettings.test.ts
@@ -19,7 +19,6 @@ describe('Validate DictionarySettings', () => {
         expect(files.filter((a) => a.includes('wordsEn'))).toHaveLength(0);
         expect(files.filter((a) => a.includes('en_us'))).toHaveLength(1);
         expect(files.filter((a) => a.includes('unknown'))).toHaveLength(0);
-        // console.log(mapDefs);
     });
 
     test('tests exclusions and empty ids', () => {

--- a/packages/cspell-lib/src/Settings/InDocSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.test.ts
@@ -75,17 +75,15 @@ describe('Validate InDocSettings', () => {
             /faullts[/]?\/ */g.toString(),
         ]);
         const ranges = TextRange.findMatchingRangesForPatterns(matches, sampleCode);
-        // console.log(ranges);
-        // console.log(replaceRangesWith(sampleCode, ranges));
         expect(ranges.length).toBe(39);
     });
 
-    test('test fetching the local for the text', () => {
+    test('fetching the local for the text', () => {
         const settings = InDoc.getInDocumentSettings(sampleCode);
         expect(settings.language).toBe('en, nl');
     });
 
-    test('test setting dictionaries for file', () => {
+    test('setting dictionaries for file', () => {
         const settings = InDoc.getInDocumentSettings(sampleCode);
         expect(settings.dictionaries).toStrictEqual(['lorem-ipsum']);
     });

--- a/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
@@ -61,7 +61,7 @@ describe('Validate LanguageSettings', () => {
         expect(sPython.ignoreRegExpList).toEqual(expect.arrayContaining(['special']));
     });
 
-    test('test that user settings include language overrides', () => {
+    test('that user settings include language overrides', () => {
         const settings = {
             languageSettings: [],
             ...mergeSettings({ languageSettings: defaultLanguageSettings }, extraSettings),
@@ -72,7 +72,7 @@ describe('Validate LanguageSettings', () => {
         expect(sPython.ignoreRegExpList).toEqual(expect.arrayContaining(['binary']));
     });
 
-    test("test that global settings are preserved if language setting doesn't exit.", () => {
+    test("that global settings are preserved if language setting doesn't exit.", () => {
         const settings = {
             enabled: true,
             allowCompoundWords: false,
@@ -85,7 +85,7 @@ describe('Validate LanguageSettings', () => {
         expect(sPython.allowCompoundWords).toBe(true);
     });
 
-    test('test merged settings with global', () => {
+    test('merged settings with global', () => {
         const merged = mergeSettings(getDefaultSettings(), getGlobalSettings());
         const sPHP = calcSettingsForLanguage(merged.languageSettings || [], 'php', 'en');
         expect(Object.keys(sPHP)).not.toHaveLength(0);

--- a/packages/cspell-lib/src/Settings/RegExpPatterns.test.ts
+++ b/packages/cspell-lib/src/Settings/RegExpPatterns.test.ts
@@ -21,7 +21,7 @@ describe('Validate InDocSettings', () => {
 
     test('tests regExSpellingGuardBlock CRLF', () => {
         const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuardBlock);
-        expect(m1).not.toBeFalsy;
+        expect(m1).not.toBeFalsy();
         // cspell:disable
         expect(m1).toEqual(
             [
@@ -43,7 +43,7 @@ describe('Validate InDocSettings', () => {
 
     test('tests regExSpellingGuardLine CRLF', () => {
         const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuardLine);
-        expect(m1).not.toBeFalsy;
+        expect(m1).not.toBeFalsy();
         // cspell:disable
         expect(m1).toEqual(
             ["const badspelling = 'disable'; // spell-checker:disable-line, yes all of it."].map((a) =>
@@ -63,7 +63,7 @@ describe('Validate InDocSettings', () => {
 
     test('tests regExSpellingGuardNext CRLF', () => {
         const m1 = sampleCode2CRLF.match(RegPat.regExSpellingGuardNext);
-        expect(m1).not.toBeFalsy;
+        expect(m1).not.toBeFalsy();
         // cspell:disable
         expect(m1).toEqual(
             ["cspell:disable-next\nconst verybadspelling = 'disable';"].map((a) => a.replace(/\n/g, '\r\n'))
@@ -216,7 +216,7 @@ describe('Validate InDocSettings', () => {
         ]);
     });
 
-    test('test for hex values', () => {
+    test('for hex values', () => {
         expect(RegPat.regExHexDigits.test('FFEE')).toBe(true);
     });
 
@@ -296,7 +296,7 @@ describe('Validate InDocSettings', () => {
         ]);
     });
 
-    test('test matching urls', () => {
+    test('matching urls', () => {
         RegPat.regExMatchUrls.lastIndex = 22;
         const reg = new RegExp(RegPat.regExMatchUrls);
         expect(reg.lastIndex).toBe(0);
@@ -313,7 +313,7 @@ describe('Validate InDocSettings', () => {
         expect(matches?.[0]).toBe('http://example.org');
     });
 
-    test('test matching href', () => {
+    test('matching href', () => {
         const reg = new RegExp(RegPat.regExHRef);
         const text = `
             <p>
@@ -329,7 +329,7 @@ describe('Validate InDocSettings', () => {
         expect(matches?.[1]).toBe('href="/example/"');
     });
 
-    test('test sha regex', () => {
+    test('sha regex', () => {
         RegPat.regExSha.lastIndex = 0;
         expect(RegPat.regExSha.test('')).toBe(false);
         RegPat.regExSha.lastIndex = 0;
@@ -349,14 +349,14 @@ describe('Validate InDocSettings', () => {
         RegPat.regExSha.lastIndex = 0;
     });
 
-    test('test regExCert', () => {
+    test('regExCert', () => {
         RegPat.regExCert.lastIndex = 0;
         const match = sampleCert.match(RegPat.regExCert);
         expect(match).toHaveLength(3);
         expect(nonCert.match(RegPat.regExCert)).toBeNull();
     });
 
-    test('test regExPublicKey', () => {
+    test('regExPublicKey', () => {
         RegPat.regExCert.lastIndex = 0;
         const match = sampleCert.match(RegPat.regExPublicKey);
         expect(match).toHaveLength(1);

--- a/packages/cspell-lib/src/SpellingDictionary/DictionaryLoader.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/DictionaryLoader.test.ts
@@ -8,7 +8,7 @@ const samples = path.join(root, 'samples');
 type ErrorResults = Record<string, unknown> | Error;
 
 describe('Validate DictionaryLoader', () => {
-    it('test not found', async () => {
+    it('load not found', async () => {
         const error = { code: 'ENOENT' };
         const unknownFormatError = new Error('Unknown file format');
         const tests: [string, LoadOptions, ErrorResults][] = [
@@ -28,7 +28,7 @@ describe('Validate DictionaryLoader', () => {
         }
     });
 
-    it('test not found', async () => {
+    it('loadEntry not found', async () => {
         const error = { code: 'ENOENT' };
         const unknownFormatError = new Error('Unknown file format');
         const tests: [string, LoadOptions, ErrorResults][] = [

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionary.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionary.test.ts
@@ -12,10 +12,6 @@ describe('Verify building Dictionary', () => {
 
         const dict = await createSpellingDictionary(words, 'words', 'test');
         expect(dict.name).toBe('words');
-        // expect(dict).toBeInstanceOf(SpellingDictionaryFromTrie);
-        if (dict instanceof SpellingDictionaryFromTrie) {
-            expect(dict.trie.root.c).toBeInstanceOf(Map);
-        }
         expect(dict.has('apple')).toBe(true);
         const suggestions = dict.suggest('aple').map(({ word }) => word);
         expect(suggestions).toEqual(expect.arrayContaining(['apple']));
@@ -23,7 +19,7 @@ describe('Verify building Dictionary', () => {
         expect(suggestions).toEqual(expect.not.arrayContaining(['banana']));
     });
 
-    test('Test compounds from word list', async () => {
+    test('compounds from word list', async () => {
         const words = [
             'apple',
             'apples',
@@ -50,7 +46,7 @@ describe('Verify building Dictionary', () => {
         expect(dict.has('applebananas')).toBe(false);
     });
 
-    test('Test case-sensitive word list', async () => {
+    test('case-sensitive word list', async () => {
         const words = ['apple', 'Seattle', 'Amsterdam', 'surf', 'words', 'English', 'McGreyer'];
 
         const dict = await createSpellingDictionary(words, 'words', 'test', {
@@ -74,7 +70,7 @@ describe('Verify building Dictionary', () => {
         expect(dict.has('MCGREYER', ignoreCase)).toBe(true); // cspell:disable-line
     });
 
-    test('Test Suggest Trie', () => {
+    test('Suggest Trie', () => {
         const words = [
             'apple',
             'ape',
@@ -115,8 +111,8 @@ describe('Verify building Dictionary', () => {
         expect(suggestions).toEqual(expect.not.arrayContaining(['banana']));
     });
 
-    test('Test wordDictionaryFormsCollector', () => {
-        function test(word: string, isCaseSensitive: boolean, expected: string[]) {
+    test('wordDictionaryFormsCollector', () => {
+        function testCase(word: string, isCaseSensitive: boolean, expected: string[]) {
             const collector = __testMethods.wordDictionaryFormsCollector(isCaseSensitive);
             expect([...collector(word)].sort()).toEqual(expected.sort());
             expect([...collector(word)]).toEqual([]);
@@ -137,7 +133,7 @@ describe('Verify building Dictionary', () => {
             ['café'.normalize('NFKC'), false, ['cafe', 'café']],
             ['café'.normalize('NFKD'), false, ['cafe', 'café']],
         ];
-        tests.forEach((t) => test(...t));
+        tests.forEach((t) => testCase(...t));
     });
 });
 

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryCollection.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryCollection.test.ts
@@ -78,7 +78,7 @@ describe('Verify using multiple dictionaries', () => {
         expect(sugs).toContain('apple mango');
     });
 
-    test('checks for compound suggestions', async () => {
+    test('checks for compound suggestions with numbChanges', async () => {
         const trie = new SpellingDictionaryFromTrie(Trie.Trie.create(wordsA), 'wordsA');
         const dicts = await Promise.all([
             trie,
@@ -117,9 +117,9 @@ describe('Verify using multiple dictionaries', () => {
         ]);
 
         const dictCollection = new SpellingDictionaryCollection(dicts, 'test', []);
-        expect(dictCollection.has('mango'));
-        expect(dictCollection.has('lion'));
-        expect(dictCollection.has('ant'));
+        expect(dictCollection.has('mango')).toBe(true);
+        expect(dictCollection.has('lion')).toBe(true);
+        expect(dictCollection.has('ant')).toBe(true);
 
         const sugsForTango = dictCollection.suggest('tango', 10);
         expect(sugsForTango).toHaveLength(1);
@@ -133,22 +133,6 @@ describe('Verify using multiple dictionaries', () => {
         expect(sugsForCellipede.map((s) => s.word)).toContain('centipede');
         expect(sugsForCellipede.map((s) => s.word)).toContain('millipede');
     });
-
-    // test('checks for duplicate suggestions', async () => {
-    //     const wordsA2 = wordsA.concat(['apples']);
-    //     const dicts = await Promise.all([
-    //         createSpellingDictionary(wordsA, 'wordsA', 'test'),
-    //         createSpellingDictionary(wordsB, 'wordsB', 'test'),
-    //         createSpellingDictionary(wordsA2, 'wordsA2', 'test'),
-    //         createSpellingDictionary(wordsC, 'wordsC', 'test'),
-    //     ]);
-
-    //     const dictCollection = createCollection(dicts, 'test', ['Avocado']);
-    //     const sugs = dictCollection.suggest('Apples', 10);
-    //     expect(sugs).toEqual([
-
-    //     ]);
-    // });
 
     test('creates using createCollectionP', () => {
         const dicts = [

--- a/packages/cspell-lib/src/SpellingDictionary/SuggestExperimental/helpert.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SuggestExperimental/helpert.test.ts
@@ -3,7 +3,7 @@ import { SuggestionResult, Feature } from './entities';
 import { FeatureMap } from './helpers';
 
 describe('Validate Suggest Helpers', () => {
-    test('test compareResult', () => {
+    test('compareResult', () => {
         const sr: SuggestionResult[] = [
             { word: 'cone', score: 0.6 },
             { word: 'apple', score: 0.3 },
@@ -15,7 +15,7 @@ describe('Validate Suggest Helpers', () => {
         expect(r).toEqual([sr[3], sr[0], sr[1], sr[2]]);
     });
 
-    test('test wordToSingleLetterFeatures', () => {
+    test('wordToSingleLetterFeatures', () => {
         const tests = [
             { v: '', e: [] },
             { v: 'a', e: [['a', 1]] },
@@ -36,7 +36,7 @@ describe('Validate Suggest Helpers', () => {
         });
     });
 
-    test('test mergeFeatures', () => {
+    test('mergeFeatures', () => {
         const tests = [
             { v: '', e: [] },
             { v: 'a', e: [['a', 1]] },
@@ -60,7 +60,7 @@ describe('Validate Suggest Helpers', () => {
         });
     });
 
-    test('test wordToTwoLetterFeatures', () => {
+    test('wordToTwoLetterFeatures', () => {
         const tests = [
             { v: '', e: [] },
             {
@@ -88,7 +88,7 @@ describe('Validate Suggest Helpers', () => {
     });
 
     // cspell:ignore ello
-    test('test segmentString', () => {
+    test('segmentString', () => {
         const tests = [
             { v: 'a', s: 1, e: 'a'.split('') },
             { v: 'hello', s: 1, e: 'hello'.split('') },
@@ -105,7 +105,7 @@ describe('Validate Suggest Helpers', () => {
         });
     });
 
-    test('test wordToFeatures', () => {
+    test('wordToFeatures', () => {
         const comp = (a: Feature, b: Feature) => a[0].localeCompare(b[0]);
         const features = helpers.wordToFeatures('^hello$');
         expect([...features].sort(comp)).toEqual(
@@ -126,7 +126,7 @@ describe('Validate Suggest Helpers', () => {
         );
     });
 
-    test('test intersectionScore', () => {
+    test('intersectionScore', () => {
         const fA = helpers.wordToFeatures('^hello$');
         const fB = helpers.wordToFeatures('^goodbye$');
         expect(fA.intersectionScore(fA)).toBe(fA.count);
@@ -135,7 +135,7 @@ describe('Validate Suggest Helpers', () => {
         expect(fA.intersectionScore(fB)).toBe(4);
     });
 
-    test('test correlationScore', () => {
+    test('correlationScore', () => {
         const fA = helpers.wordToFeatures('^hello$');
         const fB = helpers.wordToFeatures('^goodbye$');
         expect(fA.correlationScore(fA)).toBe(1);

--- a/packages/cspell-lib/src/SpellingDictionary/SuggestExperimental/suggest.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SuggestExperimental/suggest.test.ts
@@ -3,7 +3,7 @@ import { Trie } from 'cspell-trie-lib';
 import { compareResults } from './helpers';
 
 describe('Validate Suggest', () => {
-    test('test suggestions', () => {
+    test('suggestions', () => {
         const words = [
             'apple',
             'ape',

--- a/packages/cspell-lib/src/exclusionHelper.test.ts
+++ b/packages/cspell-lib/src/exclusionHelper.test.ts
@@ -12,7 +12,7 @@ describe('Verify Exclusion Helper functions', () => {
         expect(extractGlobsFromExcludeFilesGlobMap(excludeDef)).toEqual(['**/node_modules', '**/typings']);
     });
 
-    test('Test the generated matching function', () => {
+    test('the generated matching function', () => {
         const globs = ['**/node_modules', '**/typings', '.vscode'];
         const filesMatching = [
             'file:///project/myProject/node_modules',
@@ -28,7 +28,7 @@ describe('Verify Exclusion Helper functions', () => {
         });
     });
 
-    test('Test the generated matching function for nested projects', () => {
+    test('the generated matching function for nested projects', () => {
         const globs = ['**/node_modules', '**/typings', '.vscode'];
         const filesMatching = [
             'file:///User/projects/myProject/node_modules/test/test.js',
@@ -44,7 +44,7 @@ describe('Verify Exclusion Helper functions', () => {
         });
     });
 
-    test('Test against generated files', () => {
+    test('against generated files', () => {
         const globs = ['debug:/**', '**/*.rendered', 'git-index:/**'];
         const files = [
             'debug://internal/1014/extHostCommands.ts',
@@ -62,7 +62,7 @@ describe('Verify Exclusion Helper functions', () => {
         });
     });
 
-    test('Test to make sure normal files are loaded', () => {
+    test('to make sure normal files are loaded', () => {
         const globs = [
             'debug:/**', // Files that are generated while debugging (generally from a .map file)
             'vscode:/**', // VS Code generated files (settings.json for example)

--- a/packages/cspell-lib/src/index.test.ts
+++ b/packages/cspell-lib/src/index.test.ts
@@ -12,9 +12,9 @@ describe('Validate the cspell API', () => {
             expect(Object.keys(results)).not.toHaveLength(0);
             expect(results.map((to) => to.text)).toEqual(expect.arrayContaining(['Jansons']));
         });
-    });
 
-    test('clearCachedSettings', () => {
-        return cspell.clearCachedFiles();
+        test('clearCachedSettings', async () => {
+            await expect(cspell.clearCachedFiles()).resolves.not.toThrow();
+        });
     });
 });

--- a/packages/cspell-lib/src/textValidator.test.ts
+++ b/packages/cspell-lib/src/textValidator.test.ts
@@ -95,7 +95,7 @@ describe('Validate textValidator functions', () => {
         expect(errors).toEqual([]);
     });
 
-    test('test contractions', async () => {
+    test('contractions', async () => {
         const dictWords = await getSpellingDictionaryCollection();
         // cspell:disable
         const text = `We should’ve done a better job, but we couldn\\'t have known.`;
@@ -123,7 +123,7 @@ describe('Validate textValidator functions', () => {
         expect(result2.length).toBe(0);
     });
 
-    test('tests inclusion, exclusion', () => {
+    test('tests inclusion, no exclusions', () => {
         const result = calcTextInclusionRanges(sampleText, {});
         expect(result.length).toBe(1);
         expect(result.map((a) => [a.startPos, a.endPos])).toEqual([[0, sampleText.length]]);

--- a/packages/cspell-lib/src/util/FreqCounter.test.ts
+++ b/packages/cspell-lib/src/util/FreqCounter.test.ts
@@ -1,21 +1,21 @@
 import { FreqCounter } from './FreqCounter';
 
 describe('Validate FreqCounter', () => {
-    test('Test Creating an empty Counter', () => {
+    test('Creating an empty Counter', () => {
         const counter = FreqCounter.create();
         expect(counter).toBeInstanceOf(FreqCounter);
         expect(counter.total).toBe(0);
         expect(counter.getFreq(1)).toBe(0);
         expect(counter.counters).toBeInstanceOf(Map);
     });
-    test('Test Adding values to a counter', () => {
+    test('Adding values to a counter', () => {
         const counter = FreqCounter.create([1, 1, 2, 3]);
         expect(counter.total).toBe(4);
         expect(counter.getCount(1)).toBe(2);
         expect(counter.getCount(2)).toBe(1);
         expect(counter.getFreq(1)).toBe(0.5);
     });
-    test('Test merging counters', () => {
+    test('merging counters', () => {
         const counter = FreqCounter.create([1, 1, 2, 3]);
         const counter2 = FreqCounter.create([1, 2, 2, 3, 3]);
         expect(counter.total).toBe(4);

--- a/packages/cspell-lib/src/util/Memorizer.test.ts
+++ b/packages/cspell-lib/src/util/Memorizer.test.ts
@@ -1,7 +1,7 @@
 import { memorizer } from './Memorizer';
 
 describe('Validate Memorizer', () => {
-    test('Test the memorizer works', () => {
+    test('the memorizer works', () => {
         const counts = new Map<number, number>();
         const fn = (a: number) => {
             counts.set(a, (counts.get(a) || 0) + 1);
@@ -20,7 +20,7 @@ describe('Validate Memorizer', () => {
         fnTest(0, 1, 5);
     });
 
-    test('Test cache reset', () => {
+    test('cache reset', () => {
         const counts = new Map<number, number>();
         const fn = (a: number) => {
             counts.set(a, (counts.get(a) || 0) + 1);

--- a/packages/cspell-lib/src/util/iterableIteratorLib.test.ts
+++ b/packages/cspell-lib/src/util/iterableIteratorLib.test.ts
@@ -1,13 +1,13 @@
 import { toIterableIterator, concatIterables } from './iterableIteratorLib';
 
 describe('Validate Iterable Iterators', () => {
-    test('test toIterableIterator', () => {
+    test('toIterableIterator', () => {
         const values = [1, 2, 3, 4];
         expect(toIterableIterator(values)).not.toBe(values);
         expect([...toIterableIterator(values)]).toEqual(values);
     });
 
-    test('test concatIterables', () => {
+    test('concatIterables', () => {
         const values = [[1, 2, 3], toIterableIterator([4, 5, 6]), new Set([7, 8, 9])];
         expect([...concatIterables(...values)]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });

--- a/packages/cspell-lib/src/util/repMap.test.ts
+++ b/packages/cspell-lib/src/util/repMap.test.ts
@@ -1,18 +1,18 @@
 import * as repMap from './repMap';
 
 describe('ReMap Tests', () => {
-    test('test basic replace', () => {
+    test('empty replace map', () => {
         const mapper = repMap.createMapper([]);
         expect(mapper('hello')).toBe('hello');
     });
 
-    test('test basic replace', () => {
+    test('punctuation replacement', () => {
         const mapper = repMap.createMapper([['`', "'"]]);
         expect(mapper('hello')).toBe('hello');
         expect(mapper('don`t')).toBe("don't");
     });
 
-    test('test multiple replacements', () => {
+    test('multiple replacements', () => {
         const mapper = repMap.createMapper([
             ['a', 'A'],
             ['b', 'B'],
@@ -21,7 +21,7 @@ describe('ReMap Tests', () => {
         expect(mapper('banana')).toBe('BAnAnA');
     });
 
-    test('test empty replacements', () => {
+    test('empty replacements', () => {
         const mapper = repMap.createMapper([
             ['a', 'A'],
             ['b', 'B'],
@@ -31,7 +31,7 @@ describe('ReMap Tests', () => {
         expect(mapper('banana')).toBe('BAnAnA');
     });
 
-    test('test regex replacements', () => {
+    test('regex replacements', () => {
         const mapper = repMap.createMapper([
             ['!|@|#|\\$', '_'],
             ['a', 'A'],
@@ -39,7 +39,7 @@ describe('ReMap Tests', () => {
         expect(mapper('$apple!!')).toBe('_Apple__');
     });
 
-    test('test repeated replacements', () => {
+    test('repeated replacements', () => {
         const mapper = repMap.createMapper([
             ['a', 'A'],
             ['a', 'X'],
@@ -47,7 +47,7 @@ describe('ReMap Tests', () => {
         expect(mapper('apples')).toBe('Apples');
     });
 
-    test('test nested regex replacements', () => {
+    test('nested regex replacements', () => {
         const mapper = repMap.createMapper([
             ['(!)', '_'],
             ['((\\$))', '#'],
@@ -56,7 +56,7 @@ describe('ReMap Tests', () => {
         expect(mapper('$apple!!')).toBe('#Apple__');
     });
 
-    test('test bad regex replacements', () => {
+    test('bad regex replacements', () => {
         const mapper = repMap.createMapper([
             ['(', '_'],
             ['a', 'A'],
@@ -64,7 +64,7 @@ describe('ReMap Tests', () => {
         expect(mapper('(apple)')).toBe('_Apple)');
     });
 
-    test('test empty regex replacements', () => {
+    test('empty regex replacements', () => {
         const mapper = repMap.createMapper([
             ['', '_'],
             ['a', 'A'],

--- a/packages/cspell-lib/src/util/search.test.ts
+++ b/packages/cspell-lib/src/util/search.test.ts
@@ -1,7 +1,7 @@
 import * as search from './search';
 
 describe('validate the search', () => {
-    test('test the results of binary search', () => {
+    test('the results of binary search', () => {
         expect(search.binarySearch([], 5)).toBe(0);
         expect(search.binarySearch([1, 3, 7, 11], 5)).toBe(2);
         expect(search.binarySearch([1, 3, 7, 11], 1)).toBe(0);

--- a/packages/cspell-lib/src/util/text.test.ts
+++ b/packages/cspell-lib/src/util/text.test.ts
@@ -196,7 +196,7 @@ describe('Util Text', () => {
         ).toEqual(['Γ', 'γ', 'gamma', 'γάμμα']);
     });
 
-    test('test case of Chinese characters', () => {
+    test('case of Chinese characters', () => {
         expect(Text.isUpperCase('携程旅行网')).toBe(false);
         expect(Text.isLowerCase('携程旅行网')).toBe(false);
     });
@@ -231,7 +231,7 @@ describe('Util Text', () => {
         expect(linesB).toEqual(linesA);
     });
 
-    test('test extractText', () => {
+    test('extractText', () => {
         const line = Text.textOffset('This is a line of text to be processed.');
         const words = Text.extractWordsFromTextOffset(line);
         const results = words.map((wo) => Text.extractText(line, wo.offset, wo.offset + wo.text.length)).toArray();

--- a/packages/cspell-tools/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell-tools/src/__snapshots__/app.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Validate the application test app compile merge 1`] = `
+exports[`Validate the application app compile merge 1`] = `
 "amsterdam
 angeles
 city

--- a/packages/cspell-tools/src/app.test.ts
+++ b/packages/cspell-tools/src/app.test.ts
@@ -27,7 +27,7 @@ describe('Validate the application', () => {
         shell.cd(pathTemp);
     });
 
-    test('test app compile-trie', async () => {
+    test('app compile-trie', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv('compile-trie', '-n', 'cities.txt');
@@ -36,7 +36,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile-trie compress', async () => {
+    test('app compile-trie compress', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv('compile-trie', 'cities.txt');
@@ -45,7 +45,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile-trie -o', async () => {
+    test('app compile-trie -o', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv('compile-trie', '-n', 'cities.txt', '-o', relPathTemp);
@@ -54,7 +54,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile', async () => {
+    test('app compile', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv('compile', '-n', 'cities.txt', '-o', relPathTemp);
@@ -63,7 +63,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile-trie max depth', async () => {
+    test('app compile-trie max depth', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv('compile-trie', '-n', '-m', '0', 'cities.txt', '-o', relPathTemp);
@@ -72,7 +72,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile-trie compound', async () => {
+    test('app compile-trie compound', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv(
@@ -92,7 +92,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile compound', async () => {
+    test('app compile compound', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv(
@@ -109,7 +109,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile with compression', async () => {
+    test('app compile with compression', async () => {
         const commander = getCommander();
         const log = jest.spyOn(console, 'log').mockImplementation();
         const args = argv('compile', 'cities.txt', '-o', relPathTemp);
@@ -118,7 +118,7 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app compile merge', async () => {
+    test('app compile merge', async () => {
         const commander = getCommander();
         const targetDir = relPathTemp;
         const target = 'merge.txt';
@@ -135,15 +135,15 @@ describe('Validate the application', () => {
         log.mockRestore();
     });
 
-    test('test app no args', () => {
+    test('app no args', async () => {
         const commander = getCommander();
         const mock = jest.fn();
         commander.on('--help', mock);
-        expect(app.run(commander, argv())).rejects.toThrowError(Commander.CommanderError);
+        await expect(app.run(commander, argv())).rejects.toThrowError(Commander.CommanderError);
         expect(mock.mock.calls.length).toBe(1);
     });
 
-    test('test app --help', async () => {
+    test('app --help', async () => {
         const commander = getCommander();
         const mock = jest.fn();
         commander.on('--help', mock);
@@ -151,7 +151,7 @@ describe('Validate the application', () => {
         expect(mock.mock.calls.length).toBe(1);
     });
 
-    test('test app -V', async () => {
+    test('app -V', async () => {
         const commander = getCommander();
         const mock = jest.fn();
         commander.on('option:version', mock);

--- a/packages/cspell-tools/src/compiler/Reader.test.ts
+++ b/packages/cspell-tools/src/compiler/Reader.test.ts
@@ -68,7 +68,7 @@ describe('Validate the iterateWordsFromFile', () => {
         );
     });
 
-    test('annotatedWords: text', async () => {
+    test('annotatedWords: text - cities.txt', async () => {
         const reader = await createReader(path.join(samples, 'cities.txt'), {});
         expect(reader.size).toBeGreaterThan(1);
         const results = [...reader.annotatedWords()];
@@ -79,7 +79,7 @@ describe('Validate the iterateWordsFromFile', () => {
         );
     });
 
-    test('annotatedWords: text', async () => {
+    test('annotatedWords: text - sampleCodeDic.txt', async () => {
         const reader = await createReader(path.join(samples, 'sampleCodeDic.txt'), {});
         expect(reader.size).toBeGreaterThan(1);
         const results = [...reader.annotatedWords()];

--- a/packages/cspell-tools/src/compiler/wordListCompiler.test.ts
+++ b/packages/cspell-tools/src/compiler/wordListCompiler.test.ts
@@ -55,7 +55,7 @@ describe('Validate the wordListCompiler', () => {
         ]);
     });
 
-    test('test reading and normalizing a file', async () => {
+    test('reading and normalizing a file', async () => {
         const source = await streamWordsFromFile(path.join(samples, 'cities.txt'), {});
         const destName = path.join(temp, 'cities.txt');
         await compileWordList(source, destName, {
@@ -66,7 +66,7 @@ describe('Validate the wordListCompiler', () => {
         expect(output).toBe(citiesResultSorted);
     });
 
-    test('test compiling to a file without split', async () => {
+    test('compiling to a file without split', async () => {
         const source = await streamWordsFromFile(path.join(samples, 'cities.txt'), {});
         const destName = path.join(temp, 'cities2.txt');
         await compileWordList(source, destName, {
@@ -88,7 +88,7 @@ describe('Validate the wordListCompiler', () => {
         expect(tWords.sort()).toEqual([...new Set(nWords.sort())]);
     });
 
-    test('test reading and normalizing to a trie file', async () => {
+    test('reading and normalizing to a trie file', async () => {
         const source = await streamWordsFromFile(path.join(samples, 'cities.txt'), {});
         const destName = path.join(temp, 'cities.trie');
         await compileTrie(source, destName, {});
@@ -102,7 +102,7 @@ describe('Validate the wordListCompiler', () => {
         expect(words).toEqual(expected);
     });
 
-    test('test reading and normalizing to a trie gz file', async () => {
+    test('reading and normalizing to a trie gz file', async () => {
         const source = await streamWordsFromFile(path.join(samples, 'cities.txt'), {});
         const destName = path.join(temp, 'cities.trie.gz');
         await compileTrie(source, destName, {});
@@ -117,7 +117,7 @@ describe('Validate the wordListCompiler', () => {
         expect(words).toEqual(expected);
     });
 
-    test('test a simple hunspell dictionary depth 0', async () => {
+    test('a simple hunspell dictionary depth 0', async () => {
         const source = await streamWordsFromFile(path.join(samples, 'hunspell', 'example.dic'), {
             maxDepth: 0,
         });
@@ -130,7 +130,7 @@ describe('Validate the wordListCompiler', () => {
         expect(output).toBe('hello\ntry\nwork\n');
     });
 
-    test('test a simple hunspell dictionary depth 1', async () => {
+    test('a simple hunspell dictionary depth 1', async () => {
         const source = await streamWordsFromFile(path.join(samples, 'hunspell', 'example.dic'), {
             maxDepth: 1,
         });

--- a/packages/cspell-trie-lib/src/lib/SimpleDictionaryParser.test.ts
+++ b/packages/cspell-trie-lib/src/lib/SimpleDictionaryParser.test.ts
@@ -1,7 +1,7 @@
 import { parseDictionary, parseDictionaryLines } from './SimpleDictionaryParser';
 
 describe('Validate SimpleDictionaryParser', () => {
-    test('test parsing lines', () => {
+    test('parsing lines', () => {
         const expected = [
             'Begin',
             '~begin',

--- a/packages/cspell-trie-lib/src/lib/TrieBuilder.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBuilder.test.ts
@@ -2,7 +2,7 @@ import { countNodes, isCircular } from './util';
 import { TrieBuilder, buildTrie } from './TrieBuilder';
 
 describe('Validate TrieBuilder', () => {
-    test('builder', () => {
+    test('builder explicit consolidateSuffixes', () => {
         const builder = new TrieBuilder();
         const words = sampleWords.concat(applyEndings('shock')).concat(applyEndings('stock'));
         builder.insert(words);
@@ -12,7 +12,7 @@ describe('Validate TrieBuilder', () => {
         expect(isCircular(trie.root)).toBe(false);
     });
 
-    test('builder', () => {
+    test('builder no consolidateSuffixes', () => {
         const builder = new TrieBuilder();
         builder.insert(sampleWords);
         const trie = builder.build(false);

--- a/packages/cspell-trie-lib/src/lib/bufferLines.test.ts
+++ b/packages/cspell-trie-lib/src/lib/bufferLines.test.ts
@@ -4,10 +4,9 @@ describe('Validate BufferLines', () => {
     test('bufferLines', () => {
         const r = [...bufferLines(bufferLines(sampleWords, 1, ','), 10, '')];
         expect(r.join('')).toBe(sampleWords.join(',') + ',');
-    });
-    test('bufferLines', () => {
-        const r = [...bufferLines(bufferLines(concat(sampleWords, sampleWords.concat().reverse()), 1, ','), 10, '')];
-        expect(r.join('')).toBe(sampleWords.join(',') + ',' + sampleWords.concat().reverse().join(',') + ',');
+
+        const r2 = [...bufferLines(bufferLines(concat(sampleWords, sampleWords.concat().reverse()), 1, ','), 10, '')];
+        expect(r2.join('')).toBe(sampleWords.join(',') + ',' + sampleWords.concat().reverse().join(',') + ',');
     });
 });
 

--- a/packages/cspell-trie-lib/src/lib/compoundWalker.test.ts
+++ b/packages/cspell-trie-lib/src/lib/compoundWalker.test.ts
@@ -28,7 +28,7 @@ describe('Verify compound walker', () => {
         expect(words2).toEqual(expected2().map((a) => a.toLowerCase()));
     });
 
-    test('test compound edges', () => {
+    test('compound edges', () => {
         const trie = dictionary();
         const words1 = [...walkerToWords(compoundWalker(trie), 1)];
         expect(words1).toEqual([
@@ -46,7 +46,7 @@ describe('Verify compound walker', () => {
         ]);
     });
 
-    test('test that it is possible to break up the word into its compounds', () => {
+    test('that it is possible to break up the word into its compounds', () => {
         const trie = dictionary();
         const words2 = [...walkerToCompoundWords(compoundWalker(trie), 2)];
         expect(words2).toEqual(expectedCompounds2());

--- a/packages/cspell-trie-lib/src/lib/consolidate.test.ts
+++ b/packages/cspell-trie-lib/src/lib/consolidate.test.ts
@@ -25,9 +25,6 @@ describe('Validate Consolidate', () => {
         const trie3 = consolidate(trie);
         const countTrie3 = countNodes(trie3);
         expect(countTrie3).toBe(countTrie2);
-    });
-
-    test('consolidate', () => {
         expect(countNodes(consolidate(createTriFromList(sampleWords)))).toBe(96);
     });
 

--- a/packages/cspell-trie-lib/src/lib/find.dutch.test.ts
+++ b/packages/cspell-trie-lib/src/lib/find.dutch.test.ts
@@ -12,7 +12,7 @@ const dutchDictionary = path.join(__dirname, ...'../../../Samples/dicts/nl_compo
 describe('Validate findWord', () => {
     const pTrie = readTrie(dutchDictionary);
 
-    test('test find exact words preserve case', async () => {
+    test('find exact words preserve case', async () => {
         const trie = await pTrie;
 
         // cspell:ignore aanvaardbaard
@@ -81,7 +81,6 @@ describe('Validate findWord', () => {
                           matchCase: true,
                           compoundMode: 'compound',
                       }));
-            // console.log(r2);
             expect(r2.found).toEqual(word);
             expect(r2.forbidden).toBe(false);
         });
@@ -91,7 +90,6 @@ describe('Validate findWord', () => {
                 matchCase: false,
                 compoundMode: 'compound',
             });
-            // console.log(r2);
             expect(r.found).toEqual(normalizeWordToLowercase(word));
             expect(r.forbidden).toBe(false);
         });
@@ -113,7 +111,6 @@ describe('Validate findWord', () => {
                           matchCase: true,
                           compoundMode: 'compound',
                       }));
-            // console.log(r2);
             expect(r2.found).toEqual(false);
             expect(r2.forbidden).toBe(false);
         });
@@ -123,7 +120,6 @@ describe('Validate findWord', () => {
                 matchCase: false,
                 compoundMode: 'compound',
             });
-            // console.log(r2);
             expect(r.found).toEqual(false);
             expect(r.forbidden).toBe(false);
         });

--- a/packages/cspell-trie-lib/src/lib/find.test.ts
+++ b/packages/cspell-trie-lib/src/lib/find.test.ts
@@ -5,7 +5,7 @@ import { Trie } from './trie';
 describe('Validate findWord', () => {
     const trie = dictionary().root;
 
-    test('test find exact words preserve case', () => {
+    test('find exact words preserve case', () => {
         // Code is not allowed as a full word.
         expect(
             findWord(trie, 'blueerror', {
@@ -82,7 +82,7 @@ describe('Validate findWord', () => {
 });
 
 describe('Validate Legacy Compound lookup', () => {
-    test('Test compound words', () => {
+    test('compound words', () => {
         // cspell:ignore talkinglift joywalk jwalk awalk jayjay jayi
         const trie = Trie.create(sampleWords);
         function has(word: string, compoundLen: true | number): boolean {

--- a/packages/cspell-trie-lib/src/lib/flatten.test.ts
+++ b/packages/cspell-trie-lib/src/lib/flatten.test.ts
@@ -4,7 +4,7 @@ import { genSequence } from 'gensequence';
 import { TrieRefNode } from './trieRef';
 
 describe('Validate Flatten', () => {
-    test('Simple flatten', () => {
+    test('Simple flatten Array', () => {
         const trie = createTriFromList(sampleWords);
         const nodes = flattenToTrieRefNodeArray(trie);
         expect(nodes).toHaveLength(112);
@@ -12,7 +12,7 @@ describe('Validate Flatten', () => {
         expect(words).toEqual(sampleWords.sort());
     });
 
-    test('Simple flatten', () => {
+    test('Simple flatten Iterable', () => {
         const trie = createTriFromList(sampleWords);
         const nodes = [...flattenToTrieRefNodeIterable(trie)];
         expect(nodes).toHaveLength(112);

--- a/packages/cspell-trie-lib/src/lib/importExportV2.test.ts
+++ b/packages/cspell-trie-lib/src/lib/importExportV2.test.ts
@@ -4,7 +4,7 @@ import { readFile } from 'fs-extra';
 import * as path from 'path';
 
 describe('Import/Export', () => {
-    test('tests serialize / deserialize', async () => {
+    test('tests serialize / deserialize from trie', async () => {
         const trie = Trie.createTriFromList(sampleWords);
         const data = [...serializeTrie(trie, { base: 10, comment: 'Sample Words' })].join('');
         const sample = (await readFile(path.join(__dirname, '..', '..', 'Samples', 'sampleV2.trie'), 'utf8')).replace(
@@ -17,7 +17,7 @@ describe('Import/Export', () => {
         expect(words).toEqual([...sampleWords].sort());
     });
 
-    test('tests serialize / deserialize', async () => {
+    test('serialize / deserialize with object', async () => {
         const trie = Trie.createTriFromList(sampleWords);
         const data = [...serializeTrie(trie, 10)].join('');
         const root = importTrie(data.split('\n'));

--- a/packages/cspell-trie-lib/src/lib/importExportV3.test.ts
+++ b/packages/cspell-trie-lib/src/lib/importExportV3.test.ts
@@ -54,7 +54,7 @@ describe('Import/Export', () => {
         expect(words).toEqual([...sampleWords].sort());
     });
 
-    test('tests serialize / deserialize', async () => {
+    test('tests serialize / deserialize trie', async () => {
         const trie = Trie.buildTrie(sampleWords).root;
         const data = serializeTrie(trie, 10);
         const root = importTrie(data);

--- a/packages/cspell-trie-lib/src/lib/index.test.ts
+++ b/packages/cspell-trie-lib/src/lib/index.test.ts
@@ -17,7 +17,6 @@ describe('Experiment with Tries', () => {
         expect(trie.c).toBeDefined();
         Trie.orderTrie(trie);
         const extractedWords = [...Trie.iteratorTrieWords(trie)];
-        // console.log(extractedWords);
         expect(extractedWords).toEqual(words.sort());
     });
 
@@ -38,7 +37,6 @@ describe('Experiment with Tries', () => {
         expect(asString3).not.toBe(asString);
         expect(asString3.slice(asString3.indexOf('# Data'))).toBe(asString.slice(asString.indexOf('# Data')));
         expect(asString3).toEqual(expect.stringContaining('\n# one\n# two\n# three'));
-        // console.log(asString);
         const root = Trie.importTrie(asString.split('\n'));
         {
             const trie = words.reduce((t, w) => {

--- a/packages/cspell-trie-lib/src/lib/suggest-es.test.ts
+++ b/packages/cspell-trie-lib/src/lib/suggest-es.test.ts
@@ -10,7 +10,6 @@ describe('Validate Spanish Suggestions', () => {
         const trie = await getTrie();
         // cspell:ignore Carmjen
         const results = trie.suggestWithCost('carmjen', 10);
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(expect.arrayContaining(['carmen']));
         expect(suggestions[0]).toBe('carmen');

--- a/packages/cspell-trie-lib/src/lib/suggest-nl.test.ts
+++ b/packages/cspell-trie-lib/src/lib/suggest-nl.test.ts
@@ -46,7 +46,7 @@ describe('Validate Dutch Suggestions', () => {
     );
 
     test(
-        'Tests suggestions "buurtbewoners"',
+        'Tests suggestions "buurtbewoners" with cost',
         async () => {
             const trie = await pTrieNL;
             const results = trie.suggestWithCost('buurtbewoners', 1);

--- a/packages/cspell-trie-lib/src/lib/suggest.test.ts
+++ b/packages/cspell-trie-lib/src/lib/suggest.test.ts
@@ -4,10 +4,9 @@ import { parseDictionary } from './SimpleDictionaryParser';
 import * as Walker from './walker';
 
 describe('Validate Suggest', () => {
-    test('Tests suggestions', () => {
+    test('Tests suggestions for valid word', () => {
         const trie = Trie.create(sampleWords);
         const results = Sug.suggest(trie.root, 'talks');
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(expect.arrayContaining(['talks']));
         expect(suggestions).toEqual(expect.arrayContaining(['talk']));
@@ -16,11 +15,10 @@ describe('Validate Suggest', () => {
         expect(suggestions).toEqual(['talks', 'talk', 'walks', 'talked', 'talker', 'walk']);
     });
 
-    test('Tests suggestions', () => {
+    test('Tests suggestions for invalid word', () => {
         const trie = Trie.create(sampleWords);
         // cspell:ignore tallk
         const results = Sug.suggest(trie.root, 'tallk');
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(expect.arrayContaining(['talks']));
         expect(suggestions).toEqual(expect.arrayContaining(['talk']));
@@ -29,38 +27,33 @@ describe('Validate Suggest', () => {
         expect(suggestions).toEqual(['talk', 'talks', 'walk']);
     });
 
-    test('Tests suggestions', () => {
+    // cspell:ignore jernals
+    test('Tests suggestions jernals', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore jernals
         const results = Sug.suggest(trie.root, 'jernals');
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(['journals', 'journal']);
     });
 
+    // cspell:ignore juornals
     test('Tests suggestions for `juornals` (reduced cost for swap)', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore juornals
         const results = Sug.suggest(trie.root, 'juornals');
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(['journals', 'journal', 'journalism', 'journalist', 'journey', 'jovial']);
     });
 
-    test('Tests suggestions', () => {
+    test('Tests suggestions for joyfull', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore joyfull
         const results = Sug.suggest(trie.root, 'joyfull');
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(['joyfully', 'joyful', 'joyfuller', 'joyfullest', 'joyous']);
     });
 
+    // cspell:ignore walkingtalkingjoy
     test('Tests compound suggestions', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore walkingtalkingjoy
         const results = Sug.suggest(trie.root, 'walkingtalkingjoy', 1, Walker.CompoundWordsMethod.SEPARATE_WORDS);
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(['walking talking joy']);
     });
@@ -68,16 +61,14 @@ describe('Validate Suggest', () => {
     test('Tests suggestions', () => {
         const trie = Trie.create(sampleWords);
         const results = Sug.suggest(trie.root, '');
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual([]);
     });
 
+    // cspell:ignore joyfull
     test('Tests suggestions with low max num', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore joyfull
         const results = Sug.suggest(trie.root, 'joyfull', 3);
-        // console.log(JSON.stringify(results));
         const suggestions = results.map((s) => s.word);
         expect(suggestions).toEqual(['joyfully', 'joyful', 'joyfuller']);
     });
@@ -116,9 +107,9 @@ describe('Validate Suggest', () => {
         expect(suggestions).toEqual(['joyfully', 'joyful', 'joyfuller', 'joyfullest', 'joyous']);
     });
 
-    test('Tests genSuggestions with compounds', () => {
+    // cspell:ignore joyfullwalk
+    test('Tests genSuggestions with compounds SEPARATE_WORDS', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore joyfullwalk
         const collector = Sug.suggestionCollector('joyfullwalk', 3);
         collector.collect(
             Sug.genCompoundableSuggestions(trie.root, collector.word, Walker.CompoundWordsMethod.SEPARATE_WORDS)
@@ -128,9 +119,9 @@ describe('Validate Suggest', () => {
         expect(collector.maxCost).toBeLessThan(300);
     });
 
-    test('Tests genSuggestions with compounds', () => {
+    // cspell:ignore joyfullwalk joyfulwalk joyfulwalks joyfullywalk, joyfullywalks
+    test('Tests genSuggestions with compounds JOIN_WORDS', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore joyfullwalk joyfulwalk joyfulwalks joyfullywalk, joyfullywalks
         const collector = Sug.suggestionCollector('joyfullwalk', 3);
         collector.collect(
             Sug.genCompoundableSuggestions(trie.root, collector.word, Walker.CompoundWordsMethod.JOIN_WORDS)
@@ -162,9 +153,9 @@ describe('Validate Suggest', () => {
         expect(collector.suggestions[0].cost).toBe(75);
     });
 
-    test('Test that accents are closer', () => {
+    // cspell:ignore wålk
+    test('that accents are closer', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore wålk
         const collector = Sug.suggestionCollector('wålk', 3);
         collector.collect(
             Sug.genCompoundableSuggestions(trie.root, collector.word, Walker.CompoundWordsMethod.JOIN_WORDS)
@@ -173,9 +164,9 @@ describe('Validate Suggest', () => {
         expect(suggestions).toEqual(['walk', 'walks', 'talk']);
     });
 
-    test('Test that accents are closer', () => {
+    // cspell:ignore wâlkéd
+    test('that multiple accents are closer', () => {
         const trie = Trie.create(sampleWords);
-        // cspell:ignore wâlkéd
         const collector = Sug.suggestionCollector('wâlkéd', 3);
         collector.collect(
             Sug.genCompoundableSuggestions(trie.root, collector.word, Walker.CompoundWordsMethod.JOIN_WORDS)
@@ -184,8 +175,8 @@ describe('Validate Suggest', () => {
         expect(suggestions).toEqual(['walked', 'walker', 'talked']);
     });
 
-    test('Test that forbidden words are not included (collector)', () => {
-        // cspell:ignore walkingtree talkingtree
+    // cspell:ignore walkingtree talkingtree
+    test('that forbidden words are not included (collector)', () => {
         const trie = parseDictionary(`
             walk
             walking*

--- a/packages/cspell-trie-lib/src/lib/trie.test.ts
+++ b/packages/cspell-trie-lib/src/lib/trie.test.ts
@@ -64,7 +64,7 @@ describe('Validate Trie Class', () => {
         expect(words).toEqual(sampleWords.sort());
     });
 
-    test('Test where only part of the word is correct', () => {
+    test('where only part of the word is correct', () => {
         const trie = Trie.create(sampleWords);
         expect(trie.has('talking')).toBe(true);
         expect(trie.has('talkings')).toBe(false);
@@ -85,7 +85,7 @@ describe('Validate Trie Class', () => {
         expect(options.forbiddenWordPrefix).toBe('#');
     });
 
-    test('Test compound words', () => {
+    test('compound words', () => {
         // cspell:ignore talkinglift joywalk jwalk awalk jayjay jayi
         const trie = Trie.create(sampleWords);
         expect(trie.has('talkinglift', true)).toBe(true);
@@ -106,7 +106,7 @@ describe('Validate Trie Class', () => {
         expect(trie.has('walked', true)).toBe(true);
     });
 
-    test('Test compound find', () => {
+    test('compound find', () => {
         // cspell:ignore talkinglift joywalk jwalk awalk jayjay jayi
         const trie = Trie.create(sampleWords);
         expect(trie.find('talkinglift', true)?.f).toBe(1);

--- a/packages/cspell-trie-lib/src/lib/walker.test.ts
+++ b/packages/cspell-trie-lib/src/lib/walker.test.ts
@@ -19,7 +19,7 @@ describe('Validate Util Functions', () => {
         expect(result).toEqual(sampleWords.filter((a) => a.length <= 4).sort());
     });
 
-    test('Test Hinted Walker', () => {
+    test('Hinted Walker', () => {
         const root = createTriFromList(sampleWords);
         orderTrie(root);
         // cspell:ignore joty

--- a/packages/cspell-util-bundle/src/index.test.ts
+++ b/packages/cspell-util-bundle/src/index.test.ts
@@ -1,7 +1,7 @@
 import { xregexp } from '.';
 
 describe('Validate Bundled Libraries', () => {
-    test('Test xregexp', () => {
+    test('xregexp', () => {
         expect(typeof xregexp).toEqual('function');
 
         const x = xregexp('t$');

--- a/packages/cspell/src/application.test.ts
+++ b/packages/cspell/src/application.test.ts
@@ -65,7 +65,7 @@ describe('Validate the Application', () => {
         expect(result.items.map((i) => i.text).join('')).toBe(result.text);
     });
 
-    test('Test running the application from stdin', async () => {
+    test('running the application from stdin', async () => {
         const files = ['stdin'];
         const options = { wordsOnly: true, unique: true };
         const logger = new Logger();


### PR DESCRIPTION
- Adds https://www.npmjs.com/package/eslint-plugin-jest for the Jest test files only
- Automated cleanup of names base on their rules
- Removed empty tests
- Adjusted duplicate names
- Removed old commented out `console.log` statements in tests