### PR TITLE
ci: remove unnecessary dependency upon xregexp types

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -1,6 +1,8 @@
 DAWG
 ESNEXT
 WORDCHARS
+backreference
+backreferences
 bitjson
 codecov
 coverallsapp
@@ -18,6 +20,7 @@ macos
 micromatch
 monorepo
 multiline
+namespacing
 popd
 pushd
 repos

--- a/package-lock.json
+++ b/package-lock.json
@@ -2769,12 +2769,6 @@
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
     },
-    "@types/xregexp": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@types/xregexp/-/xregexp-4.3.0.tgz",
-      "integrity": "sha512-3gJTS9gt27pS7U9q5IVqo4YvKSlkf2ck8ish6etuDj6LIRxkL/2Y8RMUtK/QzvE1Yv2zwWV5yemI2BS0GGGFnA==",
-      "dev": true
-    },
     "@types/yargs": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/minimatch": "^3.0.3",
     "@types/node": "^14.14.5",
     "@types/shelljs": "^0.8.8",
-    "@types/xregexp": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
     "ajv-cli": "^3.3.0",

--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -339,24 +339,24 @@
       }
     },
     "cspell-io": {
-      "version": "5.0.1-alpha.8",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.0.1-alpha.8.tgz",
-      "integrity": "sha512-e9UGBVVYJVJhzjn10myfveElqPbuTMHnEUHEEsv8VLBPSo1t/GEpe+c00FoXVX0IYh7VgX6RbruniJtswPcUbw==",
+      "version": "5.0.1-alpha.11",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.0.1-alpha.11.tgz",
+      "integrity": "sha512-eC/P8l6fGwaUgz2ByuWVbPoAXTnvooXo8PtoR8CWBcIHp+CjBEgEAKUArx1HLEomwrW4UDs3rHXVXRI++8qiIA==",
       "requires": {
         "iconv-lite": "^0.6.2",
         "iterable-to-stream": "^1.0.1"
       }
     },
     "cspell-tools": {
-      "version": "5.0.1-alpha.8",
-      "resolved": "https://registry.npmjs.org/cspell-tools/-/cspell-tools-5.0.1-alpha.8.tgz",
-      "integrity": "sha512-0In/xbcQHAST/lUIyyagimchXO93TkmkFZmMBsn/GdSPBpSFllNYES35oedCoRsGwzpyYBINpk8eENeoOsQi0g==",
+      "version": "5.0.1-alpha.11",
+      "resolved": "https://registry.npmjs.org/cspell-tools/-/cspell-tools-5.0.1-alpha.11.tgz",
+      "integrity": "sha512-DB9bAklt5jypVeZiWcjkzk64Sbcbw+BB8z1dSP0bn49ToDZzgrVDKYd3uDMYROxngoELZqkH0uqT3H3CuOtarA==",
       "dev": true,
       "requires": {
         "commander": "^6.2.0",
-        "cspell-io": "^5.0.1-alpha.8",
-        "cspell-trie-lib": "^5.0.1-alpha.8",
-        "cspell-util-bundle": "^5.0.1-alpha.8",
+        "cspell-io": "^5.0.1-alpha.11",
+        "cspell-trie-lib": "^5.0.1-alpha.11",
+        "cspell-util-bundle": "^5.0.1-alpha.11",
         "fs-extra": "^9.0.1",
         "gensequence": "^3.1.1",
         "glob": "^7.1.6",
@@ -366,17 +366,17 @@
       }
     },
     "cspell-trie-lib": {
-      "version": "5.0.1-alpha.8",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.0.1-alpha.8.tgz",
-      "integrity": "sha512-697lGrbxbOQ+kuJQYsONKGEmaxdYaVeqTUh2pOK+Xnx+Fcw9NHwA+bYpcU5X+fUbIfdNghCYXF8vazTrGT69bQ==",
+      "version": "5.0.1-alpha.11",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.0.1-alpha.11.tgz",
+      "integrity": "sha512-B7yjeA6ywNvf2FsliWBr7OojkQCbsa2ZdhwKZN3WvKD3PE9NBNHOMrhFRQo/7p8l1C0tNaqFsvZNWpMonZo5cA==",
       "requires": {
         "gensequence": "^3.1.1"
       }
     },
     "cspell-util-bundle": {
-      "version": "5.0.1-alpha.8",
-      "resolved": "https://registry.npmjs.org/cspell-util-bundle/-/cspell-util-bundle-5.0.1-alpha.8.tgz",
-      "integrity": "sha512-hH4YnQT7Y2+GXT+NF9zuS63PLy2BKkXBs7ceJuHkZNpbojfltDm6O8BneujmS+PnkTQNdTJSvIjp/qNB6WDRqw=="
+      "version": "5.0.1-alpha.11",
+      "resolved": "https://registry.npmjs.org/cspell-util-bundle/-/cspell-util-bundle-5.0.1-alpha.11.tgz",
+      "integrity": "sha512-2rcB0nHS8UKV4zGAAenOYZ2coRo7sR0FYL2P6AqjzlNo7LbzO6T6BrPTEvgXx7dU0rxJHrVptL2S+1n4nBA6xg=="
     },
     "dot-prop": {
       "version": "5.3.0",

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryCollection.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryCollection.test.ts
@@ -41,6 +41,13 @@ describe('Verify using multiple dictionaries', () => {
         expect(dictCollection.size).toBeGreaterThanOrEqual(wordsA.length - 1 + wordsB.length + wordsC.length);
     });
 
+    test('checks mapWord is identity', async () => {
+        const dicts = await Promise.all([createSpellingDictionary(wordsA, 'wordsA', 'test')]);
+
+        const dictCollection = new SpellingDictionaryCollection(dicts, 'test', []);
+        expect(dictCollection.mapWord('Hello')).toBe('Hello');
+    });
+
     test('checks for suggestions', async () => {
         const trie = new SpellingDictionaryFromTrie(Trie.Trie.create(wordsA), 'wordsA');
         const dicts = await Promise.all([

--- a/packages/cspell-lib/src/util/util.test.ts
+++ b/packages/cspell-lib/src/util/util.test.ts
@@ -33,4 +33,12 @@ describe('Validate util', () => {
         const cleanObj = util.clean(obj);
         expect([...Object.keys(cleanObj)]).toEqual(['b', 'c', 'e']);
     });
+
+    test('scan map with no init', () => {
+        const v = [1, 2, 3, 4, 5, 6];
+        let sum = 0;
+        const r = v.map(util.scanMap((a, v) => ((sum += v - a), v)));
+        expect(r).toEqual(v);
+        expect(sum).toBe(5);
+    });
 });

--- a/packages/cspell-util-bundle/package.json
+++ b/packages/cspell-util-bundle/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist/index.js",
     "dist/index.d.ts",
+    "dist/xregexp.d.ts",
     "!**/*.map",
     "!**/*.test.*",
     "!**/temp/**"

--- a/packages/cspell-util-bundle/src/xregexp.ts
+++ b/packages/cspell-util-bundle/src/xregexp.ts
@@ -1,2 +1,129 @@
-import XRegExp from 'xregexp';
-export const xregexp = XRegExp;
+import XRegExpLib from 'xregexp';
+
+/**
+ * Match or replacement scope that will only match or replace the first occurrence.
+ */
+export type MatchScopeOne = 'one';
+
+/**
+ * Match or replacement scope that will match or replace all occurrence.
+ */
+export type MatchScopeAll = 'all';
+
+/**
+ * Valid match or replacement scopes for when doing a match or replace.
+ */
+export type MatchScope = MatchScopeOne | MatchScopeAll;
+
+export type Pattern = RegExp | string;
+
+/**
+ * A matched substring, including named capture groups as properties, or the `groups` property
+ * if the `namespacing` feature is installed.
+ */
+export interface MatchSubString extends String {
+    /**
+     * Named capture groups are accessible as properties when the `namespacing`
+     * feature is not installed.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [propName: string]: any;
+
+    /**
+     * This is only present if the the `namespacing` feature is installed
+     * using the `XRegExp.install` method.
+     */
+    groups?: NamedGroupsArray;
+}
+
+/**
+ * Represents a list of named capture groups. Only valid if the `namespacing` feature is turned on.
+ */
+export interface NamedGroupsArray {
+    /**
+     * Named capture groups are accessible as properties.
+     */
+    [key: string]: string;
+}
+
+/**
+ *   Replacement functions are invoked with three or more arguments:
+ *     - {string}        substring  - The matched substring (corresponds to `$&` above). Named backreferences are accessible as
+ *       properties of this first argument if the `namespacing` feature is off.
+ *     - {string}        args[1..n] - arguments, one for each backreference (corresponding to `$1`, `$2`, etc. above).
+ *     - {number}        args[n+1]  - The zero-based index of the match within the total search string.
+ *     - {string}        args[n+2]  - The total string being searched.
+ *     - {XRegExp.NamedGroups} args[n+3]  - If the `namespacing` feature is turned on, the last parameter is the groups object. If the
+ *       `namespacing` feature is off, then this argument is not present.
+ */
+export type ReplacementFunction = (
+    substring: MatchSubString,
+    ...args: Array<string | number | NamedGroupsArray>
+) => string;
+
+export type ReplacementValue = string | ReplacementFunction;
+
+export interface XRegExp {
+    (pattern: string, flags?: string): RegExp;
+    (pattern: RegExp): RegExp;
+
+    /**
+     * Returns a new string with one or all matches of a pattern replaced. The pattern can be a string
+     * or regex, and the replacement can be a string or a function to be called for each match. To
+     * perform a global search and replace, use the optional `scope` argument or include flag g if using
+     * a regex. Replacement strings can use `${n}` or `$<n>` for named and numbered backreferences.
+     * Replacement functions can use named backreferences via `arguments[0].name`. Also fixes browser
+     * bugs compared to the native `String.prototype.replace` and can be used reliably cross-browser.
+     *
+     * @param str - String to search.
+     * @param search - Search pattern to be replaced.
+     * @param replacement - Replacement string or a function invoked to create it.
+     * @param scope - Use 'one' to replace the first match only, or 'all'. If not explicitly specified and using a regex with
+     *        flag g, `scope` is 'all'.
+     * @returns New string with one or all matches replaced.
+     * @example
+     *
+     * // Regex search, using named backreferences in replacement string
+     * const name = XRegExp('(?<first>\\w+) (?<last>\\w+)');
+     * XRegExp.replace('John Smith', name, '$<last>, $<first>');
+     * // -> 'Smith, John'
+     *
+     * // Regex search, using named backreferences in replacement function
+     * XRegExp.replace('John Smith', name, (match) => `${match.last as string}, ${match.first as string}`);
+     * // -> 'Smith, John'
+     *
+     * // String search, with replace-all
+     * XRegExp.replace('RegExp builds RegExps', 'RegExp', 'XRegExp', 'all');
+     * // -> 'XRegExp builds XRegExps'
+     */
+    replace(str: string, search: Pattern, replacement: ReplacementValue, scope?: MatchScope): string;
+
+    /**
+     * Splits a string into an array of strings using a regex or string separator. Matches of the
+     * separator are not included in the result array. However, if `separator` is a regex that contains
+     * capturing groups, backreferences are spliced into the result each time `separator` is matched.
+     * Fixes browser bugs compared to the native `String.prototype.split` and can be used reliably
+     * cross-browser.
+     *
+     * @param str - String to split.
+     * @param separator - Regex or string to use for separating the string.
+     * @param limit - Maximum number of items to include in the result array.
+     * @returns Array of substrings.
+     * @example
+     *
+     * // Basic use
+     * XRegExp.split('a b c', ' ');
+     * // -> ['a', 'b', 'c']
+     *
+     * // With limit
+     * XRegExp.split('a b c', ' ', 2);
+     * // -> ['a', 'b']
+     *
+     * // Backreferences in result array
+     * XRegExp.split('..word1..', /([a-z]+)(\d+)/i);
+     * // -> ['..', 'word', '1', '..']
+     */
+    split(str: string, separator: Pattern, limit?: number): string[];
+}
+
+export const xregexp: XRegExp = XRegExpLib;


### PR DESCRIPTION
cspell-util-bundle forced consumers to have a copy for XRegExp to get the types.