### PR TITLE
chore: Remove parallel coveralls since not in matrix

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell/coverage/lcov.info
           flag-name: cspell
-          parallel: true
 
       - name: Coveralls cspell-glob
         uses: coverallsapp/github-action@v1.1.2
@@ -33,7 +32,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-glob/coverage/lcov.info
           flag-name: cspell-glob
-          parallel: true
 
       - name: Coveralls cspell-io
         uses: coverallsapp/github-action@v1.1.2
@@ -41,7 +39,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-io/coverage/lcov.info
           flag-name: cspell-io
-          parallel: true
 
       - name: Coveralls cspell-lib
         uses: coverallsapp/github-action@v1.1.2
@@ -49,7 +46,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-lib/coverage/lcov.info
           flag-name: cspell-lib
-          parallel: true
 
       - name: Coveralls cspell-tools
         uses: coverallsapp/github-action@v1.1.2
@@ -57,9 +53,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-tools/coverage/lcov.info
           flag-name: cspell-tools
-          parallel: true
-
-      - run: head ./packages/cspell-tools/coverage/lcov.info
 
       - name: Coveralls cspell-trie
         uses: coverallsapp/github-action@v1.1.2
@@ -67,7 +60,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-trie/coverage/lcov.info
           flag-name: cspell-trie
-          parallel: true
 
       - name: Coveralls cspell-trie-lib
         uses: coverallsapp/github-action@v1.1.2
@@ -75,9 +67,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-trie-lib/coverage/lcov.info
           flag-name: cspell-trie-lib
-          parallel: true
-
-      - run: head ./packages/cspell-trie-lib/coverage/lcov.info
 
       - name: Coveralls cspell-trie2-lib
         uses: coverallsapp/github-action@v1.1.2
@@ -85,7 +74,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-trie2-lib/coverage/lcov.info
           flag-name: cspell-trie2-lib
-          parallel: true
 
       - name: Coveralls cspell-util-bundle
         uses: coverallsapp/github-action@v1.1.2
@@ -93,19 +81,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-util-bundle/coverage/lcov.info
           flag-name: cspell-util-bundle
-          parallel: true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           directory: ./packages/*/coverage/
-
-  finished:
-    needs: coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true


### PR DESCRIPTION
Trying to see if it will get rid of the "overall coveralls/coveralls" job that usually marked as failed with a reduction of coverage