### PR TITLE
ci: Fix coverage upload breakage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,6 @@ jobs:
           path-to-lcov: ./lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2.0.1
+        uses: codecov/codecov-action@v1.5.2
         with:
           directory: ./packages/*/coverage/


### PR DESCRIPTION
Revert "build(deps): bump codecov/codecov-action from 1.5.2 to 2.0.1(#1438)"

This reverts commit 2f911009406dfc0f6689c03dbf08d7dfdce9841a.