### PR TITLE
feat: support .yaml and .js configuration files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
       - cspell4
-    paths:
-      - "**/*.js"
-      - "**/*.ts"
   pull_request:
     branches:
       - master

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - master
       - cspell4
-    paths:
-      - "**/*.js"
-      - "**/*.ts"
   schedule:
     - cron: "0 23 * * 0"
 
@@ -26,6 +23,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
           # Make sure it goes back far enough to find where the branch split from master
           fetch-depth: 20
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+          # Make sure it goes back far enough to find where the branch split from master
+          fetch-depth: 20
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -4,6 +4,7 @@ backreference
 backreferences
 bitjson
 codecov
+codeql
 cosmiconfig
 coverallsapp
 deserialize

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -4,6 +4,7 @@ backreference
 backreferences
 bitjson
 codecov
+cosmiconfig
 coverallsapp
 deserialize
 deserializer

--- a/integration-tests/snapshots/django/django/snapshot.txt
+++ b/integration-tests/snapshots/django/django/snapshot.txt
@@ -3,7 +3,7 @@ Repository: django/django
 Url: "https://github.com/django/django.git"
 Args: ["**/*.{md,py}"]
 Lines:
- CSpell: Files checked: 2115, Issues found: 7999 in 929 files
+ CSpell: Files checked: 2115, Issues found: 7992 in 929 files
  exit code: 1
 ./django/django/django/apps/config.py:115:76 - Unknown word (isclass)
 ./django/django/django/apps/config.py:192:41 - Unknown word (isupper)
@@ -114,7 +114,6 @@ Lines:
 ./django/django/django/contrib/admin/options.py:429:11 - Unknown word (isdisjoint)
 ./django/django/django/contrib/admin/options.py:643:21 - Unknown word (jquery)
 ./django/django/django/contrib/admin/options.py:648:14 - Unknown word (urlify)
-./django/django/django/contrib/admin/options.py:650:21 - Unknown word (xregexp)
 ./django/django/django/contrib/admin/options.py:79:15 - Unknown word (DBFIELD)
 ./django/django/django/contrib/admin/static/admin/css/vendor/select2/LICENSE-SELECT2.md:3:43 - Unknown word (Vaynberg)
 ./django/django/django/contrib/admin/templatetags/admin_list.py:100:62 - Unknown word (fget)
@@ -156,7 +155,6 @@ Lines:
 ./django/django/django/contrib/auth/management/commands/changepassword.py:25:25 - Unknown word (nargs)
 ./django/django/django/contrib/auth/management/commands/createsuperuser.py:40:16 - Unknown word (noinput)
 ./django/django/django/contrib/auth/management/commands/createsuperuser.py:98:41 - Unknown word (isatty)
-./django/django/django/contrib/auth/password_validation.py:165:18 - Unknown word (gzipped)
 ./django/django/django/contrib/auth/password_validation.py:166:31 - Unknown word (deduplicated)
 ./django/django/django/contrib/auth/urls.py:18:18 - Unknown word (uidb)
 ./django/django/django/contrib/auth/validators.py:4:38 - Unknown word (deconstructible)

--- a/integration-tests/snapshots/typescript-cheatsheets/react/snapshot.txt
+++ b/integration-tests/snapshots/typescript-cheatsheets/react/snapshot.txt
@@ -3,7 +3,7 @@ Repository: typescript-cheatsheets/react
 Url: "https://github.com/typescript-cheatsheets/react.git"
 Args: ["**/*.{ts,js,md}"]
 Lines:
- CSpell: Files checked: 54, Issues found: 505 in 44 files
+ CSpell: Files checked: 54, Issues found: 496 in 44 files
  exit code: 1
 ./typescript-cheatsheets/react/CONTRIBUTING.md:20:39 - Unknown word (swyx's)
 ./typescript-cheatsheets/react/CONTRIBUTING.md:22:12 - Unknown word (docsite)
@@ -198,9 +198,6 @@ Lines:
 ./typescript-cheatsheets/react/docs/migration/js-docs.md:16:84 - Unknown word (Gleb)
 ./typescript-cheatsheets/react/docs/migration/js-docs.md:16:89 - Unknown word (Bahmutov)
 ./typescript-cheatsheets/react/docs/migration/js-docs.md:7:3 - Unknown word (webpack's)
-./typescript-cheatsheets/react/genReadme.js:1:31 - Unknown word (octokit)
-./typescript-cheatsheets/react/genReadme.js:1:9 - Unknown word (Octokit)
-./typescript-cheatsheets/react/genReadme.js:20:27 - Unknown word (repos)
 ./typescript-cheatsheets/react/genReadme.js:248:50 - Unknown word (frontmatter)
 ./typescript-cheatsheets/react/genReadme.js:64:49 - Unknown word (inteface)
 ./typescript-cheatsheets/react/website/docusaurus.config.js:1:21 - Unknown word (orgs)

--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
       "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -172,8 +171,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helpers": {
       "version": "7.12.5",
@@ -190,7 +188,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
       "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
@@ -201,7 +198,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -210,7 +206,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -221,7 +216,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -229,20 +223,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -971,6 +962,11 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "@types/prettier": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.6.tgz",
@@ -1367,8 +1363,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1560,6 +1555,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1816,7 +1823,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -1824,8 +1830,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -2375,6 +2380,22 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -2440,8 +2461,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -3196,8 +3216,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -3258,8 +3277,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3355,8 +3373,7 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -3751,11 +3768,18 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3798,6 +3822,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -5154,6 +5183,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "15.4.1",

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -49,6 +49,7 @@
     "@cspell/cspell-bundled-dicts": "^5.1.0",
     "comment-json": "^4.1.0",
     "configstore": "^5.0.1",
+    "cosmiconfig": "^7.0.0",
     "cspell-io": "^5.1.3",
     "cspell-trie-lib": "^5.1.3",
     "fs-extra": "^9.1.0",

--- a/packages/cspell-lib/samples/linked/cspell.js
+++ b/packages/cspell-lib/samples/linked/cspell.js
@@ -1,0 +1,5 @@
+const cspell = {
+    import: ['./cspell-imports.json'],
+};
+
+module.exports = cspell;

--- a/packages/cspell-lib/samples/linked/text.txt
+++ b/packages/cspell-lib/samples/linked/text.txt
@@ -1,0 +1,1 @@
+Het is leuk naar buiten te lopen.

--- a/packages/cspell-lib/samples/yaml-config/cspell.yaml
+++ b/packages/cspell-lib/samples/yaml-config/cspell.yaml
@@ -1,0 +1,3 @@
+id: Yaml Example Config
+import:
+  - ./../cspell-imports.json


### PR DESCRIPTION
Related to #847

cspell will search for the following configuration files:
```
       'package.json',
        'cspell.json',
        'cSpell.json',
        '.cspell.json',
        '.vscode/cspell.json',
        '.vscode/cSpell.json',
        '.vscode/.cspell.json',
        '.cSpell.json',
        'cspell.yaml',
        'cspell.yml',
        'cspell.js',
        'cspell.cjs',
```