### PR TITLE
fix: issue cause by commit d1a7fa7

### DIFF
--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -318,7 +318,7 @@ describe('Validate Glob resolution', () => {
 
     test('normalized settings', () => {
         expect(sampleSettings).not.toEqual(sampleSettingsV1);
-        expect(sampleSettings.globRoot).toEqual(sampleSettingsV1.globRoot);
+        expect(sampleSettings.globRoot).not.toEqual(sampleSettingsV1.globRoot);
         expect(sampleSettings.globRoot).toBe(__dirname);
         expect(sampleSettingsV1.globRoot).toContain(process.cwd());
         expect(sampleSettings.ignorePaths).toEqual(
@@ -339,7 +339,7 @@ describe('Validate Glob resolution', () => {
         const settingsV1 = normalizeSettings(rawSampleSettingsV1, __filename);
 
         expect(settingsV).toEqual(sampleSettings);
-        expect(settingsV1).toEqual(sampleSettingsV1);
+        expect(settingsV1).not.toEqual(sampleSettingsV1);
 
         delete settingsV1.version;
         expect(settingsV1).toEqual(sampleSettings);

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -561,7 +561,7 @@ function mergeSources(left: CSpellSettings, right: CSpellSettings): Source {
     };
 }
 
-function max<T>(a: undefined, b: undefined): undefined;
+function max(a: undefined, b: undefined): undefined;
 function max<T>(a: T, b: undefined): T;
 function max<T>(a: undefined, b: T): T;
 function max<T>(a: T | undefined, b: T | undefined): T | undefined;
@@ -633,9 +633,6 @@ function resolveGlobRoot(settings: CSpellSettings, pathToSettingsFile: string): 
         settings.globRoot ??
         (settings.version === '0.1' || (envGlobRoot && !settings.version) ? defaultGlobRoot : settingsFileDir);
     const globRoot = path.resolve(settingsFileDir, rawRoot.replace('${cwd}', cwd));
-    if (settings.globRoot) return globRoot;
-    if (settingsFileDir.startsWith(globRoot)) return settingsFileDir;
-    if (globRoot.startsWith(settingsFileDir)) return settingsFileDir;
     return globRoot;
 }
 


### PR DESCRIPTION
See [fix: Adjust the way glob roots are calculated](https://github.com/streetsidesoftware/cspell/commit/d1a7fa78759257d692598bf712254201ed0dd126#commitcomment-47719278)

@timwsuqld I'm rolling back those changes from that commit.
It will not impact your "new" setup, but it will do a better job of preserving the old behavior.