### PR TITLE
chore: Make NPM updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -21,7 +21,7 @@ updates:
     directory: "/" # Location of package manifests
     target-branch: "cspell4"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -10,7 +10,7 @@ on:
       - "**/package-lock.json"
   workflow_dispatch:
   schedule:
-    - cron: "3 5 * * *"
+    - cron: "0 12 * * 0"
 
 jobs:
   update-dependencies:


### PR DESCRIPTION
The Dependabot security updates should still come in more frequently if required, but this pushes it so the other updates only come once a week instead of daily