### PR TITLE
chore: use rimraf instead of rm -rf in update-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test-watch": "lerna run --parallel test-watch",
     "test": "lerna run test && ajv -s ./cspell.schema.json -d cspell.json",
     "test-integrations": "cd ./integration-tests && npm run integration-tests",
-    "update-packages": "lerna exec \"npm update -S && rm -rf node_modules package-lock.json && npm i\" && lerna bootstrap"
+    "update-packages": "lerna exec \"npm update -S && rimraf node_modules package-lock.json && npm i\" && lerna bootstrap"
   },
   "repository": {
     "type": "git",

--- a/packages/cspell-util-bundle/package-lock.json
+++ b/packages/cspell-util-bundle/package-lock.json
@@ -694,9 +694,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",
-      "integrity": "sha512-YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.5.tgz",
+      "integrity": "sha512-Dc6ar9x16BdaR3NSxSF7T4IjL9gxxViJq8RmFd+2UAyA+K6ck2W+gUwfgpG/y9TPyUuBL35109bbULpEynvltA==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -1407,9 +1407,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001157",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz",
-      "integrity": "sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==",
+      "version": "1.0.30001158",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz",
+      "integrity": "sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g==",
       "dev": true
     },
     "capture-exit": {
@@ -1847,9 +1847,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.593",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.593.tgz",
-      "integrity": "sha512-GvO7G1ZxvffnMvPCr4A7+iQPVuvpyqMrx2VWSERAjG+pHK6tmO9XqYdBfMIq9corRyi4bNImSDEiDvIoDb8HrA==",
+      "version": "1.3.596",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz",
+      "integrity": "sha512-nLO2Wd2yU42eSoNJVQKNf89CcEGqeFZd++QsnN2XIgje1s/19AgctfjLIbPORlvcCO8sYjLwX4iUgDdusOY8Sg==",
       "dev": true
     },
     "emittery": {
@@ -4941,9 +4941,9 @@
       }
     },
     "terser": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.8.tgz",
-      "integrity": "sha512-zVotuHoIfnYjtlurOouTazciEfL7V38QMAOhGqpXDEg6yT13cF4+fEP9b0rrCEQTn+tT46uxgFsTZzhygk+CzQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.4.0.tgz",
+      "integrity": "sha512-3dZunFLbCJis9TAF2VnX+VrQLctRUmt1p3W2kCsJuZE4ZgWqh//+1MZ62EanewrqKoUf4zIaDGZAvml4UDc0OQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",


### PR DESCRIPTION
There was a small change in cspell-util-bundle that was included