### PR TITLE
chore: Don't run dependency updates on forks

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   update-dependencies:
+    if: github.repository_owner == "streetsidesoftware"
     strategy:
       matrix:
         branch:


### PR DESCRIPTION
Just scratching my own itch, since Actions don't run on forks by default, but this means this job will only run on your repo even when the fork has Actions turned on