### PR TITLE
feat: Add link command

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,10 @@
-cspell.schema.json
-tsconfig*.json
-integration-tests/config/config.json
-integration-tests/repositories/*/*/**
-cspell.json
 .vscode/
 [sS]amples/
-lerna.json
 CHANGELOG.md
+cspell.json
+cspell.schema.json
+dist/
+integration-tests/config/config.json
+integration-tests/repositories/*/*/**
+lerna.json
+tsconfig*.json

--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -2273,6 +2273,14 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2455,6 +2463,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -4105,6 +4118,14 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+    },
+    "resolve-global": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+      "requires": {
+        "global-dirs": "^0.1.1"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -87,6 +87,7 @@
     "gensequence": "^3.1.1",
     "minimatch": "^3.0.4",
     "resolve-from": "^5.0.0",
+    "resolve-global": "^1.0.0",
     "vscode-uri": "^2.1.2"
   },
   "engines": {

--- a/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
@@ -324,3 +324,7 @@ export interface Source {
     filename?: string;
     sources?: CSpellSettings[];
 }
+
+export interface GlobalCSpellSettings {
+    import: CSpellSettings['import'];
+}

--- a/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsDef.ts
@@ -324,7 +324,3 @@ export interface Source {
     filename?: string;
     sources?: CSpellSettings[];
 }
-
-export interface GlobalCSpellSettings {
-    import: CSpellSettings['import'];
-}

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -8,20 +8,17 @@ import {
     Pattern,
     CSpellSettingsWithSourceTrace,
     ImportFileRef,
-    GlobalCSpellSettings,
 } from './CSpellSettingsDef';
 import * as path from 'path';
 import { normalizePathForDictDefs } from './DictionarySettings';
 import * as util from '../util/util';
-import { logError } from '../util/logger';
-import ConfigStore from 'configstore';
 import minimatch from 'minimatch';
 import { resolveFile } from '../util/resolveFile';
+import { getRawGlobalSettings } from './GlobalSettings';
 
 const currentSettingsFileVersion = '0.1';
 
 export const sectionCSpell = 'cSpell';
-const packageName = 'cspell';
 
 export const defaultFileName = 'cSpell.json';
 
@@ -307,45 +304,13 @@ function resolveFilename(filename: string, relativeTo: string): ImportFileRef {
     };
 }
 
-export function getRawGlobalSettings(): CSpellSettings {
-    const globalConf: CSpellSettings = {};
-
-    try {
-        const cfgStore = new ConfigStore(packageName);
-        Object.assign(globalConf, cfgStore.all);
-        globalConf.source = {
-            name: 'CSpell Configstore',
-            filename: cfgStore.path,
-        };
-    } catch (error) {
-        logError(error);
-    }
-
-    return globalConf;
-}
-
-export function writeRawGlobalSettings(settings: GlobalCSpellSettings): Error | undefined {
-    const toWrite: GlobalCSpellSettings = {
-        import: settings.import,
-    };
-
-    try {
-        const cfgStore = new ConfigStore(packageName);
-        cfgStore.set(toWrite);
-        return undefined;
-    } catch (error) {
-        if (error instanceof Error) return error;
-        return new Error(error.toString());
-    }
-}
-
 export function getGlobalSettings(): CSpellSettings {
     if (!globalSettings) {
         const globalConf = getRawGlobalSettings();
 
         globalSettings = {
             id: 'global_config',
-            ...normalizeSettings(globalConf || {}, __dirname),
+            ...normalizeSettings(globalConf || {}, '.'),
         };
     }
     return globalSettings;

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -128,6 +128,12 @@ export function readSettings(
     return importSettings(ref, defaultValue);
 }
 
+export function readRawSettings(filename: string, relativeTo?: string): CSpellSettings {
+    relativeTo = relativeTo || process.cwd();
+    const ref = resolveFilename(filename, relativeTo);
+    return readJsonFile(ref);
+}
+
 export function readSettingsFiles(filenames: string[]): CSpellSettings {
     return filenames.map((filename) => readSettings(filename)).reduce((a, b) => mergeSettings(a, b), defaultSettings);
 }

--- a/packages/cspell-lib/src/Settings/GlobalSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/GlobalSettings.test.ts
@@ -1,0 +1,78 @@
+import { getGlobalConfigPath, getRawGlobalSettings, writeRawGlobalSettings } from './GlobalSettings';
+import Configstore from 'configstore';
+// eslint-disable-next-line jest/no-mocks-import
+import {
+    clearData as clearConfigstore,
+    // setData as setConfigstore,
+    clearMocks,
+    mockAll,
+    mockSetData,
+} from '../__mocks__/configstore';
+
+const mockLog = jest.fn();
+console.log = mockLog;
+jest.mock('configstore');
+
+const mockConfigstore = Configstore as jest.Mock<Configstore>;
+
+describe('Validate GlobalSettings', () => {
+    beforeEach(() => {
+        mockConfigstore.mockClear();
+        mockLog.mockClear();
+        clearMocks();
+        clearConfigstore();
+    });
+
+    test('getGlobalConfigPath', () => {
+        expect(getGlobalConfigPath()).toEqual(expect.stringMatching(/cspell\.json$/));
+    });
+
+    test('getRawGlobalSettings', () => {
+        const path = getGlobalConfigPath();
+        const s = getRawGlobalSettings();
+        expect(s).toEqual({
+            source: {
+                name: 'CSpell Configstore',
+                filename: path,
+            },
+        });
+        expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    test('getRawGlobalSettings with Error', () => {
+        mockAll.mockImplementation(() => {
+            throw new Error('fail');
+        });
+        const s = getRawGlobalSettings();
+        expect(s).toEqual({
+            source: {
+                name: 'CSpell Configstore',
+                filename: undefined,
+            },
+        });
+        expect(mockLog).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    test('writeRawGlobalSettings', () => {
+        const s = getRawGlobalSettings();
+        const updated = { ...s, import: ['hello'], extra: { name: 'extra', value: 'ok' } };
+        writeRawGlobalSettings(updated);
+        expect(mockSetData).toHaveBeenCalledWith({
+            import: ['hello'],
+        });
+    });
+
+    test('writeRawGlobalSettings with Error', () => {
+        const updated = { import: ['hello'] };
+        mockSetData.mockImplementation(() => {
+            throw new Error('fail');
+        });
+        const error1 = writeRawGlobalSettings(updated);
+        expect(error1).toBeInstanceOf(Error);
+        mockSetData.mockImplementation(() => {
+            throw 'fail';
+        });
+        const error2 = writeRawGlobalSettings(updated);
+        expect(error2).toBeInstanceOf(Error);
+    });
+});

--- a/packages/cspell-lib/src/Settings/GlobalSettings.ts
+++ b/packages/cspell-lib/src/Settings/GlobalSettings.ts
@@ -1,0 +1,57 @@
+import { CSpellSettings, CSpellSettingsWithSourceTrace } from './CSpellSettingsDef';
+import { logError } from '../util/logger';
+import ConfigStore from 'configstore';
+
+const packageName = 'cspell';
+
+export interface GlobalSettingsWithSource extends Partial<GlobalCSpellSettings> {
+    source: CSpellSettingsWithSourceTrace['source'];
+}
+
+export interface GlobalCSpellSettings {
+    import: CSpellSettings['import'];
+}
+
+export function getRawGlobalSettings(): GlobalSettingsWithSource {
+    const name = 'CSpell Configstore';
+
+    const globalConf: GlobalSettingsWithSource = {
+        source: {
+            name,
+            filename: undefined,
+        },
+    };
+
+    try {
+        const cfgStore = new ConfigStore(packageName);
+        Object.assign(globalConf, cfgStore.all);
+        globalConf.source = {
+            name,
+            filename: cfgStore.path,
+        };
+    } catch (error) {
+        logError(error);
+    }
+
+    return globalConf;
+}
+
+export function writeRawGlobalSettings(settings: GlobalCSpellSettings): Error | undefined {
+    const toWrite: GlobalCSpellSettings = {
+        import: settings.import,
+    };
+
+    try {
+        const cfgStore = new ConfigStore(packageName);
+        cfgStore.set(toWrite);
+        return undefined;
+    } catch (error) {
+        if (error instanceof Error) return error;
+        return new Error(error.toString());
+    }
+}
+
+export function getGlobalConfigPath(): string {
+    const cfgStore = new ConfigStore(packageName);
+    return cfgStore.path;
+}

--- a/packages/cspell-lib/src/Settings/link.test.ts
+++ b/packages/cspell-lib/src/Settings/link.test.ts
@@ -6,11 +6,14 @@ import {
     setData as setConfigstore,
     clearMocks,
     mockSetData,
+    getConfigstoreLocation,
 } from '../__mocks__/configstore';
 
 jest.mock('configstore');
 
 const mockConfigstore = Configstore as jest.Mock<Configstore>;
+
+const configFileLocation = getConfigstoreLocation();
 
 describe('Validate Link.ts', () => {
     beforeEach(() => {
@@ -24,7 +27,7 @@ describe('Validate Link.ts', () => {
         expect(r).toEqual({
             list: [],
             globalSettings: {
-                source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                source: { filename: configFileLocation, name: 'CSpell Configstore' },
             },
         });
         expect(mockSetData).not.toHaveBeenCalled();
@@ -38,7 +41,7 @@ describe('Validate Link.ts', () => {
         expect(r).toEqual({
             list: [],
             globalSettings: {
-                source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                source: { filename: configFileLocation, name: 'CSpell Configstore' },
                 import: [],
             },
         });
@@ -59,7 +62,7 @@ describe('Validate Link.ts', () => {
                     }),
                 ],
                 globalSettings: expect.objectContaining({
-                    source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                    source: { filename: configFileLocation, name: 'CSpell Configstore' },
                 }),
             })
         );
@@ -80,7 +83,7 @@ describe('Validate Link.ts', () => {
                     }),
                 ],
                 globalSettings: expect.objectContaining({
-                    source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                    source: { filename: configFileLocation, name: 'CSpell Configstore' },
                 }),
             })
         );

--- a/packages/cspell-lib/src/Settings/link.test.ts
+++ b/packages/cspell-lib/src/Settings/link.test.ts
@@ -1,0 +1,216 @@
+import { addPathsToGlobalImports, listGlobalImports, removePathsFromGlobalImports } from './link';
+import Configstore from 'configstore';
+// eslint-disable-next-line jest/no-mocks-import
+import {
+    clearData as clearConfigstore,
+    setData as setConfigstore,
+    clearMocks,
+    mockSetData,
+} from '../__mocks__/configstore';
+
+jest.mock('configstore');
+
+const mockConfigstore = Configstore as jest.Mock<Configstore>;
+
+describe('Validate Link.ts', () => {
+    beforeEach(() => {
+        mockConfigstore.mockClear();
+        clearMocks();
+        clearConfigstore();
+    });
+
+    test('listGlobalImports configstore empty', () => {
+        const r = listGlobalImports();
+        expect(r).toEqual({
+            list: [],
+            globalSettings: {
+                source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+            },
+        });
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    test('listGlobalImports configstore empty import', () => {
+        setConfigstore({
+            import: [],
+        });
+        const r = listGlobalImports();
+        expect(r).toEqual({
+            list: [],
+            globalSettings: {
+                source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                import: [],
+            },
+        });
+    });
+
+    test('listGlobalImports with imports', () => {
+        const python = require.resolve('cspell-dict-python/cspell-ext.json');
+        setConfigstore({
+            import: [python],
+        });
+        const r = listGlobalImports();
+        expect(r).toEqual(
+            expect.objectContaining({
+                list: [
+                    expect.objectContaining({
+                        filename: python,
+                        error: undefined,
+                    }),
+                ],
+                globalSettings: expect.objectContaining({
+                    source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                }),
+            })
+        );
+    });
+
+    test('listGlobalImports with import errors', () => {
+        const filename = '__not_found_file_.ext';
+        setConfigstore({
+            import: [filename],
+        });
+        const r = listGlobalImports();
+        expect(r).toEqual(
+            expect.objectContaining({
+                list: [
+                    expect.objectContaining({
+                        filename: filename,
+                        error: expect.stringContaining('Failed to read config'),
+                    }),
+                ],
+                globalSettings: expect.objectContaining({
+                    source: { filename: '/User/local/data/config/configstore', name: 'CSpell Configstore' },
+                }),
+            })
+        );
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    test('addPathsToGlobalImports', () => {
+        const pathPython = require.resolve('cspell-dict-python/cspell-ext.json');
+        const pathCpp = require.resolve('cspell-dict-cpp/cspell-ext.json');
+        const pathHtml = require.resolve('cspell-dict-html/cspell-ext.json');
+        const pathCss = require.resolve('cspell-dict-css/cspell-ext.json');
+
+        setConfigstore({
+            import: [pathPython, pathCss],
+        });
+
+        const r = addPathsToGlobalImports([pathCpp, pathPython, pathHtml]);
+
+        expect(r.resolvedSettings).toHaveLength(3);
+        expect(r).toEqual({
+            error: undefined,
+            success: true,
+            resolvedSettings: [
+                expect.objectContaining({ filename: pathCpp, error: undefined }),
+                expect.objectContaining({ filename: pathPython, error: undefined }),
+                expect.objectContaining({ filename: pathHtml, error: undefined }),
+            ],
+        });
+        expect(mockSetData).toHaveBeenCalledWith({
+            import: [pathPython, pathCss, pathCpp, pathHtml],
+        });
+    });
+
+    test('addPathsToGlobalImports with errors', () => {
+        const pathPython = require.resolve('cspell-dict-python/cspell-ext.json');
+        const pathCpp = require.resolve('cspell-dict-cpp/cspell-ext.json');
+        const pathNotFound = '__not_found_file_.ext';
+
+        setConfigstore({
+            import: [pathPython],
+        });
+
+        const r = addPathsToGlobalImports([pathCpp, pathPython, pathNotFound]);
+
+        expect(r.resolvedSettings).toHaveLength(3);
+        expect(r).toEqual({
+            error: 'Unable to resolve files.',
+            success: false,
+            resolvedSettings: [
+                expect.objectContaining({ filename: pathCpp, error: undefined }),
+                expect.objectContaining({ filename: pathPython, error: undefined }),
+                expect.objectContaining({
+                    filename: pathNotFound,
+                    error: expect.stringContaining('Failed to read config'),
+                }),
+            ],
+        });
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+
+    test('removePathsFromGlobalImports', () => {
+        const pathPython = require.resolve('cspell-dict-python/cspell-ext.json');
+        const pathCpp = require.resolve('cspell-dict-cpp/cspell-ext.json');
+        const pathHtml = require.resolve('cspell-dict-html/cspell-ext.json');
+        const pathCss = require.resolve('cspell-dict-css/cspell-ext.json');
+
+        setConfigstore({
+            import: [pathCpp, pathPython, pathCss, pathHtml],
+        });
+
+        const r = removePathsFromGlobalImports([pathCpp, 'cspell-dict-css']);
+
+        expect(r).toEqual({
+            success: true,
+            error: undefined,
+            removed: [pathCpp, pathCss],
+        });
+
+        expect(mockSetData).toHaveBeenCalledWith({
+            import: [pathPython, pathHtml],
+        });
+    });
+
+    test('removePathsFromGlobalImports with unknown', () => {
+        const pathPython = require.resolve('cspell-dict-python/cspell-ext.json');
+        const pathCpp = require.resolve('cspell-dict-cpp/cspell-ext.json');
+        const pathHtml = require.resolve('cspell-dict-html/cspell-ext.json');
+        const pathCss = require.resolve('cspell-dict-css/cspell-ext.json');
+
+        setConfigstore({
+            import: [pathCpp, pathPython, pathCss, pathHtml],
+        });
+
+        const r = removePathsFromGlobalImports([
+            pathCpp,
+            'cspell-dict-unknown',
+            'cspell-ext.json',
+            'cspell-dict-html',
+            'python/cspell-ext.json',
+        ]);
+
+        expect(r).toEqual({
+            success: true,
+            error: undefined,
+            removed: [pathCpp, pathHtml],
+        });
+
+        expect(mockSetData).toHaveBeenCalledWith({
+            import: [pathPython, pathCss],
+        });
+    });
+
+    test('removePathsFromGlobalImports with nothing to remove', () => {
+        const pathPython = require.resolve('cspell-dict-python/cspell-ext.json');
+        const pathCpp = require.resolve('cspell-dict-cpp/cspell-ext.json');
+        const pathHtml = require.resolve('cspell-dict-html/cspell-ext.json');
+        const pathCss = require.resolve('cspell-dict-css/cspell-ext.json');
+
+        setConfigstore({
+            import: [pathCpp, pathPython, pathCss, pathHtml],
+        });
+
+        const r = removePathsFromGlobalImports(['cspell-dict-unknown', 'cspell-ext.json', 'python/cspell-ext.json']);
+
+        expect(r).toEqual({
+            success: true,
+            error: undefined,
+            removed: [],
+        });
+
+        expect(mockSetData).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cspell-lib/src/Settings/link.ts
+++ b/packages/cspell-lib/src/Settings/link.ts
@@ -1,0 +1,176 @@
+import * as Path from 'path';
+import * as fs from 'fs';
+import { CSpellSettingsWithSourceTrace } from './CSpellSettingsDef';
+import { getRawGlobalSettings, readSettings, writeRawGlobalSettings } from './CSpellSettingsServer';
+
+export interface ListGlobalImportsResult {
+    filename: string;
+    name: string | undefined;
+    id: string | undefined;
+    error: string | undefined;
+    dictionaryDefinitions: CSpellSettingsWithSourceTrace['dictionaryDefinitions'];
+    languageSettings: CSpellSettingsWithSourceTrace['languageSettings'];
+    package: NodePackage | undefined;
+}
+
+export interface ListGlobalImportsResults {
+    list: ListGlobalImportsResult[];
+    globalSettings: CSpellSettingsWithSourceTrace;
+}
+
+interface NodePackage {
+    name: string | undefined;
+    filename: string;
+}
+
+export function listGlobalImports(): ListGlobalImportsResults {
+    const globalSettings = getRawGlobalSettings();
+    const list = resolveImports(globalSettings).map(({ filename, settings, error }) => ({
+        filename,
+        error,
+        id: settings.id,
+        name: settings.name,
+        dictionaryDefinitions: settings.dictionaryDefinitions,
+        languageSettings: settings.languageSettings,
+        package: findPackageForCSpellConfig(Path.dirname(filename)),
+    }));
+
+    return {
+        list,
+        globalSettings,
+    };
+}
+
+export interface AddPathsToGlobalImportsResults {
+    success: boolean;
+    resolvedSettings: ResolveSettingsResult[];
+    error: string | undefined;
+}
+
+function isString(s: string | undefined): s is string {
+    return s !== undefined;
+}
+
+export function addPathsToGlobalImports(paths: string[]): AddPathsToGlobalImportsResults {
+    const resolvedSettings = paths.map(resolveSettings);
+    const hasError = resolvedSettings.filter((r) => !!r.error).length > 0;
+    if (hasError) {
+        return {
+            success: false,
+            resolvedSettings,
+            error: 'Unable to resolve files.',
+        };
+    }
+
+    const rawGlobalSettings = getRawGlobalSettings();
+    const resolvedImports = resolveImports(rawGlobalSettings);
+
+    const imports = new Set(resolvedImports.map((r) => r.resolvedToFilename || r.filename));
+    resolvedSettings
+        .map((s) => s.resolvedToFilename)
+        .filter(isString)
+        .reduce((imports, s) => imports.add(s), imports);
+
+    const globalSettings = {
+        import: [...imports],
+    };
+
+    const error = writeRawGlobalSettings(globalSettings);
+    return {
+        success: !error,
+        error: error?.message,
+        resolvedSettings,
+    };
+}
+
+export interface RemovePathsFromGlobalImportsResult {
+    success: boolean;
+    error: string | undefined;
+    removed: string[];
+}
+
+export function removePathsFromGlobalImports(paths: string[]): RemovePathsFromGlobalImportsResult {
+    const listResult = listGlobalImports();
+
+    const toRemove = new Set<string>();
+
+    type TestResultToExclude = (r: ListGlobalImportsResult) => boolean;
+
+    function matchPackage(pathToRemove: string): TestResultToExclude {
+        return ({ package: pkg, id }) => pathToRemove === pkg?.name || pathToRemove === id;
+    }
+
+    function matchFilename(pathToRemove: string): TestResultToExclude {
+        return Path.dirname(pathToRemove) ? ({ filename }) => filename.endsWith(pathToRemove) : () => false;
+    }
+
+    paths
+        .map((a) => a.trim())
+        .filter((a) => !!a)
+        .forEach((pathToRemove) => {
+            const excludePackage = matchPackage(pathToRemove);
+            const excludeFilename = matchFilename(pathToRemove);
+            const shouldExclude: TestResultToExclude = (r) => excludePackage(r) || excludeFilename(r);
+            for (const r of listResult.list) {
+                if (shouldExclude(r)) {
+                    toRemove.add(r.filename);
+                }
+            }
+        });
+
+    const toImport = normalizeImports(listResult.globalSettings.import).filter((p) => !toRemove.has(p));
+
+    const updatedSettings = {
+        import: toImport,
+    };
+
+    const error = toRemove.size > 0 ? writeRawGlobalSettings(updatedSettings) : undefined;
+
+    return {
+        success: true,
+        removed: [...toRemove],
+        error: error?.toString(),
+    };
+}
+
+export interface ResolveSettingsResult {
+    filename: string;
+    resolvedToFilename: string | undefined;
+    error?: string;
+    settings: CSpellSettingsWithSourceTrace;
+}
+
+function resolveSettings(filename: string): ResolveSettingsResult {
+    const settings = readSettings(filename, {});
+    const ref = settings.__importRef;
+
+    return {
+        filename,
+        resolvedToFilename: ref?.filename,
+        error: ref?.error?.message,
+        settings,
+    };
+}
+
+function normalizeImports(imports: CSpellSettingsWithSourceTrace['import']): string[] {
+    return typeof imports === 'string' ? [imports] : imports || [];
+}
+
+function resolveImports(s: CSpellSettingsWithSourceTrace): ResolveSettingsResult[] {
+    const imported = normalizeImports(s.import);
+
+    return imported.map(resolveSettings);
+}
+
+function findPackageForCSpellConfig(pathToConfig: string): NodePackage | undefined {
+    try {
+        const filename = Path.join(pathToConfig, 'package.json');
+        const pkg = JSON.parse(fs.readFileSync(filename, 'utf8'));
+        return {
+            filename,
+            name: pkg['name'],
+        };
+    } catch (e) {
+        return undefined;
+    }
+}

--- a/packages/cspell-lib/src/Settings/link.ts
+++ b/packages/cspell-lib/src/Settings/link.ts
@@ -1,7 +1,7 @@
 import * as Path from 'path';
 import * as fs from 'fs';
 import { CSpellSettingsWithSourceTrace } from './CSpellSettingsDef';
-import { readSettings } from './CSpellSettingsServer';
+import { readRawSettings } from './CSpellSettingsServer';
 import { getRawGlobalSettings, writeRawGlobalSettings } from './GlobalSettings';
 
 export interface ListGlobalImportsResult {
@@ -158,13 +158,15 @@ export interface ResolveSettingsResult {
 }
 
 function resolveSettings(filename: string): ResolveSettingsResult {
-    const settings = readSettings(filename, {});
+    const settings = readRawSettings(filename);
     const ref = settings.__importRef;
+    const resolvedToFilename = ref?.filename;
+    const error = ref?.error?.message || (!resolvedToFilename && 'File not Found') || undefined;
 
     return {
         filename,
-        resolvedToFilename: ref?.filename,
-        error: ref?.error?.message,
+        resolvedToFilename,
+        error,
         settings,
     };
 }

--- a/packages/cspell-lib/src/Settings/link.ts
+++ b/packages/cspell-lib/src/Settings/link.ts
@@ -1,7 +1,8 @@
 import * as Path from 'path';
 import * as fs from 'fs';
 import { CSpellSettingsWithSourceTrace } from './CSpellSettingsDef';
-import { getRawGlobalSettings, readSettings, writeRawGlobalSettings } from './CSpellSettingsServer';
+import { readSettings } from './CSpellSettingsServer';
+import { getRawGlobalSettings, writeRawGlobalSettings } from './GlobalSettings';
 
 export interface ListGlobalImportsResult {
     filename: string;

--- a/packages/cspell-lib/src/__mocks__/configstore.ts
+++ b/packages/cspell-lib/src/__mocks__/configstore.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const data: Record<string, any> = {};
+
+export function setData(value: any): void;
+export function setData(key: string, value: any): void;
+export function setData(keyValue: string | any, value?: any): void {
+    if (typeof keyValue == 'string') {
+        data[keyValue] = value;
+        return;
+    }
+    Object.assign(data, keyValue);
+}
+
+export const mockSetData = jest.fn(setData);
+
+export const mockAll = jest.fn(() => data);
+
+export function clearData(): void {
+    for (const key of Object.keys(data)) {
+        delete data[key];
+    }
+}
+
+export const mockClearData = jest.fn(clearData);
+
+export function clearMocks() {
+    mockAll.mockClear();
+    mockSetData.mockClear();
+    mockClearData.mockClear();
+    clearData();
+}
+
+const mock = jest.fn().mockImplementation(() => {
+    const r = {
+        path: '/User/local/data/config/configstore',
+        all: data,
+        set: mockSetData,
+        size: 0,
+        clear: mockClearData,
+    };
+    Object.defineProperty(r, 'all', { get: mockAll });
+    return r;
+});
+
+export default mock;

--- a/packages/cspell-lib/src/__mocks__/configstore.ts
+++ b/packages/cspell-lib/src/__mocks__/configstore.ts
@@ -32,15 +32,25 @@ export function clearMocks() {
     clearData();
 }
 
-const mock = jest.fn().mockImplementation(() => {
+export function getConfigstoreLocation(id?: string) {
+    id = id || 'cspell';
+    return `/User/local/data/.config/configstore/${id}.json`;
+}
+
+const mock = jest.fn().mockImplementation((id: string) => {
     const r = {
-        path: '/User/local/data/config/configstore',
-        all: data,
+        path: getConfigstoreLocation(id),
         set: mockSetData,
         size: 0,
         clear: mockClearData,
     };
-    Object.defineProperty(r, 'all', { get: mockAll });
+    Object.defineProperty(r, 'all', {
+        get: mockAll,
+        set: (v) => {
+            clearData();
+            setData(v);
+        },
+    });
     return r;
 });
 

--- a/packages/cspell-lib/src/index.ts
+++ b/packages/cspell-lib/src/index.ts
@@ -23,7 +23,8 @@ export { combineTextAndLanguageSettings } from './Settings/TextDocumentSettings'
 export { combineTextAndLanguageSettings as constructSettingsForText } from './Settings/TextDocumentSettings';
 
 import * as Text from './util/text';
-export { Text };
+import * as Link from './Settings/link';
+export { Text, Link };
 export { resolveFile } from './util/resolveFile';
 
 import * as ExclusionHelper from './exclusionHelper';

--- a/packages/cspell-lib/src/util/resolveFile.ts
+++ b/packages/cspell-lib/src/util/resolveFile.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import resolveFrom from 'resolve-from';
 import * as os from 'os';
+import resolveGlobal from 'resolve-global';
 
 export interface ResolveFileResult {
     filename: string;
@@ -24,6 +25,7 @@ export function resolveFile(filename: string, relativeTo: string): ResolveFileRe
         { filename: path.resolve(filename), fn: tryResolveExists },
         { filename: filename, fn: methodResolveFrom },
         { filename: filename.replace(testNodeModules, ''), fn: methodResolveFrom },
+        { filename: filename, fn: tryResolveGlobal },
     ];
 
     for (const step of steps) {
@@ -31,6 +33,11 @@ export function resolveFile(filename: string, relativeTo: string): ResolveFileRe
         if (r.found) return r;
     }
     return { filename: path.resolve(relativeTo, filename), found: false };
+}
+
+function tryResolveGlobal(filename: string): ResolveFileResult {
+    const r = resolveGlobal.silent(filename);
+    return { filename: r || filename, found: !!r };
 }
 
 function tryResolveExists(filename: string): ResolveFileResult {

--- a/packages/cspell/.vscode/launch.json
+++ b/packages/cspell/.vscode/launch.json
@@ -4,15 +4,21 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-
         {
             "type": "node",
             "request": "launch",
             "name": "cspell: Run",
             "program": "${workspaceRoot}/bin.js",
-			"args": ["--root=..", "-v", "**/*.ts", "*.md" ],
+            "args": [
+                "--root=..",
+                "-v",
+                "**/*.ts",
+                "*.md"
+            ],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true
         },
         {
@@ -20,9 +26,11 @@
             "request": "launch",
             "name": "cspell: Run no args",
             "program": "${workspaceRoot}/bin.js",
-			"args": [],
+            "args": [],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true
         },
         {
@@ -30,9 +38,14 @@
             "request": "launch",
             "name": "cspell: Run CSpell against current file",
             "program": "${workspaceRoot}/bin.js",
-			"args": ["-v", "${file}"],
+            "args": [
+                "-v",
+                "${file}"
+            ],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true,
             "preLaunchTask": "npm: build"
         },
@@ -41,9 +54,14 @@
             "request": "launch",
             "name": "cspell: Run CSpell against stdin",
             "program": "${workspaceRoot}/bin.js",
-			"args": ["-v", "stdin"],
+            "args": [
+                "-v",
+                "stdin"
+            ],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true,
             "preLaunchTask": "npm: build",
             "console": "integratedTerminal"
@@ -53,9 +71,14 @@
             "request": "launch",
             "name": "cspell: Run Trace",
             "program": "${workspaceRoot}/bin.js",
-			"args": ["trace", "about"],
+            "args": [
+                "trace",
+                "about"
+            ],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true
         },
         {
@@ -63,9 +86,46 @@
             "request": "launch",
             "name": "cspell: Run Check",
             "program": "${workspaceRoot}/bin.js",
-			"args": ["check", "--config", "${workspaceRoot}/samples/.cspell.json", "${workspaceRoot}/samples/src/sample.c"],
+            "args": [
+                "check",
+                "--config",
+                "${workspaceRoot}/samples/.cspell.json",
+                "${workspaceRoot}/samples/src/sample.c"
+            ],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
+            "sourceMaps": true
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "cspell: Run Link",
+            "program": "${workspaceRoot}/bin.js",
+            "args": [
+                "link"
+            ],
+            "cwd": "${workspaceRoot}",
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
+            "sourceMaps": true
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "cspell: Run Link Add",
+            "program": "${workspaceRoot}/bin.js",
+            "args": [
+                "link",
+                "add",
+                "cspell-dict-nl-nl/cspell-ext.json"
+            ],
+            "cwd": "${workspaceRoot}/../cspell-lib",
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true
         },
         {
@@ -73,17 +133,26 @@
             "request": "launch",
             "name": "cspell: Run bad glob",
             "program": "${workspaceRoot}/dist/app.js",
-			"args": ["-v", "src", "**/*.test.ts"],
+            "args": [
+                "-v",
+                "src",
+                "**/*.test.ts"
+            ],
             "cwd": "${workspaceRoot}",
-			"outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*.js"
+            ],
             "sourceMaps": true
         },
-		{
+        {
             "type": "node",
             "request": "launch",
             "name": "cspell: Jest current-file",
             "program": "${workspaceFolder}/../../node_modules/.bin/jest",
-            "args": ["--runInBand", "${file}"],
+            "args": [
+                "--runInBand",
+                "${file}"
+            ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "disableOptimisticBPs": true,
@@ -96,7 +165,9 @@
             "request": "launch",
             "name": "cspell: Jest All",
             "program": "${workspaceFolder}/../../node_modules/.bin/jest",
-            "args": ["--runInBand"],
+            "args": [
+                "--runInBand"
+            ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "disableOptimisticBPs": true,

--- a/packages/cspell/package-lock.json
+++ b/packages/cspell/package-lock.json
@@ -689,6 +689,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/configstore": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-SvCBBPzOIe/3Tu7jTl2Q8NjITjLmq9m7obzjSyb8PXWWZ31xVK6w4T6v8fOx+lrgQnqk3Yxc00LDolFsSakKCA==",
+      "dev": true
+    },
     "@types/fs-extra": {
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.4.tgz",
@@ -846,8 +852,7 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -4683,7 +4688,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -70,7 +70,8 @@
     "fs-extra": "^9.0.1",
     "get-stdin": "^8.0.0",
     "glob": "^7.1.6",
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.4",
+    "strip-ansi": "^6.0.0"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -1,6 +1,8 @@
 import * as app from './app';
 import * as Commander from 'commander';
 import * as Path from 'path';
+import * as Link from './link';
+// import { listGlobalImports /* addPathsToGlobalImports, removePathsFromGlobalImports */ } from './link';
 
 const projectRoot = Path.join(__dirname, '..');
 
@@ -33,7 +35,23 @@ interface TestCase {
 }
 
 describe('Validate cli', () => {
-    let current = '';
+    const error = jest.spyOn(console, 'error').mockName('console.error').mockImplementation();
+    const log = jest.spyOn(console, 'log').mockName('console.log').mockImplementation();
+    const info = jest.spyOn(console, 'info').mockName('console.info').mockImplementation();
+    const listGlobalImports = jest.spyOn(Link, 'listGlobalImports').mockName('istGlobalImports');
+    const addPathsToGlobalImports = jest.spyOn(Link, 'addPathsToGlobalImports').mockName('addPathsToGlobalImports');
+    const removePathsFromGlobalImports = jest
+        .spyOn(Link, 'removePathsFromGlobalImports')
+        .mockName('removePathsFromGlobalImports');
+
+    afterEach(() => {
+        info.mockClear();
+        log.mockClear();
+        error.mockClear();
+        listGlobalImports.mockClear();
+        addPathsToGlobalImports.mockClear();
+        removePathsFromGlobalImports.mockClear();
+    });
 
     test.each`
         msg                              | testArgs                                                                | errorCheck         | eError   | eLog     | eInfo
@@ -54,30 +72,74 @@ describe('Validate cli', () => {
         ${'must find force no error'}    | ${['*.not', '--no-must-find-files']}                                    | ${undefined}       | ${true}  | ${false} | ${false}
         ${'cspell-bad.json'}             | ${['-c', pathSamples('cspell-bad.json'), __filename]}                   | ${undefined}       | ${true}  | ${false} | ${false}
         ${'cspell-import-missing.json'}  | ${['-c', pathSamples('linked/cspell-import-missing.json'), __filename]} | ${app.CheckFailed} | ${true}  | ${false} | ${false}
-    `('app $msg $testArgs', async ({ msg, testArgs, errorCheck, eError, eLog, eInfo }: TestCase) => {
-        expect(current).toBe('');
-        current = msg;
+    `('app $msg $testArgs', executeTest);
+
+    async function executeTest({ testArgs, errorCheck, eError, eLog, eInfo }: TestCase) {
         const commander = getCommander();
-        const error = jest.spyOn(console, 'error').mockName('console.error').mockImplementation();
-        const log = jest.spyOn(console, 'log').mockName('console.log').mockImplementation();
-        const info = jest.spyOn(console, 'info').mockName('console.info').mockImplementation();
         const args = argv(...testArgs);
-        try {
-            const result = app.run(commander, args);
-            if (!errorCheck) {
-                await expect(result).resolves.toBeUndefined();
-            } else {
-                await expect(result).rejects.toThrowError(errorCheck);
-            }
-            eError ? expect(error).toHaveBeenCalled() : expect(error).not.toHaveBeenCalled();
-            eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
-            eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
-            expect(current).toBe(msg);
-        } finally {
-            info.mockRestore();
-            log.mockRestore();
-            error.mockRestore();
-            current = '';
+        const result = app.run(commander, args);
+        if (!errorCheck) {
+            await expect(result).resolves.toBeUndefined();
+        } else {
+            await expect(result).rejects.toThrowError(errorCheck);
         }
-    });
+        eError ? expect(error).toHaveBeenCalled() : expect(error).not.toHaveBeenCalled();
+        eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
+        eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
+    }
+
+    test.each`
+        msg       | testArgs                                                 | errorCheck   | eError   | eLog    | eInfo
+        ${'link'} | ${['link']}                                              | ${undefined} | ${false} | ${true} | ${false}
+        ${'link'} | ${['link', 'ls']}                                        | ${undefined} | ${false} | ${true} | ${false}
+        ${'link'} | ${['link', 'list']}                                      | ${undefined} | ${false} | ${true} | ${false}
+        ${'link'} | ${['link', 'add', 'cspell-dict-cpp/cspell-ext.json']}    | ${undefined} | ${false} | ${true} | ${false}
+        ${'link'} | ${['link', 'remove', 'cspell-dict-cpp/cspell-ext.json']} | ${undefined} | ${false} | ${true} | ${false}
+    `('app $msg $testArgs', executeLinkTest);
+
+    async function executeLinkTest({ testArgs, errorCheck, eError, eLog, eInfo }: TestCase) {
+        listGlobalImports.mockImplementation(_listGlobalImports());
+        addPathsToGlobalImports.mockImplementation(_addPathsToGlobalImports());
+        removePathsFromGlobalImports.mockImplementation(_removePathsFromGlobalImports());
+        const commander = getCommander();
+        const args = argv(...testArgs);
+        const result = app.run(commander, args);
+        if (!errorCheck) {
+            await expect(result).resolves.toBeUndefined();
+        } else {
+            await expect(result).rejects.toThrowError(errorCheck);
+        }
+        eError ? expect(error).toHaveBeenCalled() : expect(error).not.toHaveBeenCalled();
+        eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
+        eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
+    }
 });
+
+function _listGlobalImports(): typeof Link['listGlobalImports'] {
+    return () => {
+        return {
+            list: [],
+            globalSettings: {},
+        };
+    };
+}
+
+function _addPathsToGlobalImports(): typeof Link['addPathsToGlobalImports'] {
+    return (_paths: string[]) => {
+        return {
+            success: true,
+            resolvedSettings: [],
+            error: undefined,
+        };
+    };
+}
+
+function _removePathsFromGlobalImports(): typeof Link['removePathsFromGlobalImports'] {
+    return (paths: string[]) => {
+        return {
+            success: true,
+            error: undefined,
+            removed: paths,
+        };
+    };
+}

--- a/packages/cspell/src/app.ts
+++ b/packages/cspell/src/app.ts
@@ -241,7 +241,7 @@ export async function run(program?: commander.Command, argv?: string[]): Promise
             .command('list', { isDefault: true })
             .alias('ls')
             .description('List currently linked configurations.')
-            .action(async () => {
+            .action(() => {
                 showHelp = false;
                 const imports = listGlobalImports();
                 const table = listGlobalImportsResultToTable(imports.list);
@@ -253,7 +253,7 @@ export async function run(program?: commander.Command, argv?: string[]): Promise
             .command('add <dictionaries...>')
             .alias('a')
             .description('Add dictionaries any other settings to the cspell global config.')
-            .action(async (dictionaries: string[]) => {
+            .action((dictionaries: string[]) => {
                 showHelp = false;
                 const r = addPathsToGlobalImports(dictionaries);
                 const table = addPathsToGlobalImportsResultToTable(r);
@@ -269,7 +269,7 @@ export async function run(program?: commander.Command, argv?: string[]): Promise
             .command('remove <paths...>')
             .alias('r')
             .description('Remove matching paths / packages from the global config.')
-            .action(async (dictionaries: string[]) => {
+            .action((dictionaries: string[]) => {
                 showHelp = false;
                 const r = removePathsFromGlobalImports(dictionaries);
                 console.log('Removing:');

--- a/packages/cspell/src/app.ts
+++ b/packages/cspell/src/app.ts
@@ -5,6 +5,14 @@ const npmPackage = require(path.join(__dirname, '..', 'package.json'));
 import { CSpellApplicationOptions, BaseOptions, checkText } from './application';
 import * as App from './application';
 import chalk = require('chalk');
+import {
+    addPathsToGlobalImports,
+    addPathsToGlobalImportsResultToTable,
+    listGlobalImports,
+    listGlobalImportsResultToTable,
+    removePathsFromGlobalImports,
+} from './link';
+import { tableToLines } from './util/table';
 
 interface Options extends CSpellApplicationOptions {
     legacy?: boolean;
@@ -218,6 +226,58 @@ export async function run(program?: commander.Command, argv?: string[]): Promise
                     console.error('No files found');
                     throw new CheckFailed('No files found', 1);
                 }
+            });
+
+        // interface LinkOptions extends BaseOptions {
+        //     delete: boolean;
+        //     doctor: boolean;
+        // }
+
+        const linkCommand = prog
+            .command('link')
+            .description('Link dictionaries any other settings to the cspell global config.');
+
+        linkCommand
+            .command('list', { isDefault: true })
+            .alias('ls')
+            .description('List currently linked configurations.')
+            .action(async () => {
+                showHelp = false;
+                const imports = listGlobalImports();
+                const table = listGlobalImportsResultToTable(imports.list);
+                tableToLines(table).forEach((line) => console.log(line));
+                return;
+            });
+
+        linkCommand
+            .command('add <dictionaries...>')
+            .alias('a')
+            .description('Add dictionaries any other settings to the cspell global config.')
+            .action(async (dictionaries: string[]) => {
+                showHelp = false;
+                const r = addPathsToGlobalImports(dictionaries);
+                const table = addPathsToGlobalImportsResultToTable(r);
+                console.log('Adding:');
+                tableToLines(table).forEach((line) => console.log(line));
+                if (r.error) {
+                    throw new CheckFailed(r.error, 1);
+                }
+                return;
+            });
+
+        linkCommand
+            .command('remove <paths...>')
+            .alias('r')
+            .description('Remove matching paths / packages from the global config.')
+            .action(async (dictionaries: string[]) => {
+                showHelp = false;
+                const r = removePathsFromGlobalImports(dictionaries);
+                console.log('Removing:');
+                if (r.error) {
+                    throw new CheckFailed(r.error, 1);
+                }
+                r.removed.map((f) => console.log(f));
+                return;
             });
 
         /*

--- a/packages/cspell/src/application.test.ts
+++ b/packages/cspell/src/application.test.ts
@@ -1,3 +1,6 @@
+import * as path from 'path';
+import * as App from './application';
+
 const getStdinResult = {
     value: '',
 };
@@ -5,9 +8,6 @@ const getStdinResult = {
 jest.mock('get-stdin', () => {
     return jest.fn(() => Promise.resolve(getStdinResult.value));
 });
-
-import * as path from 'path';
-import * as App from './application';
 
 describe('Validate the Application', () => {
     jest.setTimeout(10000); // make sure we have enough time on Travis.

--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -9,7 +9,6 @@ import getStdin from 'get-stdin';
 export { TraceResult, IncludeExcludeFlag } from 'cspell-lib';
 import { GlobMatcher } from 'cspell-glob';
 import { IOptions } from './IOptions';
-export { listGlobalImports } from './link';
 
 // cspell:word nocase
 

--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -1,14 +1,15 @@
-import * as glob from 'glob';
+import glob from 'glob';
 import * as cspell from 'cspell-lib';
 import * as fsp from 'fs-extra';
 import * as path from 'path';
 import * as commentJson from 'comment-json';
 import * as util from './util/util';
 import { traceWords, TraceResult, CheckTextInfo } from 'cspell-lib';
-import getStdin = require('get-stdin');
+import getStdin from 'get-stdin';
 export { TraceResult, IncludeExcludeFlag } from 'cspell-lib';
 import { GlobMatcher } from 'cspell-glob';
 import { IOptions } from './IOptions';
+export { listGlobalImports } from './link';
 
 // cspell:word nocase
 

--- a/packages/cspell/src/link.test.ts
+++ b/packages/cspell/src/link.test.ts
@@ -1,0 +1,73 @@
+import { addPathsToGlobalImportsResultToTable, listGlobalImportsResultToTable } from './link';
+
+const esc = expect.stringContaining;
+
+describe('Validate link.ts', () => {
+    test('listGlobalImportsResultToTable', () => {
+        expect(
+            listGlobalImportsResultToTable([
+                {
+                    filename: 'file1',
+                    name: 'CSpell Sample Dictionary',
+                    id: undefined,
+                    error: undefined,
+                    dictionaryDefinitions: [
+                        {
+                            name: 'sample',
+                            path: 'sample.txt.gz',
+                        },
+                    ],
+                    languageSettings: undefined,
+                    package: {
+                        name: 'cspell-dict-sample',
+                        filename: 'package.json',
+                    },
+                },
+                {
+                    filename: 'file2',
+                    name: undefined,
+                    id: undefined,
+                    error: 'fail',
+                    dictionaryDefinitions: undefined,
+                    languageSettings: undefined,
+                    package: undefined,
+                },
+            ])
+        ).toEqual({
+            header: ['id', 'package', 'name', 'filename', 'dictionaries', 'errors'],
+            rows: [
+                ['', 'cspell-dict-sample', 'CSpell Sample Dictionary', 'file1', 'sample', ''],
+                ['', '', '', esc('file2'), '', esc('Failed to read file.')],
+            ],
+        });
+    });
+
+    test('addPathsToGlobalImportsResultToTable', () => {
+        expect(
+            addPathsToGlobalImportsResultToTable({
+                success: true,
+                resolvedSettings: [
+                    {
+                        filename: 'file1',
+                        resolvedToFilename: undefined,
+                        error: undefined,
+                        settings: {},
+                    },
+                    {
+                        filename: 'file2',
+                        resolvedToFilename: undefined,
+                        error: 'failed',
+                        settings: {},
+                    },
+                ],
+                error: undefined,
+            })
+        ).toEqual({
+            header: ['filename', 'errors'],
+            rows: [
+                ['file1', ''],
+                [expect.stringContaining('file2'), expect.stringContaining('Failed to read file.')],
+            ],
+        });
+    });
+});

--- a/packages/cspell/src/link.ts
+++ b/packages/cspell/src/link.ts
@@ -1,0 +1,217 @@
+import { CSpellSettingsWithSourceTrace, getRawGlobalSettings, readSettings, writeRawGlobalSettings } from 'cspell-lib';
+import chalk from 'chalk';
+import * as Path from 'path';
+import * as fs from 'fs';
+
+export interface ListGlobalImportsResult {
+    filename: string;
+    name: string | undefined;
+    id: string | undefined;
+    error: string | undefined;
+    dictionaryDefinitions: CSpellSettingsWithSourceTrace['dictionaryDefinitions'];
+    languageSettings: CSpellSettingsWithSourceTrace['languageSettings'];
+    package: NodePackage | undefined;
+}
+
+export interface ListGlobalImportsResults {
+    list: ListGlobalImportsResult[];
+    globalSettings: CSpellSettingsWithSourceTrace;
+}
+
+interface NodePackage {
+    name: string | undefined;
+    filename: string;
+}
+
+export function listGlobalImports(): ListGlobalImportsResults {
+    const globalSettings = getRawGlobalSettings();
+    const list = resolveImports(globalSettings).map(({ filename, settings, error }) => ({
+        filename,
+        error,
+        id: settings.id,
+        name: settings.name,
+        dictionaryDefinitions: settings.dictionaryDefinitions,
+        languageSettings: settings.languageSettings,
+        package: findPackageForCSpellConfig(Path.dirname(filename)),
+    }));
+
+    return {
+        list,
+        globalSettings,
+    };
+}
+
+export function listGlobalImportsResultToTable(results: ListGlobalImportsResult[]): string[][] {
+    const table: string[][] = [];
+    const b = (s: string) => chalk.underline(chalk.bold(s));
+    const header = ['id', 'package', 'name', 'filename', 'dictionaries', 'errors'].map(b);
+    const decorate = (isError: boolean) => (isError ? (s: string) => chalk.red(s) : (s: string) => s);
+
+    function toColumns(r: ListGlobalImportsResult): string[] {
+        return [
+            r.id,
+            r.package?.name,
+            r.name,
+            r.filename,
+            r.dictionaryDefinitions?.map((def) => def.name).join(', '),
+            r.error ? 'Failed to read file.' : '',
+        ]
+            .map((c) => c || '')
+            .map(decorate(!!r.error));
+    }
+
+    table.push(header);
+    results.map(toColumns).forEach((row) => table.push(row));
+    return table;
+}
+
+export interface AddPathsToGlobalImportsResults {
+    success: boolean;
+    resolvedSettings: ResolveSettingsResult[];
+    error: string | undefined;
+}
+
+function isString(s: string | undefined): s is string {
+    return s !== undefined;
+}
+
+export function addPathsToGlobalImports(paths: string[]): AddPathsToGlobalImportsResults {
+    const resolvedSettings = paths.map(resolveSettings);
+    const hasError = resolvedSettings.filter((r) => !!r.error).length > 0;
+    if (hasError) {
+        return {
+            success: false,
+            resolvedSettings,
+            error: 'Unable to resolve files.',
+        };
+    }
+
+    const rawGlobalSettings = getRawGlobalSettings();
+    const resolvedImports = resolveImports(rawGlobalSettings);
+
+    const imports = new Set(resolvedImports.map((r) => r.resolvedToFilename || r.filename));
+    resolvedSettings
+        .map((s) => s.resolvedToFilename)
+        .filter(isString)
+        .reduce((imports, s) => imports.add(s), imports);
+
+    const globalSettings = {
+        import: [...imports],
+    };
+
+    const error = writeRawGlobalSettings(globalSettings);
+    return {
+        success: !error,
+        error: error?.message,
+        resolvedSettings,
+    };
+}
+
+export function addPathsToGlobalImportsResultToTable(results: AddPathsToGlobalImportsResults): string[][] {
+    const table: string[][] = [];
+    const b = (s: string) => chalk.underline(chalk.bold(s));
+    const header = ['filename', 'errors'].map(b);
+    const decorate = (isError: boolean) => (isError ? (s: string) => chalk.red(s) : (s: string) => s);
+
+    function toColumns(r: ResolveSettingsResult): string[] {
+        return [r.resolvedToFilename || r.filename, r.error ? 'Failed to read file.' : '']
+            .map((c) => c || '')
+            .map(decorate(!!r.error));
+    }
+
+    table.push(header);
+    results.resolvedSettings.map(toColumns).forEach((row) => table.push(row));
+    return table;
+}
+
+export interface RemovePathsFromGlobalImportsResult {
+    success: boolean;
+    error: string | undefined;
+    removed: string[];
+}
+
+export function removePathsFromGlobalImports(paths: string[]): RemovePathsFromGlobalImportsResult {
+    const listResult = listGlobalImports();
+
+    const toRemove = new Set<string>();
+
+    type TestResultToExclude = (r: ListGlobalImportsResult) => boolean;
+
+    function matchPackage(pathToRemove: string): TestResultToExclude {
+        return ({ package: pkg, id }) => pathToRemove === pkg?.name || pathToRemove === id;
+    }
+
+    function matchFilename(pathToRemove: string): TestResultToExclude {
+        return Path.dirname(pathToRemove) ? ({ filename }) => filename.endsWith(pathToRemove) : () => false;
+    }
+
+    paths
+        .map((a) => a.trim())
+        .filter((a) => !!a)
+        .forEach((pathToRemove) => {
+            const excludePackage = matchPackage(pathToRemove);
+            const excludeFilename = matchFilename(pathToRemove);
+            const shouldExclude: TestResultToExclude = (r) => excludePackage(r) || excludeFilename(r);
+            for (const r of listResult.list) {
+                if (shouldExclude(r)) {
+                    toRemove.add(r.filename);
+                }
+            }
+        });
+
+    const toImport = normalizeImports(listResult.globalSettings.import).filter((p) => !toRemove.has(p));
+
+    const updatedSettings = {
+        import: toImport,
+    };
+
+    const error = toRemove.size > 0 ? writeRawGlobalSettings(updatedSettings) : undefined;
+
+    return {
+        success: true,
+        removed: [...toRemove],
+        error: error?.toString(),
+    };
+}
+
+interface ResolveSettingsResult {
+    filename: string;
+    resolvedToFilename: string | undefined;
+    error?: string;
+    settings: CSpellSettingsWithSourceTrace;
+}
+
+function resolveSettings(filename: string): ResolveSettingsResult {
+    const settings = readSettings(filename, {});
+    const ref = settings.__importRef;
+
+    return {
+        filename,
+        resolvedToFilename: ref?.filename,
+        error: ref?.error?.message,
+        settings,
+    };
+}
+
+function normalizeImports(imports: CSpellSettingsWithSourceTrace['import']): string[] {
+    return typeof imports === 'string' ? [imports] : imports || [];
+}
+
+function resolveImports(s: CSpellSettingsWithSourceTrace): ResolveSettingsResult[] {
+    const imported = normalizeImports(s.import);
+
+    return imported.map(resolveSettings);
+}
+
+function findPackageForCSpellConfig(pathToConfig: string): NodePackage | undefined {
+    try {
+        const filename = Path.join(pathToConfig, 'package.json');
+        const pkg = JSON.parse(fs.readFileSync(filename, 'utf8'));
+        return {
+            filename,
+            name: pkg['name'],
+        };
+    } catch (e) {
+        return undefined;
+    }
+}

--- a/packages/cspell/src/link.ts
+++ b/packages/cspell/src/link.ts
@@ -1,12 +1,13 @@
 import { Link } from 'cspell-lib';
 import chalk from 'chalk';
+import { Table } from './util/table';
 
 export const listGlobalImports = Link.listGlobalImports;
+export const addPathsToGlobalImports = Link.addPathsToGlobalImports;
+export const removePathsFromGlobalImports = Link.removePathsFromGlobalImports;
 
-export function listGlobalImportsResultToTable(results: Link.ListGlobalImportsResult[]): string[][] {
-    const table: string[][] = [];
-    const b = (s: string) => chalk.underline(chalk.bold(s));
-    const header = ['id', 'package', 'name', 'filename', 'dictionaries', 'errors'].map(b);
+export function listGlobalImportsResultToTable(results: Link.ListGlobalImportsResult[]): Table {
+    const header = ['id', 'package', 'name', 'filename', 'dictionaries', 'errors'];
     const decorate = (isError: boolean) => (isError ? (s: string) => chalk.red(s) : (s: string) => s);
 
     function toColumns(r: Link.ListGlobalImportsResult): string[] {
@@ -22,17 +23,14 @@ export function listGlobalImportsResultToTable(results: Link.ListGlobalImportsRe
             .map(decorate(!!r.error));
     }
 
-    table.push(header);
-    results.map(toColumns).forEach((row) => table.push(row));
-    return table;
+    return {
+        header,
+        rows: results.map(toColumns),
+    };
 }
 
-export const addPathsToGlobalImports = Link.addPathsToGlobalImports;
-
-export function addPathsToGlobalImportsResultToTable(results: Link.AddPathsToGlobalImportsResults): string[][] {
-    const table: string[][] = [];
-    const b = (s: string) => chalk.underline(chalk.bold(s));
-    const header = ['filename', 'errors'].map(b);
+export function addPathsToGlobalImportsResultToTable(results: Link.AddPathsToGlobalImportsResults): Table {
+    const header = ['filename', 'errors'];
     const decorate = (isError: boolean) => (isError ? (s: string) => chalk.red(s) : (s: string) => s);
 
     function toColumns(r: Link.ResolveSettingsResult): string[] {
@@ -41,9 +39,8 @@ export function addPathsToGlobalImportsResultToTable(results: Link.AddPathsToGlo
             .map(decorate(!!r.error));
     }
 
-    table.push(header);
-    results.resolvedSettings.map(toColumns).forEach((row) => table.push(row));
-    return table;
+    return {
+        header,
+        rows: results.resolvedSettings.map(toColumns),
+    };
 }
-
-export const removePathsFromGlobalImports = Link.removePathsFromGlobalImports;

--- a/packages/cspell/src/link.ts
+++ b/packages/cspell/src/link.ts
@@ -1,53 +1,15 @@
-import { CSpellSettingsWithSourceTrace, getRawGlobalSettings, readSettings, writeRawGlobalSettings } from 'cspell-lib';
+import { Link } from 'cspell-lib';
 import chalk from 'chalk';
-import * as Path from 'path';
-import * as fs from 'fs';
 
-export interface ListGlobalImportsResult {
-    filename: string;
-    name: string | undefined;
-    id: string | undefined;
-    error: string | undefined;
-    dictionaryDefinitions: CSpellSettingsWithSourceTrace['dictionaryDefinitions'];
-    languageSettings: CSpellSettingsWithSourceTrace['languageSettings'];
-    package: NodePackage | undefined;
-}
+export const listGlobalImports = Link.listGlobalImports;
 
-export interface ListGlobalImportsResults {
-    list: ListGlobalImportsResult[];
-    globalSettings: CSpellSettingsWithSourceTrace;
-}
-
-interface NodePackage {
-    name: string | undefined;
-    filename: string;
-}
-
-export function listGlobalImports(): ListGlobalImportsResults {
-    const globalSettings = getRawGlobalSettings();
-    const list = resolveImports(globalSettings).map(({ filename, settings, error }) => ({
-        filename,
-        error,
-        id: settings.id,
-        name: settings.name,
-        dictionaryDefinitions: settings.dictionaryDefinitions,
-        languageSettings: settings.languageSettings,
-        package: findPackageForCSpellConfig(Path.dirname(filename)),
-    }));
-
-    return {
-        list,
-        globalSettings,
-    };
-}
-
-export function listGlobalImportsResultToTable(results: ListGlobalImportsResult[]): string[][] {
+export function listGlobalImportsResultToTable(results: Link.ListGlobalImportsResult[]): string[][] {
     const table: string[][] = [];
     const b = (s: string) => chalk.underline(chalk.bold(s));
     const header = ['id', 'package', 'name', 'filename', 'dictionaries', 'errors'].map(b);
     const decorate = (isError: boolean) => (isError ? (s: string) => chalk.red(s) : (s: string) => s);
 
-    function toColumns(r: ListGlobalImportsResult): string[] {
+    function toColumns(r: Link.ListGlobalImportsResult): string[] {
         return [
             r.id,
             r.package?.name,
@@ -65,55 +27,15 @@ export function listGlobalImportsResultToTable(results: ListGlobalImportsResult[
     return table;
 }
 
-export interface AddPathsToGlobalImportsResults {
-    success: boolean;
-    resolvedSettings: ResolveSettingsResult[];
-    error: string | undefined;
-}
+export const addPathsToGlobalImports = Link.addPathsToGlobalImports;
 
-function isString(s: string | undefined): s is string {
-    return s !== undefined;
-}
-
-export function addPathsToGlobalImports(paths: string[]): AddPathsToGlobalImportsResults {
-    const resolvedSettings = paths.map(resolveSettings);
-    const hasError = resolvedSettings.filter((r) => !!r.error).length > 0;
-    if (hasError) {
-        return {
-            success: false,
-            resolvedSettings,
-            error: 'Unable to resolve files.',
-        };
-    }
-
-    const rawGlobalSettings = getRawGlobalSettings();
-    const resolvedImports = resolveImports(rawGlobalSettings);
-
-    const imports = new Set(resolvedImports.map((r) => r.resolvedToFilename || r.filename));
-    resolvedSettings
-        .map((s) => s.resolvedToFilename)
-        .filter(isString)
-        .reduce((imports, s) => imports.add(s), imports);
-
-    const globalSettings = {
-        import: [...imports],
-    };
-
-    const error = writeRawGlobalSettings(globalSettings);
-    return {
-        success: !error,
-        error: error?.message,
-        resolvedSettings,
-    };
-}
-
-export function addPathsToGlobalImportsResultToTable(results: AddPathsToGlobalImportsResults): string[][] {
+export function addPathsToGlobalImportsResultToTable(results: Link.AddPathsToGlobalImportsResults): string[][] {
     const table: string[][] = [];
     const b = (s: string) => chalk.underline(chalk.bold(s));
     const header = ['filename', 'errors'].map(b);
     const decorate = (isError: boolean) => (isError ? (s: string) => chalk.red(s) : (s: string) => s);
 
-    function toColumns(r: ResolveSettingsResult): string[] {
+    function toColumns(r: Link.ResolveSettingsResult): string[] {
         return [r.resolvedToFilename || r.filename, r.error ? 'Failed to read file.' : '']
             .map((c) => c || '')
             .map(decorate(!!r.error));
@@ -124,94 +46,4 @@ export function addPathsToGlobalImportsResultToTable(results: AddPathsToGlobalIm
     return table;
 }
 
-export interface RemovePathsFromGlobalImportsResult {
-    success: boolean;
-    error: string | undefined;
-    removed: string[];
-}
-
-export function removePathsFromGlobalImports(paths: string[]): RemovePathsFromGlobalImportsResult {
-    const listResult = listGlobalImports();
-
-    const toRemove = new Set<string>();
-
-    type TestResultToExclude = (r: ListGlobalImportsResult) => boolean;
-
-    function matchPackage(pathToRemove: string): TestResultToExclude {
-        return ({ package: pkg, id }) => pathToRemove === pkg?.name || pathToRemove === id;
-    }
-
-    function matchFilename(pathToRemove: string): TestResultToExclude {
-        return Path.dirname(pathToRemove) ? ({ filename }) => filename.endsWith(pathToRemove) : () => false;
-    }
-
-    paths
-        .map((a) => a.trim())
-        .filter((a) => !!a)
-        .forEach((pathToRemove) => {
-            const excludePackage = matchPackage(pathToRemove);
-            const excludeFilename = matchFilename(pathToRemove);
-            const shouldExclude: TestResultToExclude = (r) => excludePackage(r) || excludeFilename(r);
-            for (const r of listResult.list) {
-                if (shouldExclude(r)) {
-                    toRemove.add(r.filename);
-                }
-            }
-        });
-
-    const toImport = normalizeImports(listResult.globalSettings.import).filter((p) => !toRemove.has(p));
-
-    const updatedSettings = {
-        import: toImport,
-    };
-
-    const error = toRemove.size > 0 ? writeRawGlobalSettings(updatedSettings) : undefined;
-
-    return {
-        success: true,
-        removed: [...toRemove],
-        error: error?.toString(),
-    };
-}
-
-interface ResolveSettingsResult {
-    filename: string;
-    resolvedToFilename: string | undefined;
-    error?: string;
-    settings: CSpellSettingsWithSourceTrace;
-}
-
-function resolveSettings(filename: string): ResolveSettingsResult {
-    const settings = readSettings(filename, {});
-    const ref = settings.__importRef;
-
-    return {
-        filename,
-        resolvedToFilename: ref?.filename,
-        error: ref?.error?.message,
-        settings,
-    };
-}
-
-function normalizeImports(imports: CSpellSettingsWithSourceTrace['import']): string[] {
-    return typeof imports === 'string' ? [imports] : imports || [];
-}
-
-function resolveImports(s: CSpellSettingsWithSourceTrace): ResolveSettingsResult[] {
-    const imported = normalizeImports(s.import);
-
-    return imported.map(resolveSettings);
-}
-
-function findPackageForCSpellConfig(pathToConfig: string): NodePackage | undefined {
-    try {
-        const filename = Path.join(pathToConfig, 'package.json');
-        const pkg = JSON.parse(fs.readFileSync(filename, 'utf8'));
-        return {
-            filename,
-            name: pkg['name'],
-        };
-    } catch (e) {
-        return undefined;
-    }
-}
+export const removePathsFromGlobalImports = Link.removePathsFromGlobalImports;

--- a/packages/cspell/src/util/table.test.ts
+++ b/packages/cspell/src/util/table.test.ts
@@ -1,0 +1,14 @@
+import { tableToLines } from './table';
+
+describe('Validate table.ts', () => {
+    test('tableToLines', () => {
+        const table = [
+            ['id', 'name'],
+            ['27438', 'Computer'],
+            ['273438', 'Desk'],
+            ['46438', 'Monitor'],
+        ];
+        const x = tableToLines(table);
+        expect(x).toEqual(['id     | name    ', '27438  | Computer', '273438 | Desk    ', '46438  | Monitor ']);
+    });
+});

--- a/packages/cspell/src/util/table.test.ts
+++ b/packages/cspell/src/util/table.test.ts
@@ -1,14 +1,22 @@
-import { tableToLines } from './table';
+import { Table, tableToLines } from './table';
+import strip from 'strip-ansi';
 
 describe('Validate table.ts', () => {
     test('tableToLines', () => {
-        const table = [
-            ['id', 'name'],
-            ['27438', 'Computer'],
-            ['273438', 'Desk'],
-            ['46438', 'Monitor'],
-        ];
+        const table: Table = {
+            header: ['id', 'name'],
+            rows: [
+                ['27438', 'Computer'],
+                ['273438', 'Desk'],
+                ['46438', 'Monitor'],
+            ],
+        };
         const x = tableToLines(table);
-        expect(x).toEqual(['id     | name    ', '27438  | Computer', '273438 | Desk    ', '46438  | Monitor ']);
+        expect(x.map(strip)).toEqual([
+            'id     | name    ',
+            '27438  | Computer',
+            '273438 | Desk    ',
+            '46438  | Monitor ',
+        ]);
     });
 });

--- a/packages/cspell/src/util/table.ts
+++ b/packages/cspell/src/util/table.ts
@@ -1,0 +1,16 @@
+import strip from 'strip-ansi';
+
+export function tableToLines(data: string[][], deliminator = ' | '): string[] {
+    const columnWidths: number[] = [];
+
+    data.forEach((line) =>
+        line.forEach((col, idx) => {
+            columnWidths[idx] = Math.max(strip(col).length, columnWidths[idx] || 0);
+        })
+    );
+
+    const r = data.map((line) =>
+        line.map((col, i) => col + ' '.repeat(columnWidths[i] - strip(col).length)).join(deliminator)
+    );
+    return r;
+}

--- a/packages/cspell/tsconfig.json
+++ b/packages/cspell/tsconfig.json
@@ -1,14 +1,20 @@
 {
 	"compilerOptions": {
 		"target": "es2019",
-		"lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+		"lib": [
+			"es2019",
+			"es2020.promise",
+			"es2020.bigint",
+			"es2020.string"
+		],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,
 		"alwaysStrict": true,
-        "declaration": true,
+		"declaration": true,
 		"noImplicitAny": true,
 		"noImplicitThis": true,
+		"esModuleInterop": true,
 		"strictNullChecks": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,


### PR DESCRIPTION
Add `link` command to the cli:

The `link` command will:
- `list` - will list any globally linked configuration files
- `add` - will add a configuration file to the global configuration.
- `remove` - will remove a configuration file from the global configuration.

Example to add `cspell.json` form the home directory to the global configuration. 
```sh
cspell link add ~/cspell.json
```

Sample output:
```
Adding:
filename                 | errors
/Users/jason/cspell.json |   
```

Example List
```sh
cspell link
```

Sample output:
```
id    | package           | name              | filename                                                | dictionaries | errors
      |                   |                   | /Users/jason/cspell.json                                |              |       
de-de | cspell-dict-de-de | German Dictionary | /Users/jason/.nvm/.../cspell-dict-de-de/cspell-ext.json | de-de        |       
```

