### PR TITLE
ci: use bootstrap --no-ci

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -729,9 +729,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3653,11 +3653,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "requires": {
-        "is-core-module": "^2.0.0",
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -24,7 +24,7 @@
     "shelljs": "^0.8.4"
   },
   "devDependencies": {
-    "@types/node": "^14.14.2",
+    "@types/node": "^14.14.7",
     "@types/shelljs": "^0.8.8",
     "jest": "^26.6.3",
     "typescript": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test-watch": "lerna run --parallel test-watch",
     "test": "lerna run test && ajv -s ./cspell.schema.json -d cspell.json",
     "test-integrations": "cd ./integration-tests && npm run integration-tests",
-    "update-packages": "lerna exec \"npm update -S && rimraf node_modules package-lock.json && npm i\" && lerna bootstrap"
+    "update-packages": "lerna exec \"npm update -S && rimraf node_modules package-lock.json && npm i\" && lerna bootstrap --no-ci"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When updating packages, use `lerna bootstrap --no-ci` so that the package-lock files get updated.

Note: `--no-ci` used to be the default.