### PR TITLE
chore: Shake out root packages included in sub-packages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ integration-tests/config/config.json
 cspell.json
 .vscode/
 [sS]amples/
+lerna.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,12 +2594,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/braces": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",
-      "integrity": "sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==",
-      "dev": true
-    },
     "@types/configstore": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-4.0.0.tgz",
@@ -2695,15 +2689,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "@types/micromatch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.1.tgz",
-      "integrity": "sha512-my6fLBvpY70KattTNzYOK6KU1oR1+UCz9ug/JbcF5UrEmeCt9P7DV2t7L8+t18mMPINqGQCE4O8PLOPbI84gxw==",
-      "dev": true,
-      "requires": {
-        "@types/braces": "*"
-      }
     },
     "@types/minimatch": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,22 +2594,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/eslint": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",
-      "integrity": "sha512-YCY4kzHMsHoyKspQH+nwSe+70Kep7Vjt2X+dZe5Vs2vkRudqtoFoUIv1RlJmZB8Hbp7McneupoZij4PadxsK5Q==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-      "dev": true
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,15 +4484,6 @@
         "configstore": "^5.0.1"
       }
     },
-    "cspell-dict-es-es": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/cspell-dict-es-es/-/cspell-dict-es-es-1.0.24.tgz",
-      "integrity": "sha512-Wmaw5RLXbJXTpV8b4FTWmoyV1cHebO1nYepYCDL4EERQKJogDp1gPPYfbr/XlcBNqd1dlXvEemOSAOGqwpShtw==",
-      "dev": true,
-      "requires": {
-        "configstore": "^5.0.1"
-      }
-    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3896,20 +3896,6 @@
         "proto-list": "~1.2.1"
       }
     },
-    "configstore": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
-      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "^5.2.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "unique-string": "^2.0.0",
-        "write-file-atomic": "^3.0.0",
-        "xdg-basedir": "^4.0.0"
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -4467,21 +4453,6 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true
-    },
-    "cspell-dict-en_us": {
-      "version": "1.2.34",
-      "resolved": "https://registry.npmjs.org/cspell-dict-en_us/-/cspell-dict-en_us-1.2.34.tgz",
-      "integrity": "sha512-BCiAotkU19/a/FJrhfs3C8c16k6QPGb+KIpQ/sJZQFVTI69nxgGvZ3yidBWS+fo1Q4UDx3atiNEE/cmcY6uZAw==",
-      "dev": true,
-      "requires": {
-        "configstore": "^5.0.1"
       }
     },
     "cssom": {
@@ -12352,15 +12323,6 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "^2.0.0"
-      }
-    },
     "universal-user-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
@@ -12808,12 +12770,6 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
       "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
-      "dev": true
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4493,15 +4493,6 @@
         "configstore": "^5.0.1"
       }
     },
-    "cspell-dict-nl-nl": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/cspell-dict-nl-nl/-/cspell-dict-nl-nl-1.0.29.tgz",
-      "integrity": "sha512-JxRAMp/aldKeS4i4DaUQgBedohZljgXkj07FJ1qhYkNVAPZBqecPnU/wCcoIzK0X58HQDLhSkvjy29VS6VUZcA==",
-      "dev": true,
-      "requires": {
-        "configstore": "^5.0.1"
-      }
-    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,15 +2616,6 @@
       "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
       "dev": true
     },
-    "@types/fs-extra": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.4.tgz",
-      "integrity": "sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2705,16 +2705,6 @@
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
-    "@types/shelljs": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.8.tgz",
-      "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9211,15 +9211,6 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
-    "lorem-ipsum": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.3.tgz",
-      "integrity": "sha512-CX2r84DMWjW/DWiuzicTI9aRaJPAw2cvAGMJYZh/nx12OkTGqloj8y8FU0S8ZkKwOdqhfxEA6Ly8CW2P6Yxjwg==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.17.1"
-      }
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3431,12 +3431,6 @@
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
       "dev": true
     },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4798,12 +4792,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
-    },
     "encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -4833,17 +4821,6 @@
         "once": "^1.4.0"
       }
     },
-    "enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      }
-    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -4870,15 +4847,6 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -9161,28 +9129,6 @@
         }
       }
     },
-    "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
-    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -9387,16 +9333,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "memory-fs": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-      "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "dev": true,
-      "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -10501,12 +10437,6 @@
       "requires": {
         "genfun": "^5.0.0"
       }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -11821,12 +11751,6 @@
         }
       }
     },
-    "tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true
-    },
     "tar": {
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
@@ -12099,77 +12023,6 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
           "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
-        }
-      }
-    },
-    "ts-loader": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.11.tgz",
-      "integrity": "sha512-06X+mWA2JXoXJHYAesUUL4mHFYhnmyoCdQVMXofXF552Lzd4wNwSGg7unJpttqUP7ziaruM8d7u8LUB6I1sgzA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.3.0",
-        "enhanced-resolve": "^4.0.0",
-        "loader-utils": "^1.0.2",
-        "micromatch": "^4.0.0",
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,12 +2594,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/configstore": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-4.0.0.tgz",
-      "integrity": "sha512-SvCBBPzOIe/3Tu7jTl2Q8NjITjLmq9m7obzjSyb8PXWWZ31xVK6w4T6v8fOx+lrgQnqk3Yxc00LDolFsSakKCA==",
-      "dev": true
-    },
     "@types/eslint": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "ajv-cli": "^3.3.0",
-    "cspell-dict-en_us": "^1.2.34",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/fs-extra": "^9.0.4",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.15",
-    "@types/minimatch": "^3.0.3",
     "@types/node": "^14.14.7",
     "@types/shelljs": "^0.8.8",
     "@typescript-eslint/eslint-plugin": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "homepage": "https://github.com/streetsidesoftware/cspell#readme",
   "devDependencies": {
-    "@types/configstore": "^4.0.0",
     "@types/eslint": "^7.2.4",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.7",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.3",
     "lerna": "^3.22.1",
-    "lorem-ipsum": "^2.0.3",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "homepage": "https://github.com/streetsidesoftware/cspell#readme",
   "devDependencies": {
-    "@types/jest": "^26.0.15",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "ajv-cli": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",
     "ts-jest": "^26.4.4",
-    "ts-loader": "^8.0.11",
     "typescript": "^4.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@typescript-eslint/parser": "^4.7.0",
     "ajv-cli": "^3.3.0",
     "cspell-dict-en_us": "^1.2.34",
-    "cspell-dict-es-es": "^1.0.24",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@types/eslint": "^7.2.4",
     "@types/jest": "^26.0.15",
-    "@types/node": "^14.14.7",
     "@types/shelljs": "^0.8.8",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@types/eslint": "^7.2.4",
     "@types/jest": "^26.0.15",
-    "@types/shelljs": "^0.8.8",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "ajv-cli": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "homepage": "https://github.com/streetsidesoftware/cspell#readme",
   "devDependencies": {
-    "@types/eslint": "^7.2.4",
     "@types/jest": "^26.0.15",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@types/configstore": "^4.0.0",
     "@types/eslint": "^7.2.4",
-    "@types/fs-extra": "^9.0.4",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@types/configstore": "^4.0.0",
     "@types/eslint": "^7.2.4",
-    "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.7",
     "@types/shelljs": "^0.8.8",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "ajv-cli": "^3.3.0",
     "cspell-dict-en_us": "^1.2.34",
     "cspell-dict-es-es": "^1.0.24",
-    "cspell-dict-nl-nl": "^1.0.29",
     "eslint": "^7.13.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/fs-extra": "^9.0.4",
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.15",
-    "@types/micromatch": "^4.0.1",
     "@types/minimatch": "^3.0.3",
     "@types/node": "^14.14.7",
     "@types/shelljs": "^0.8.8",

--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -743,6 +743,12 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -95,6 +95,7 @@
   "devDependencies": {
     "@types/configstore": "^4.0.0",
     "@types/fs-extra": "^9.0.4",
+    "@types/minimatch": "^3.0.3",
     "@types/node": "^14.14.7",
     "cspell-dict-nl-nl": "^1.0.25",
     "jest": "^26.6.3",


### PR DESCRIPTION
Left all the general dev packages used in the root and supporting tools, but removed the ones already installed in the child packages explicitly now