### PR TITLE
feat: Support `packageProp` in `cosmiconfig`

### DIFF
--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -37,6 +37,7 @@ export const ENV_CSPELL_GLOB_ROOT = 'CSPELL_GLOB_ROOT';
  *   the `cspell.config.js`.
  */
 const searchPlaces = [
+    'package.json',
     // Original locations
     '.cspell.json',
     'cspell.json',
@@ -62,7 +63,6 @@ const searchPlaces = [
 ];
 
 const cspellCosmiconfig: CosmicOptions & CosmicOptionsSync = {
-    packageProp: 'cspell',
     searchPlaces,
     loaders: {
         '.json': (_filename: string, content: string) => json.parse(content),

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -62,6 +62,7 @@ const searchPlaces = [
 ];
 
 const cspellCosmiconfig: CosmicOptions & CosmicOptionsSync = {
+    packageProp: 'cspell',
     searchPlaces,
     loaders: {
         '.json': (_filename: string, content: string) => json.parse(content),


### PR DESCRIPTION
This PR adds support for the [`packageProp`](https://github.com/davidtheclark/cosmiconfig#packageprop) in [`cosmiconfig`](https://github.com/davidtheclark/cosmiconfig).

This feature enables developers to remove yet another boilerplate file from their apps.