### PR TITLE
fix: cleanup folder for cspell-glob

### DIFF
--- a/packages/cspell-glob/package.json
+++ b/packages/cspell-glob/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -p . -w",
-    "clean": "rimraf lib",
+    "clean": "rimraf dist",
     "clean-build": "npm run clean && npm run build",
     "prepare": "npm run build",
     "coverage": "jest --coverage",


### PR DESCRIPTION
Change from lib to dist in a previous PR, but I missed this ref