### PR TITLE
ci: run lint on every pull_request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,27 +1,9 @@
 name: Lint
 on:
   pull_request:
-    paths:
-      - ".eslint*"
-      - ".prettier*"
-      - "**/*.js"
-      - "**/*.ts"
-      - "**/*.md"
-      - "**/*.json"
-      - "**/*.yml"
-      - "**/*.yaml"
   push:
-    paths:
-      - ".eslint*"
-      - ".prettier*"
-      - "**/*.js"
-      - "**/*.ts"
-      - "**/*.md"
-      - "**/*.json"
-      - "**/*.yml"
-      - "**/*.yaml"
-    branches-ignore:
-      - "dependabot/**"
+    branches:
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
The build was broken because a dependabot pull_request changed the eslint rules.