### PR TITLE
feat: Support negation matches in languageSettings for languageIds

### DIFF
--- a/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
@@ -14,6 +14,14 @@ const extraSettings: CSpellUserSettings = {
             patterns: [{ name: 'special', pattern: 'special' }],
             ignoreRegExpList: ['special'],
         },
+        {
+            languageId: '!python,!javascript',
+            ignoreRegExpList: ['no-python-and-javascript'],
+        },
+        {
+            languageId: 'python,javascript',
+            ignoreRegExpList: ['python-and-javascript'],
+        },
     ],
 };
 
@@ -84,6 +92,26 @@ describe('Validate LanguageSettings', () => {
         expect(sPython.enabled).toBe(true);
         expect(sPython.allowCompoundWords).toBe(true);
     });
+
+    test.each`
+        languageId      | ignoreContains                                    | ignoreNotContains
+        ${'python'}     | ${['binary', 'special', 'python-and-javascript']} | ${['no-python-and-javascript']}
+        ${'javascript'} | ${['binary', 'python-and-javascript']}            | ${['no-python-and-javascript']}
+        ${'plaintext'}  | ${['binary', 'no-python-and-javascript']}         | ${['python-and-javascript']}
+    `(
+        'that ! works for $languageId, contains $ignoreContains, $ignoreNotContains',
+        ({ languageId, ignoreContains, ignoreNotContains }) => {
+            const settings = {
+                enabled: true,
+                allowCompoundWords: false,
+                languageSettings: [],
+                ...mergeSettings({ languageSettings: defaultLanguageSettings }, extraSettings),
+            };
+            const s = calcUserSettingsForLanguage(settings, languageId);
+            expect(s.ignoreRegExpList).toEqual(expect.arrayContaining(ignoreContains));
+            expect(s.ignoreRegExpList).not.toEqual(expect.arrayContaining(ignoreNotContains));
+        }
+    );
 
     test('merged settings with global', () => {
         const merged = mergeSettings(getDefaultSettings(), getGlobalSettings());

--- a/packages/cspell-lib/src/Settings/LanguageSettings.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.ts
@@ -51,7 +51,7 @@ export function calcSettingsForLanguage(
     const allowedLocals = normalizeLocal(local);
     return defaultLanguageSettings
         .concat(languageSettings)
-        .filter((s) => !s.languageId || s.languageId === '*' || normalizeLanguageId(s.languageId).has(languageId))
+        .filter((s) => doesLanguageSettingMatchLanguageId(s, languageId))
         .filter((s) => !s.local || s.local === '*' || isLocalInSet(s.local, allowedLocals))
         .map((langSetting) => {
             const id = normalizeLanguageIdToString(langSetting.local || langSetting.languageId || 'language');
@@ -66,6 +66,17 @@ export function calcSettingsForLanguage(
             }),
             {}
         );
+}
+
+function doesLanguageSettingMatchLanguageId(s: LanguageSetting, languageId: LanguageId): boolean {
+    const languageSettingsLanguageIds = s.languageId;
+    if (!languageSettingsLanguageIds || languageSettingsLanguageIds === '*') return true;
+    const ids = normalizeLanguageId(languageSettingsLanguageIds);
+    if (ids.has(languageId)) return true;
+    if (ids.has('!' + languageId)) return false;
+
+    const numExcludes = [...ids].filter((id) => id.startsWith('!')).length;
+    return numExcludes === ids.size;
 }
 
 export function calcUserSettingsForLanguage(settings: CSpellUserSettings, languageId: string): CSpellUserSettings {


### PR DESCRIPTION
Support the the following:

```json
"languageSettings": [
    {
        "languageId": "!markdown",
        "flagWords": ["colour"]
    }
]
```

We means, forbid "colour" in all file types except `markdown`.