### PR TITLE
chore: Skip linting on Dependabot pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ on:
       - '**/.eslintignore'
       - '**/package*.json'
       - '**/*.ts'
+    branches-ignore:
+      - 'dependabot/*'
 
 jobs:
   lint:


### PR DESCRIPTION
Other jobs use explicit branch filters alread, but Lint job is running
twice for dependabot branch/prs