### PR TITLE
Revert "chore: Remove parallel coveralls since not in matrix (#561)"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell/coverage/lcov.info
           flag-name: cspell
+          parallel: true
 
       - name: Coveralls cspell-glob
         uses: coverallsapp/github-action@v1.1.2
@@ -32,6 +33,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-glob/coverage/lcov.info
           flag-name: cspell-glob
+          parallel: true
 
       - name: Coveralls cspell-io
         uses: coverallsapp/github-action@v1.1.2
@@ -39,6 +41,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-io/coverage/lcov.info
           flag-name: cspell-io
+          parallel: true
 
       - name: Coveralls cspell-lib
         uses: coverallsapp/github-action@v1.1.2
@@ -46,6 +49,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-lib/coverage/lcov.info
           flag-name: cspell-lib
+          parallel: true
 
       - name: Coveralls cspell-tools
         uses: coverallsapp/github-action@v1.1.2
@@ -53,6 +57,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-tools/coverage/lcov.info
           flag-name: cspell-tools
+          parallel: true
+
+      - run: head ./packages/cspell-tools/coverage/lcov.info
 
       - name: Coveralls cspell-trie
         uses: coverallsapp/github-action@v1.1.2
@@ -60,6 +67,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-trie/coverage/lcov.info
           flag-name: cspell-trie
+          parallel: true
 
       - name: Coveralls cspell-trie-lib
         uses: coverallsapp/github-action@v1.1.2
@@ -67,6 +75,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-trie-lib/coverage/lcov.info
           flag-name: cspell-trie-lib
+          parallel: true
+
+      - run: head ./packages/cspell-trie-lib/coverage/lcov.info
 
       - name: Coveralls cspell-trie2-lib
         uses: coverallsapp/github-action@v1.1.2
@@ -74,6 +85,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-trie2-lib/coverage/lcov.info
           flag-name: cspell-trie2-lib
+          parallel: true
 
       - name: Coveralls cspell-util-bundle
         uses: coverallsapp/github-action@v1.1.2
@@ -81,8 +93,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./packages/cspell-util-bundle/coverage/lcov.info
           flag-name: cspell-util-bundle
+          parallel: true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           directory: ./packages/*/coverage/
+
+  finished:
+    needs: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
This reverts commit 76c80f0762e0542fe33e9d458dd3826b9281bf67.

Uploading to Coverall one module at a time screws coveralls.

By using parallel, it considers all the packages part of the same build.

Otherwise they are considered separate builds, see image:
![image](https://user-images.githubusercontent.com/3740137/99315895-b0527780-2863-11eb-8db6-bcc2e2905dc2.png)
