### PR TITLE
chore: Fix Lint CI globs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,24 @@ name: Lint
 on:
   pull_request:
     paths:
-      - "**/.eslintignore"
-      - "**/*.{js,ts,md,yaml,yml,json}"
+      - ".eslint*"
+      - ".prettier*"
+      - "**/*.js"
+      - "**/*.ts"
+      - "**/*.md"
+      - "**/*.json"
+      - "**/*.yml"
+      - "**/*.yaml"
   push:
     paths:
-      - "**/.eslintignore"
-      - "**/*.{js,ts,md,yaml,yml,json}"
+      - ".eslint*"
+      - ".prettier*"
+      - "**/*.js"
+      - "**/*.ts"
+      - "**/*.md"
+      - "**/*.json"
+      - "**/*.yml"
+      - "**/*.yaml"
     branches-ignore:
       - "dependabot/*"
 


### PR DESCRIPTION
GitHub actions path globs are more basic in their regexs https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#patterns-to-match-file-paths