### PR TITLE
chore: Remove hard reference to source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",
-    "source-map-support": "^0.5.19",
     "ts-jest": "^26.4.4",
     "ts-json-schema-generator": "^0.78.0",
     "ts-loader": "^8.0.11",


### PR DESCRIPTION
Depenedncy of jest-runner, but not by any package directly