### PR TITLE
fix: globbing for dependabot PR filtering

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ on:
       - "**/*.yml"
       - "**/*.yaml"
     branches-ignore:
-      - "dependabot/*"
+      - "dependabot/**"
 
 jobs:
   lint:


### PR DESCRIPTION
Noticed in #593 that it's still building those branches. Looked at another repo with the setup and it used the double asterisks instead so trying that here