### PR TITLE
feat: Support local configuration files

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -581,6 +581,11 @@
       "description": "Optional name of configuration",
       "type": "string"
     },
+    "noConfigSearch": {
+      "default": false,
+      "description": "Prevents searching for local configuration when checking individual documents.",
+      "type": "boolean"
+    },
     "numSuggestions": {
       "default": 10,
       "description": "Number of suggestions to make",

--- a/packages/cspell-lib/cspell.config.json
+++ b/packages/cspell-lib/cspell.config.json
@@ -3,9 +3,7 @@
     "id": "cspell-package-config",
     "name": "cspell Package Config",
     "language": "en",
-    "words": [
-        "gensequence"
-    ],
+    "words": ["gensequence"],
     "maxNumberOfProblems": 100,
     "ignorePaths": [
         "dictionaries/**",
@@ -22,7 +20,5 @@
     "allowCompoundWords": false,
     "dictionaryDefinitions": [],
     "ignoreWords": [],
-    "import": [
-        "../../cspell.json"
-    ]
+    "import": ["../../cspell.json"]
 }

--- a/packages/cspell-lib/cspell.config.json
+++ b/packages/cspell-lib/cspell.config.json
@@ -1,11 +1,10 @@
 {
-    "version": "0.1",
-    "id": "cspell-project-config",
-    "name": "cspell Project Config",
+    "version": "0.2",
+    "id": "cspell-package-config",
+    "name": "cspell Package Config",
     "language": "en",
     "words": [
-        "gensequence",
-        "xregexp"
+        "gensequence"
     ],
     "maxNumberOfProblems": 100,
     "ignorePaths": [

--- a/packages/cspell-lib/docs/configuration.md
+++ b/packages/cspell-lib/docs/configuration.md
@@ -1,0 +1,108 @@
+# cspell Configuration
+
+## Supported Configuration Files
+
+The spell checker will look for the following configuration files.
+
+- `.cspell.json`
+- `cspell.json`
+- `.cSpell.json`
+- `cSpell.json`
+- `.vscode/cspell.json`
+- `.vscode/cSpell.json`
+- `.vscode/.cspell.json`
+- `cspell.config.js`
+- `cspell.config.cjs`
+- `cspell.config.json`
+- `cspell.config.yaml`
+- `cspell.config.yml`
+- `cspell.yaml`
+- `cspell.yml`
+
+## Configuration Search
+
+While spell checking files, the spell checker will look for the nearest configuration file in the directory hierarchy.
+This allows for folder level configurations to be honored.
+It is possible to stop this behavior by adding adding `"noConfigSearch": true` to the top level configuration.
+
+A Monorepo Example:
+
+```
+repo-root
+├── cspell.config.json
+├─┬ packages
+│ ├─┬ package-A
+│ │ ├── cspell.json
+│ │ ├── README.md
+│ │ └── CHANGELOG.md
+│ ├─┬ package-B
+│ │ ├── README.md
+│ │ └── CHANGELOG.md
+│ ├─┬ package-C
+│ │ ├── cspell.yaml
+│ │ ├── README.md
+│ │ └── CHANGELOG.md
+```
+
+The following command will search the repo start at `repo-root` looking for `.md` files.
+
+```
+repo-root % cspell "**/*.md"
+```
+
+The root configuration is used to determine which files to check. Files matching the globs in `ignorePaths` will not be checked. When a file is found, the directory hierarchy is searched looking for the nearest configuration file.
+
+For example:
+
+| File                           | Config Used                      |
+| ------------------------------ | -------------------------------- |
+| `packages/package-A/README.md` | `packages/package-A/cspell.json` |
+| `packages/package-A/CONFIG.md` | `packages/package-A/cspell.json` |
+| `packages/package-B/README.md` | `cspell.config.json`             |
+| `packages/package-C/README.md` | `packages/package-C/cspell.yaml` |
+
+## Example Configurations:
+
+### Example `cspell.config.js`
+
+```javascript
+'use strict';
+
+/** @type { import("@cspell/cspell-types").CSpellUserSettings } */
+const cspell = {
+  description: 'Company cspell settings',
+  languageSettings: [
+    {
+      languageId: 'cpp',
+      allowCompoundWords: false,
+      patterns: [
+        {
+          // define a pattern to ignore #includes
+          name: 'pound-includes',
+          pattern: /^\s*#include.*/g,
+        },
+      ],
+      ignoreRegExpList: ['pound-includes'],
+    },
+  ],
+  dictionaryDefinitions: [
+    {
+      name: 'custom-words',
+      path: './custom-words.txt',
+    },
+  ],
+  dictionaries: ['custom-words'],
+};
+
+module.exports = cspell;
+```
+
+### Example import from `cspell.json`
+
+Import a `cspell.config.js` file from a `cspell.json` file.
+
+```javascript
+{
+    "import": ["../cspell.config.js"]
+}
+```

--- a/packages/cspell-lib/samples/js-config/cspell.config.js
+++ b/packages/cspell-lib/samples/js-config/cspell.config.js
@@ -3,6 +3,26 @@
 /** @type { import("@cspell/cspell-types").CSpellUserSettings } */
 const cspell = {
     description: 'cspell.config.js file in samples/js-config',
+    languageSettings: [
+        {
+            languageId: 'cpp',
+            allowCompoundWords: false,
+            patterns: [
+                {
+                    name: 'pound-includes',
+                    pattern: /^\s*#include.*/g,
+                },
+            ],
+            ignoreRegExpList: ['pound-includes'],
+        },
+    ],
+    dictionaryDefinitions: [
+        {
+            name: 'custom-words',
+            path: './custom-words.txt',
+        },
+    ],
+    dictionaries: ['custom-words'],
 };
 
 module.exports = cspell;

--- a/packages/cspell-lib/samples/js-config/custom-words.txt
+++ b/packages/cspell-lib/samples/js-config/custom-words.txt
@@ -1,0 +1,4 @@
+here
+are
+some
+words

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -175,7 +175,7 @@ describe('Validate CSpellSettingsServer', () => {
     });
 
     test('tests loading a missing cSpell.json file', () => {
-        const filename = path.join(__dirname, '..', '..', 'cSpell.json');
+        const filename = path.join(__dirname, '..', '..', 'cspell.config.json');
         const settings = readSettings(filename);
         expect(settings.__importRef?.filename).toBe(path.resolve(filename));
         expect(settings.__importRef?.error).toBeUndefined();

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -16,6 +16,7 @@ import { resolveFile } from '../util/resolveFile';
 import { getRawGlobalSettings } from './GlobalSettings';
 import { cosmiconfig, cosmiconfigSync, OptionsSync as CosmicOptionsSync, Options as CosmicOptions } from 'cosmiconfig';
 import { GlobMatcher } from 'cspell-glob';
+import { ImportError } from './ImportError';
 
 const currentSettingsFileVersion = '0.1';
 
@@ -541,12 +542,6 @@ function isImportFileRefWithError(ref: ImportFileRef): ref is ImportFileRefWithE
 export function extractImportErrors(settings: CSpellSettings): ImportFileRefWithError[] {
     const imports = mergeImportRefs(settings, {});
     return !imports ? [] : [...imports.values()].filter(isImportFileRefWithError);
-}
-
-class ImportError extends Error {
-    constructor(msg: string, readonly cause?: Error) {
-        super(msg);
-    }
 }
 
 function resolveGlobRoot(settings: CSpellSettings, pathToSettingsFile: string): string {

--- a/packages/cspell-lib/src/Settings/ImportError.ts
+++ b/packages/cspell-lib/src/Settings/ImportError.ts
@@ -1,0 +1,5 @@
+export class ImportError extends Error {
+    constructor(msg: string, readonly cause?: Error) {
+        super(msg);
+    }
+}

--- a/packages/cspell-lib/src/index.ts
+++ b/packages/cspell-lib/src/index.ts
@@ -5,9 +5,9 @@ export { TextOffset, TextDocumentOffset } from './util/text';
 export {
     checkText,
     CheckTextInfo,
-    TextInfoItem,
-    IncludeExcludeOptions,
     IncludeExcludeFlag,
+    IncludeExcludeOptions,
+    TextInfoItem,
     validateText,
 } from './validator';
 export { defaultFileName as defaultSettingsFilename } from './Settings';
@@ -15,14 +15,20 @@ export {
     CompoundWordsMethod,
     createSpellingDictionary,
     getDictionary,
+    refreshDictionaryCache,
     SpellingDictionary,
     SuggestionCollector,
     SuggestionResult,
-    refreshDictionaryCache,
 } from './SpellingDictionary';
 export { combineTextAndLanguageSettings } from './Settings/TextDocumentSettings';
 export { combineTextAndLanguageSettings as constructSettingsForText } from './Settings/TextDocumentSettings';
-export { spellCheckFile, SpellCheckFileOptions, SpellCheckFileResult } from './spellCheckFile';
+export {
+    Document,
+    spellCheckDocument,
+    spellCheckFile,
+    SpellCheckFileOptions,
+    SpellCheckFileResult,
+} from './spellCheckFile';
 
 import * as Text from './util/text';
 import * as Link from './Settings/link';

--- a/packages/cspell-lib/src/index.ts
+++ b/packages/cspell-lib/src/index.ts
@@ -22,6 +22,7 @@ export {
 } from './SpellingDictionary';
 export { combineTextAndLanguageSettings } from './Settings/TextDocumentSettings';
 export { combineTextAndLanguageSettings as constructSettingsForText } from './Settings/TextDocumentSettings';
+export { spellCheckFile, SpellCheckFileOptions, SpellCheckFileResult } from './spellCheckFile';
 
 import * as Text from './util/text';
 import * as Link from './Settings/link';

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -1,9 +1,10 @@
 import { CSpellUserSettings } from '@cspell/cspell-types';
 import * as Path from 'path';
+import { posix } from 'path';
 import { URI } from 'vscode-uri';
 import { ImportError } from './Settings/ImportError';
 import {
-    PartialDocument,
+    Document,
     spellCheckDocument,
     spellCheckFile,
     SpellCheckFileOptions,
@@ -91,7 +92,7 @@ describe('Validate Spell Checking Documents', () => {
         return URI.file(s(file)).toString();
     }
 
-    function d(uri: string, text?: string): PartialDocument {
+    function d(uri: string, text?: string): Document {
         return text === undefined ? { uri } : { uri, text };
     }
 
@@ -167,7 +168,7 @@ describe('Validate Uri assumptions', () => {
     }
 
     function normalizePath(p: string): string {
-        return fixDriveLetter(p).replace(/\\/g, '/');
+        return posix.normalize('/' + fixDriveLetter(p).replace(/\\/g, '/'));
     }
 
     interface UriTestCase {

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -158,10 +158,6 @@ describe('Validate Uri assumptions', () => {
         return { path };
     }
 
-    function fsPath(fsPath: string): PartialUri {
-        return { fsPath: fixDriveLetter(fsPath) };
-    }
-
     function m(...parts: PartialUri[]): PartialUri {
         const u: PartialUri = {};
         for (const p of parts) {
@@ -181,7 +177,7 @@ describe('Validate Uri assumptions', () => {
 
     test.each`
         uri                                                      | expected                                                                                  | comment
-        ${u(__filename)}                                         | ${m(schema('file'), path(normalizePath(__filename)), fsPath(__filename))}                 | ${''}
+        ${u(__filename)}                                         | ${m(schema('file'), path(normalizePath(__filename)))}                                     | ${''}
         ${'stdin:///'}                                           | ${m(schema('stdin'), path('/'), authority(''))}                                           | ${''}
         ${'https://github.com/streetsidesoftware/cspell/issues'} | ${m(schema('https'), authority('github.com'), path('/streetsidesoftware/cspell/issues'))} | ${''}
         ${'C:\\home\\project\\file.js'}                          | ${m(schema('C'), path('\\home\\project\\file.js'))}                                       | ${'Windows path by "accident"'}

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -159,7 +159,7 @@ describe('Validate Uri assumptions', () => {
     }
 
     function fsPath(fsPath: string): PartialUri {
-        return { fsPath };
+        return { fsPath: fixDriveLetter(fsPath) };
     }
 
     function m(...parts: PartialUri[]): PartialUri {

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -1,11 +1,19 @@
 import { CSpellUserSettings } from '@cspell/cspell-types';
-import * as path from 'path';
+import * as Path from 'path';
+import { posix } from 'path';
+import { URI } from 'vscode-uri';
 import { ImportError } from './Settings/ImportError';
-import { spellCheckFile, SpellCheckFileOptions, SpellCheckFileResult } from './spellCheckFile';
+import {
+    PartialDocument,
+    spellCheckDocument,
+    spellCheckFile,
+    SpellCheckFileOptions,
+    SpellCheckFileResult,
+} from './spellCheckFile';
 
-const samples = path.resolve(__dirname, '../samples');
+const samples = Path.resolve(__dirname, '../samples');
 
-describe('Validate Spell Check Files', () => {
+describe('Validate Spell Checking Files', () => {
     interface TestSpellCheckFile {
         filename: string;
         settings: CSpellUserSettings;
@@ -52,6 +60,133 @@ describe('Validate Spell Check Files', () => {
     );
 });
 
+describe('Validate Spell Checking Documents', () => {
+    interface TestSpellCheckFile {
+        uri: string;
+        text: string | undefined;
+        settings: CSpellUserSettings;
+        options: SpellCheckFileOptions;
+        expected: Partial<SpellCheckFileResult>;
+    }
+
+    function oc<T>(t: T): T {
+        return expect.objectContaining(t);
+    }
+
+    function err(msg: string): Error {
+        return new ImportError(msg);
+    }
+
+    function eFailed(file: string): Error {
+        return err(`Failed to find config file at: "${s(file)}"`);
+    }
+
+    function errNoEnt(file: string): Error {
+        const message = `ENOENT: no such file or directory, open '${file}'`;
+        return expect.objectContaining(new Error(message));
+    }
+
+    function f(file: string): string {
+        return URI.file(s(file)).toString();
+    }
+
+    function d(uri: string, text?: string): PartialDocument {
+        return text === undefined ? { uri } : { uri, text };
+    }
+
+    type ArrayType<T> = T extends (infer R)[] ? R : never;
+
+    type Issue = ArrayType<SpellCheckFileResult['issues']>;
+
+    function i(...words: string[]): Partial<Issue>[] {
+        return words.map((text) => ({ text })).map((i) => expect.objectContaining(i));
+    }
+
+    // cspell:ignore texxt
+    test.each`
+        uri                     | text            | settings                       | options                                       | expected
+        ${f('src/not_found.c')} | ${''}           | ${{}}                          | ${{}}                                         | ${{ checked: false, errors: [errNoEnt('src/not_found.c')] }}
+        ${f('src/sample.c')}    | ${''}           | ${{}}                          | ${{}}                                         | ${{ checked: true, issues: [], localConfigFilepath: s('.cspell.json'), errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{}}                          | ${{ noConfigSearch: true }}                   | ${{ checked: true, localConfigFilepath: undefined, errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{ noConfigSearch: true }}    | ${{}}                                         | ${{ checked: true, localConfigFilepath: undefined, errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{}}                          | ${{ configFile: s('../cspell.config.json') }} | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{ noConfigSearch: true }}    | ${{ configFile: s('../cspell.config.json') }} | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{ noConfigSearch: true }}    | ${{ noConfigSearch: false }}                  | ${{ checked: true, localConfigFilepath: s('.cspell.json'), errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{}}                          | ${{}}                                         | ${{ document: oc(d(f('src/sample.c'))), errors: undefined }}
+        ${f('src/sample.c')}    | ${''}           | ${{}}                          | ${{ configFile: s('../cSpell.json') }}        | ${{ checked: false, localConfigFilepath: s('../cSpell.json'), errors: [eFailed(s('../cSpell.json'))] }}
+        ${f('src/not_found.c')} | ${''}           | ${{}}                          | ${{}}                                         | ${{ checked: false, errors: [errNoEnt('src/not_found.c')] }}
+        ${f(__filename)}        | ${''}           | ${{}}                          | ${{}}                                         | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
+        ${'stdin:///'}          | ${'some text'}  | ${{ languageId: 'plaintext' }} | ${{}}                                         | ${{ checked: true, issues: [], localConfigFilepath: undefined, errors: undefined }}
+        ${'stdin:///'}          | ${'some text'}  | ${{ languageId: 'plaintext' }} | ${{}}                                         | ${{ document: oc(d('stdin:///')) }}
+        ${'stdin:///'}          | ${'some texxt'} | ${{ languageId: 'plaintext' }} | ${{}}                                         | ${{ checked: true, issues: i('texxt'), localConfigFilepath: undefined, errors: undefined }}
+        ${'stdin:///'}          | ${''}           | ${{ languageId: 'plaintext' }} | ${{}}                                         | ${{ checked: false, issues: [], localConfigFilepath: undefined, errors: [err('Unsupported schema: "stdin", open "stdin:/"')] }}
+    `(
+        'spellCheckFile $filename $settings $options',
+        async ({ uri, text, settings, options, expected }: TestSpellCheckFile) => {
+            const r = await spellCheckDocument(d(uri, text || undefined), options, settings);
+            expect(r).toEqual(oc(expected));
+        }
+    );
+});
+
+describe('Validate Uri assumptions', () => {
+    interface UriComponents {
+        scheme: string;
+        authority: string;
+        path: string;
+        query: string;
+        fragment: string;
+        fsPath?: string;
+    }
+
+    type PartialUri = Partial<UriComponents>;
+
+    function u(filename: string): string {
+        return URI.file(filename).toString();
+    }
+
+    function schema(scheme: string): PartialUri {
+        return { scheme };
+    }
+
+    function authority(authority: string): PartialUri {
+        return { authority };
+    }
+
+    function path(path: string): PartialUri {
+        return { path };
+    }
+
+    function fsPath(fsPath: string): PartialUri {
+        return { fsPath };
+    }
+
+    function m(...parts: PartialUri[]): PartialUri {
+        const u: PartialUri = {};
+        for (const p of parts) {
+            Object.assign(u, p);
+        }
+        return u;
+    }
+
+    interface UriTestCase {
+        uri: string;
+        expected: PartialUri;
+    }
+
+    test.each`
+        uri                                                      | expected                                                                                  | comment
+        ${u(__filename)}                                         | ${m(schema('file'), path(posix.normalize(__filename)), fsPath(__filename))}               | ${''}
+        ${'stdin:///'}                                           | ${m(schema('stdin'), path('/'), authority(''))}                                           | ${''}
+        ${'https://github.com/streetsidesoftware/cspell/issues'} | ${m(schema('https'), authority('github.com'), path('/streetsidesoftware/cspell/issues'))} | ${''}
+        ${'https://github.com/streetsidesoftware/cspell/issues'} | ${m(fsPath(Path.normalize('/streetsidesoftware/cspell/issues')))}                         | ${''}
+        ${'C:\\home\\project\\file.js'}                          | ${m(schema('C'), path('\\home\\project\\file.js'))}                                       | ${'Windows path by "accident"'}
+    `('URI assumptions uri: "$uri" $comment -- $expected', ({ uri, expected }: UriTestCase) => {
+        const u = URI.parse(uri);
+        expect(u).toEqual(expect.objectContaining(expected));
+    });
+});
+
 function s(file: string) {
-    return path.resolve(samples, file);
+    return Path.resolve(samples, file);
 }

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -1,6 +1,7 @@
 import { CSpellUserSettings } from '@cspell/cspell-types';
 import * as path from 'path';
-import { spellCheckFile, SpellCheckFileOptions } from './spellCheckFile';
+import { ImportError } from './Settings/ImportError';
+import { spellCheckFile, SpellCheckFileOptions, SpellCheckFileResult } from './spellCheckFile';
 
 const samples = path.resolve(__dirname, '../samples');
 
@@ -9,19 +10,46 @@ describe('Validate Spell Check Files', () => {
         filename: string;
         settings: CSpellUserSettings;
         options: SpellCheckFileOptions;
+        expected: Partial<SpellCheckFileResult>;
+    }
+
+    function oc<T>(t: T): T {
+        return expect.objectContaining(t);
+    }
+
+    function err(msg: string): Error {
+        return new ImportError(msg);
+    }
+
+    function eFailed(file: string): Error {
+        return err(`Failed to find config file at: "${s(file)}"`);
+    }
+
+    function errNoEnt(file: string): Error {
+        const message = `ENOENT: no such file or directory, open '${file}'`;
+        return expect.objectContaining(new Error(message));
     }
 
     test.each`
-        filename             | settings | options
-        ${s('src/sample.c')} | ${{}}    | ${{}}
-    `('spellCheckFile $file $settings', async ({ filename, settings, options }: TestSpellCheckFile) => {
-        const r = await spellCheckFile(filename, options, settings);
-        expect(r).toEqual(
-            expect.objectContaining({
-                issues: [],
-            })
-        );
-    });
+        filename             | settings                    | options                                       | expected
+        ${'src/not_found.c'} | ${{}}                       | ${{}}                                         | ${{ checked: false, errors: [errNoEnt('src/not_found.c')] }}
+        ${'src/sample.c'}    | ${{}}                       | ${{}}                                         | ${{ checked: true, issues: [], localConfigFilepath: s('.cspell.json'), errors: undefined }}
+        ${'src/sample.c'}    | ${{}}                       | ${{ noConfigSearch: true }}                   | ${{ checked: true, localConfigFilepath: undefined, errors: undefined }}
+        ${'src/sample.c'}    | ${{ noConfigSearch: true }} | ${{}}                                         | ${{ checked: true, localConfigFilepath: undefined, errors: undefined }}
+        ${'src/sample.c'}    | ${{}}                       | ${{ configFile: s('../cspell.config.json') }} | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
+        ${'src/sample.c'}    | ${{ noConfigSearch: true }} | ${{ configFile: s('../cspell.config.json') }} | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
+        ${'src/sample.c'}    | ${{ noConfigSearch: true }} | ${{ noConfigSearch: false }}                  | ${{ checked: true, localConfigFilepath: s('.cspell.json'), errors: undefined }}
+        ${'src/sample.c'}    | ${{}}                       | ${{}}                                         | ${{ document: oc({ uri: oc({ fsPath: s('src/sample.c') }) }), errors: undefined }}
+        ${'src/sample.c'}    | ${{}}                       | ${{ configFile: s('../cSpell.json') }}        | ${{ checked: false, localConfigFilepath: s('../cSpell.json'), errors: [eFailed(s('../cSpell.json'))] }}
+        ${'src/not_found.c'} | ${{}}                       | ${{}}                                         | ${{ checked: false, errors: [errNoEnt('src/not_found.c')] }}
+        ${__filename}        | ${{}}                       | ${{}}                                         | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
+    `(
+        'spellCheckFile $filename $settings $options',
+        async ({ filename, settings, options, expected }: TestSpellCheckFile) => {
+            const r = await spellCheckFile(s(filename), options, settings);
+            expect(r).toEqual(expect.objectContaining(expected));
+        }
+    );
 });
 
 function s(file: string) {

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -39,7 +39,7 @@ describe('Validate Spell Check Files', () => {
         ${'src/sample.c'}    | ${{}}                       | ${{ configFile: s('../cspell.config.json') }} | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
         ${'src/sample.c'}    | ${{ noConfigSearch: true }} | ${{ configFile: s('../cspell.config.json') }} | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
         ${'src/sample.c'}    | ${{ noConfigSearch: true }} | ${{ noConfigSearch: false }}                  | ${{ checked: true, localConfigFilepath: s('.cspell.json'), errors: undefined }}
-        ${'src/sample.c'}    | ${{}}                       | ${{}}                                         | ${{ document: oc({ uri: oc({ fsPath: s('src/sample.c') }) }), errors: undefined }}
+        ${'src/sample.c'}    | ${{}}                       | ${{}}                                         | ${{ document: expect.anything(), errors: undefined }}
         ${'src/sample.c'}    | ${{}}                       | ${{ configFile: s('../cSpell.json') }}        | ${{ checked: false, localConfigFilepath: s('../cSpell.json'), errors: [eFailed(s('../cSpell.json'))] }}
         ${'src/not_found.c'} | ${{}}                       | ${{}}                                         | ${{ checked: false, errors: [errNoEnt('src/not_found.c')] }}
         ${__filename}        | ${{}}                       | ${{}}                                         | ${{ checked: true, localConfigFilepath: s('../cspell.config.json'), errors: undefined }}
@@ -47,7 +47,7 @@ describe('Validate Spell Check Files', () => {
         'spellCheckFile $filename $settings $options',
         async ({ filename, settings, options, expected }: TestSpellCheckFile) => {
             const r = await spellCheckFile(s(filename), options, settings);
-            expect(r).toEqual(expect.objectContaining(expected));
+            expect(r).toEqual(oc(expected));
         }
     );
 });

--- a/packages/cspell-lib/src/spellCheckFile.ts
+++ b/packages/cspell-lib/src/spellCheckFile.ts
@@ -49,14 +49,14 @@ export interface SpellCheckFileResult {
 const defaultEncoding: BufferEncoding = 'utf8';
 
 export type UriString = string;
-export interface Document {
-    uri: UriString;
+
+export interface Document extends PartialDocument {
     text: string;
 }
-
 export interface PartialDocument {
     uri: UriString;
     text?: string;
+    languageId?: string;
 }
 
 /**
@@ -208,9 +208,13 @@ export function determineDocumentSettings(
     const uri = URI.parse(document.uri);
     const filename = uri.fsPath;
     const ext = path.extname(filename);
-    const fileOverrideSettings = calcOverrideSettings(settings, path.resolve(filename));
+    const fileOverrideSettings = calcOverrideSettings(settings, filename);
     const fileSettings = mergeSettings(getDefaultSettings(), getGlobalSettings(), fileOverrideSettings);
-    const languageIds = settings.languageId ? [settings.languageId] : getLanguagesForExt(ext);
+    const languageIds = document.languageId
+        ? document.languageId
+        : settings.languageId
+        ? settings.languageId
+        : getLanguagesForExt(ext);
     const config = combineTextAndLanguageSettings(fileSettings, document.text, languageIds);
     return {
         document,

--- a/packages/cspell-lib/src/spellCheckFile.ts
+++ b/packages/cspell-lib/src/spellCheckFile.ts
@@ -6,6 +6,7 @@ import {
     calcOverrideSettings,
     getDefaultSettings,
     getGlobalSettings,
+    loadConfig,
     mergeSettings,
     searchForConfig,
 } from './Settings';
@@ -14,16 +15,35 @@ import * as path from 'path';
 import { combineTextAndLanguageSettings } from './Settings/TextDocumentSettings';
 
 export interface SpellCheckFileOptions {
+    /**
+     * Optional path to a configuration file.
+     * If given, it will be used instead of searching for a configuration file.
+     */
     configFile?: string;
+    /**
+     * File encoding
+     * @defaultValue 'utf-8'
+     */
     encoding?: BufferEncoding;
+    /**
+     * Prevents searching for local configuration files
+     * By default the spell checker looks for configuration files
+     * starting at the location of given filename.
+     * If `configFile` is defined it will still be loaded instead of searching.
+     * `false` will override the value in `settings.noConfigSearch`.
+     * @defaultValue undefined
+     */
+    noConfigSearch?: boolean;
 }
 
 export interface SpellCheckFileResult {
     document: Document;
     settingsUsed: CSpellSettingsWithSourceTrace;
+    localConfigFilepath: string | undefined;
     options: SpellCheckFileOptions;
     issues: ValidationIssue[];
     checked: boolean;
+    errors: Error[] | undefined;
 }
 
 const defaultEncoding: BufferEncoding = 'utf8';
@@ -38,7 +58,42 @@ export async function spellCheckFile(
     options: SpellCheckFileOptions,
     settings: CSpellUserSettings
 ): Promise<SpellCheckFileResult> {
-    const [localConfig, document] = await Promise.all([searchForConfig(file), readDocument(file, options.encoding)]);
+    const errors: Error[] = [];
+    function addPossibleError(error: Error | undefined) {
+        if (!error) return;
+        errors.push(error);
+    }
+
+    function catchError<P>(p: Promise<P>): Promise<P | undefined> {
+        return p.catch((error) => {
+            addPossibleError(error);
+            return undefined;
+        });
+    }
+
+    const useSearchForConfig =
+        (!options.noConfigSearch && !settings.noConfigSearch) || options.noConfigSearch === false;
+    const pLocalConfig = options.configFile
+        ? catchError(loadConfig(options.configFile))
+        : useSearchForConfig
+        ? catchError(searchForConfig(file))
+        : undefined;
+    const [localConfig, document] = await Promise.all([pLocalConfig, catchError(readDocument(file, options.encoding))]);
+
+    addPossibleError(localConfig?.__importRef?.error);
+
+    if (!document || errors.length) {
+        return {
+            document: { uri: document?.uri ?? URI.file(file), text: document?.text ?? '' },
+            options,
+            settingsUsed: localConfig || settings,
+            localConfigFilepath: localConfig?.__importRef?.filename,
+            issues: [],
+            checked: false,
+            errors,
+        };
+    }
+
     const config = localConfig ? mergeSettings(settings, localConfig) : settings;
     const docSettings = determineDocumentSettings(document, config);
 
@@ -50,8 +105,10 @@ export async function spellCheckFile(
         document,
         options,
         settingsUsed: docSettings.settings,
+        localConfigFilepath: localConfig?.__importRef?.filename,
         issues,
         checked: shouldCheck,
+        errors: undefined,
     };
 
     return result;
@@ -72,7 +129,10 @@ interface DetermineDocumentSettingsResult {
     settings: CSpellUserSettings;
 }
 
-function determineDocumentSettings(document: Document, settings: CSpellUserSettings): DetermineDocumentSettingsResult {
+export function determineDocumentSettings(
+    document: Document,
+    settings: CSpellUserSettings
+): DetermineDocumentSettingsResult {
     const filename = document.uri.fsPath;
     const ext = path.extname(filename);
     const fileOverrideSettings = calcOverrideSettings(settings, path.resolve(filename));

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -581,6 +581,11 @@
       "description": "Optional name of configuration",
       "type": "string"
     },
+    "noConfigSearch": {
+      "default": false,
+      "description": "Prevents searching for local configuration when checking individual documents.",
+      "type": "boolean"
+    },
     "numSuggestions": {
       "default": 10,
       "description": "Number of suggestions to make",

--- a/packages/cspell-types/src/settings/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/settings/CSpellSettingsDef.ts
@@ -65,6 +65,12 @@ export interface FileSettings extends ExtendableSettings {
      * Glob patterns are relative to the `globRoot` of the configuration file that defines them.
      */
     ignorePaths?: Glob[];
+
+    /**
+     * Prevents searching for local configuration when checking individual documents.
+     * @default false
+     */
+    noConfigSearch?: boolean;
 }
 
 export interface ExtendableSettings extends Settings {

--- a/packages/cspell/src/CSpellApplicationConfiguration.ts
+++ b/packages/cspell/src/CSpellApplicationConfiguration.ts
@@ -1,0 +1,52 @@
+import { GlobSrcInfo, calcExcludeGlobInfo } from './util/glob';
+import * as path from 'path';
+import * as util from './util/util';
+import { IOptions } from './util/IOptions';
+import {
+    DebugEmitter,
+    Emitters,
+    MessageEmitter,
+    MessageTypes,
+    ProgressEmitter,
+    SpellingErrorEmitter,
+    Issue,
+} from './emitters';
+import { CSpellApplicationOptions } from './options';
+
+const defaultContextRange = 20;
+const nullEmitter: () => void = () => {
+    /* empty */
+};
+
+// cspell:word nocase
+const defaultMinimatchOptions: IOptions = { nocase: true };
+export const defaultConfigGlobOptions: IOptions = defaultMinimatchOptions;
+
+export class CSpellApplicationConfiguration {
+    readonly info: MessageEmitter;
+    readonly progress: ProgressEmitter;
+    readonly debug: DebugEmitter;
+    readonly logIssue: SpellingErrorEmitter;
+    readonly uniqueFilter: (issue: Issue) => boolean;
+    readonly locale: string;
+
+    readonly configFile: string | undefined;
+    readonly configGlobOptions: IOptions = defaultConfigGlobOptions;
+    readonly excludes: GlobSrcInfo[];
+    readonly root: string;
+    readonly showContext: number;
+
+    constructor(readonly files: string[], readonly options: CSpellApplicationOptions, readonly emitters: Emitters) {
+        this.root = path.resolve(options.root || process.cwd());
+        this.info = emitters.info || nullEmitter;
+        this.debug = emitters.debug || ((msg: string) => this.info(msg, MessageTypes.Debug));
+        this.configFile = options.config;
+        this.excludes = calcExcludeGlobInfo(this.root, options.exclude);
+        this.logIssue = emitters.issue || nullEmitter;
+        this.locale = options.locale || options.local || '';
+        this.uniqueFilter = options.unique ? util.uniqueFilterFnGenerator((issue: Issue) => issue.text) : () => true;
+        this.progress = emitters.progress || nullEmitter;
+        this.showContext =
+            options.showContext === true ? defaultContextRange : options.showContext ? options.showContext : 0;
+    }
+}

--- a/packages/cspell/src/app.ts
+++ b/packages/cspell/src/app.ts
@@ -2,7 +2,8 @@ import * as path from 'path';
 import * as commander from 'commander';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const npmPackage = require(path.join(__dirname, '..', 'package.json'));
-import { CSpellApplicationOptions, BaseOptions, checkText } from './application';
+import { checkText } from './application';
+import { CSpellApplicationOptions, BaseOptions, TraceOptions } from './options';
 import * as App from './application';
 import chalk = require('chalk');
 import {
@@ -27,7 +28,6 @@ interface Options extends CSpellApplicationOptions {
      */
     relative?: boolean;
 }
-type TraceOptions = App.TraceOptions;
 // interface InitOptions extends Options {}
 
 const templateIssue = `{green $uri}:{yellow $row:$col} - Unknown word ({red $text})`;

--- a/packages/cspell/src/application.test.ts
+++ b/packages/cspell/src/application.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as App from './application';
 import { Emitters, ProgressFileComplete, Issue } from './emitters';
+import { CSpellApplicationOptions } from './options';
 
 const getStdinResult = {
     value: '',
@@ -154,7 +155,7 @@ describe('Application, Validate Samples', () => {
 interface SampleTest {
     file: string;
     issues: string[];
-    options?: App.CSpellApplicationOptions;
+    options?: CSpellApplicationOptions;
 }
 
 function sampleTests(): SampleTest[] {

--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -1,10 +1,9 @@
 import {
-    globP,
-    GlobOptions,
-    GlobSrcInfo,
-    calcExcludeGlobInfo,
     extractGlobExcludesFromConfig,
     extractPatterns,
+    GlobOptions,
+    globP,
+    GlobSrcInfo,
     normalizeGlobsToRoot,
 } from './util/glob';
 import * as cspell from 'cspell-lib';
@@ -16,69 +15,13 @@ import { traceWords, TraceResult, CheckTextInfo, getDictionary } from 'cspell-li
 import { CSpellSettings, CSpellUserSettings, Glob } from '@cspell/cspell-types';
 import getStdin from 'get-stdin';
 export { TraceResult, IncludeExcludeFlag } from 'cspell-lib';
-import { IOptions } from './util/IOptions';
 import { measurePromise } from './util/timer';
-import {
-    DebugEmitter,
-    Emitters,
-    MessageEmitter,
-    MessageTypes,
-    ProgressEmitter,
-    SpellingErrorEmitter,
-    Issue,
-} from './emitters';
-
-// cspell:word nocase
+import { Emitters, MessageTypes, Issue } from './emitters';
+import { CSpellApplicationConfiguration } from './CSpellApplicationConfiguration';
+import { BaseOptions, CSpellApplicationOptions, TraceOptions } from './options';
 
 const UTF8: BufferEncoding = 'utf8';
 const STDIN = 'stdin';
-const defaultContextRange = 20;
-export interface CSpellApplicationOptions extends BaseOptions {
-    /**
-     * Display verbose information
-     */
-    verbose?: boolean;
-    /**
-     * Show extensive output.
-     */
-    debug?: boolean;
-    /**
-     * a globs to exclude files from being checked.
-     */
-    exclude?: string[] | string;
-    /**
-     * Only report the words, no line numbers or file names.
-     */
-    wordsOnly?: boolean;
-    /**
-     * unique errors per file only.
-     */
-    unique?: boolean;
-    /**
-     * root directory, defaults to `cwd`
-     */
-    root?: string;
-    /**
-     * Show part of a line where an issue is found.
-     * if true, it will show the default number of characters on either side.
-     * if a number, it will shat number of characters on either side.
-     */
-    showContext?: boolean | number;
-    /**
-     * Show suggestions for spelling errors.
-     */
-    showSuggestions?: boolean;
-}
-
-export type TraceOptions = BaseOptions;
-
-export interface BaseOptions {
-    config?: string;
-    languageId?: string;
-    locale?: string;
-    local?: string; // deprecated
-}
-
 export type AppError = NodeJS.ErrnoException;
 
 export interface RunResult {
@@ -86,42 +29,6 @@ export interface RunResult {
     filesWithIssues: Set<string>;
     issues: number;
     errors: number;
-}
-
-const defaultMinimatchOptions: IOptions = { nocase: true };
-const defaultConfigGlobOptions: IOptions = defaultMinimatchOptions;
-
-const nullEmitter = () => {
-    /* empty */
-};
-
-export class CSpellApplicationConfiguration {
-    readonly info: MessageEmitter;
-    readonly progress: ProgressEmitter;
-    readonly debug: DebugEmitter;
-    readonly logIssue: SpellingErrorEmitter;
-    readonly uniqueFilter: (issue: Issue) => boolean;
-    readonly locale: string;
-
-    readonly configFile: string | undefined;
-    readonly configGlobOptions: IOptions = defaultConfigGlobOptions;
-    readonly excludes: GlobSrcInfo[];
-    readonly root: string;
-    readonly showContext: number;
-
-    constructor(readonly files: string[], readonly options: CSpellApplicationOptions, readonly emitters: Emitters) {
-        this.root = path.resolve(options.root || process.cwd());
-        this.info = emitters.info || nullEmitter;
-        this.debug = emitters.debug || ((msg: string) => this.info(msg, MessageTypes.Debug));
-        this.configFile = options.config;
-        this.excludes = calcExcludeGlobInfo(this.root, options.exclude);
-        this.logIssue = emitters.issue || nullEmitter;
-        this.locale = options.locale || options.local || '';
-        this.uniqueFilter = options.unique ? util.uniqueFilterFnGenerator((issue: Issue) => issue.text) : () => true;
-        this.progress = emitters.progress || nullEmitter;
-        this.showContext =
-            options.showContext === true ? defaultContextRange : options.showContext ? options.showContext : 0;
-    }
 }
 
 interface ConfigInfo {

--- a/packages/cspell/src/options.ts
+++ b/packages/cspell/src/options.ts
@@ -1,0 +1,45 @@
+export interface CSpellApplicationOptions extends BaseOptions {
+    /**
+     * Display verbose information
+     */
+    verbose?: boolean;
+    /**
+     * Show extensive output.
+     */
+    debug?: boolean;
+    /**
+     * a globs to exclude files from being checked.
+     */
+    exclude?: string[] | string;
+    /**
+     * Only report the words, no line numbers or file names.
+     */
+    wordsOnly?: boolean;
+    /**
+     * unique errors per file only.
+     */
+    unique?: boolean;
+    /**
+     * root directory, defaults to `cwd`
+     */
+    root?: string;
+    /**
+     * Show part of a line where an issue is found.
+     * if true, it will show the default number of characters on either side.
+     * if a number, it will shat number of characters on either side.
+     */
+    showContext?: boolean | number;
+    /**
+     * Show suggestions for spelling errors.
+     */
+    showSuggestions?: boolean;
+}
+
+export type TraceOptions = BaseOptions;
+
+export interface BaseOptions {
+    config?: string;
+    languageId?: string;
+    locale?: string;
+    local?: string; // deprecated
+}


### PR DESCRIPTION
## Supported Configuration Files

The spell checker will look for the following configuration files.

- `.cspell.json`
- `cspell.json`
- `.cSpell.json`
- `cSpell.json`
- `.vscode/cspell.json`
- `.vscode/cSpell.json`
- `.vscode/.cspell.json`
- `cspell.config.js`
- `cspell.config.cjs`
- `cspell.config.json`
- `cspell.config.yaml`
- `cspell.config.yml`
- `cspell.yaml`
- `cspell.yml`

## Configuration Search

While spell checking files, the spell checker will look for the nearest configuration file in the directory hierarchy.
This allows for folder level configurations to be honored.
It is possible to stop this behavior by adding adding `"noConfigSearch": true` to the top level configuration.

A Monorepo Example:

```
repo-root
├── cspell.config.json
├─┬ packages
│ ├─┬ package-A
│ │ ├── cspell.json
│ │ ├── README.md
│ │ └── CHANGELOG.md
│ ├─┬ package-B
│ │ ├── README.md
│ │ └── CHANGELOG.md
│ ├─┬ package-C
│ │ ├── cspell.yaml
│ │ ├── README.md
│ │ └── CHANGELOG.md
```

The following command will search the repo start at `repo-root` looking for `.md` files.

```
repo-root % cspell "**/*.md"
```

The root configuration is used to determine which files to check. Files matching the globs in `ignorePaths` will not be checked. When a file is found, the directory hierarchy is searched looking for the nearest configuration file.

For example:

| File                           | Config Used                      |
| ------------------------------ | -------------------------------- |
| `packages/package-A/README.md` | `packages/package-A/cspell.json` |
| `packages/package-A/CONFIG.md` | `packages/package-A/cspell.json` |
| `packages/package-B/README.md` | `cspell.config.json`             |
| `packages/package-C/README.md` | `packages/package-C/cspell.yaml` |
