### PR TITLE
feat: Support forbidden words in dictionaries

### DIFF
--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionary.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionary.ts
@@ -37,6 +37,7 @@ export interface SpellingDictionary {
     has(word: string, useCompounds: boolean): boolean;
     has(word: string, options: HasOptions): boolean;
     has(word: string, options?: HasOptions): boolean;
+    isForbidden(word: string): boolean;
     suggest(
         word: string,
         numSuggestions?: number,

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryFromTrie.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryFromTrie.ts
@@ -85,6 +85,11 @@ export class SpellingDictionaryFromTrie implements SpellingDictionary {
         }
         return false;
     }
+
+    public isForbidden(word: string): boolean {
+        return this.trie.isForbiddenWord(word);
+    }
+
     public suggest(
         word: string,
         numSuggestions?: number,

--- a/packages/cspell-lib/src/SpellingDictionary/createSpellingDictionary.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/createSpellingDictionary.ts
@@ -24,6 +24,7 @@ export function createFailedToLoadDictionary(error: SpellingDictionaryLoadError)
         source,
         type: 'error',
         has: () => false,
+        isForbidden: () => false,
         suggest: () => [],
         mapWord: (a) => a,
         genSuggestions: () => {

--- a/packages/cspell-lib/src/trace.ts
+++ b/packages/cspell-lib/src/trace.ts
@@ -7,6 +7,7 @@ import { genSequence } from 'gensequence';
 export interface TraceResult {
     word: string;
     found: boolean;
+    forbidden: boolean;
     dictName: string;
     dictSource: string;
     configSource: string;
@@ -50,6 +51,7 @@ export async function traceWords(words: string[], settings: CSpellSettings): Pro
             return dicts.dictionaries.map((dict) => ({
                 word,
                 found: dict.has(word),
+                forbidden: dict.isForbidden(word),
                 dictName: dict.name,
                 dictSource: dict.source,
                 configSource: config.name || '',

--- a/packages/cspell-lib/src/util/Memorizer.test.ts
+++ b/packages/cspell-lib/src/util/Memorizer.test.ts
@@ -20,25 +20,49 @@ describe('Validate Memorizer', () => {
         fnTest(0, 1, 5);
     });
 
-    test('cache reset', () => {
+    test('cache reset dual cache', () => {
         const counts = new Map<number, number>();
         const fn = (a: number) => {
-            counts.set(a, (counts.get(a) || 0) + 1);
-            return a;
+            const v = (counts.get(a) || 0) + 1;
+            counts.set(a, v);
+            return v;
         };
         const calc = memorizer(fn, 2);
-        const fnTest = (v: number, expected: number, repeat: number) => {
-            for (; repeat > 0; repeat--) {
-                expect(calc(v)).toBe(v);
-                expect(counts.get(v)).toBe(expected);
-            }
-        };
+        expect(calc(5)).toBe(1);
+        expect(calc(5)).toBe(1);
+        expect(calc(6)).toBe(1);
+        expect(calc(0)).toBe(1);
+        expect(calc(0)).toBe(1);
+        expect(calc(5)).toBe(1);
+        expect(calc(6)).toBe(1);
+        expect(calc(0)).toBe(1);
+    });
+});
 
-        fnTest(5, 1, 5);
-        fnTest(6, 1, 5);
-        fnTest(0, 1, 5);
-        fnTest(5, 2, 5);
-        fnTest(6, 2, 5);
-        fnTest(0, 2, 5);
+describe('Validate Memorizer Dual Cache', () => {
+    const counts = new Map<string, number>();
+    const fn = (a: string) => {
+        const v = (counts.get(a) || 0) + 1;
+        counts.set(a, v);
+        return v;
+    };
+    const calc = memorizer(fn, 2);
+
+    test.each`
+        value  | expected
+        ${'a'} | ${1}
+        ${'b'} | ${1}
+        ${'c'} | ${1}
+        ${'b'} | ${1}
+        ${'a'} | ${1}
+        ${'c'} | ${1}
+        ${'d'} | ${1}
+        ${'e'} | ${1}
+        ${'a'} | ${1}
+        ${'b'} | ${2}
+        ${'c'} | ${2}
+    `('cache reset dual cache $value $expected', ({ value, expected }) => {
+        expect(calc(value)).toBe(expected);
+        expect(calc(value)).toBe(expected);
     });
 });

--- a/packages/cspell-lib/src/util/Memorizer.ts
+++ b/packages/cspell-lib/src/util/Memorizer.ts
@@ -1,22 +1,71 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultSize = 50000;
 
-export function memorizer<A0, T>(fn: (arg: A0) => T, size?: number): (arg0: A0) => T;
-export function memorizer<A0, A1, T>(fn: (arg: A0, arg1: A1) => T, size?: number): (arg0: A0, arg1: A1) => T;
-export function memorizer<A0, A1, A2, T>(
-    fn: (arg: A0, arg1: A1, arg2: A2) => T,
-    size?: number
-): (arg0: A0, arg1: A1, arg2: A2) => T;
-export function memorizer<A, T>(fn: (...args: A[]) => T, size: number = defaultSize): (...args: A[]) => T {
-    const cache = new Map<string, T>();
-    return (...args: A[]) => {
-        const key = args.join('>!@[');
-        if (!cache.has(key)) {
-            if (cache.size >= size) {
-                cache.clear();
-            }
-            cache.set(key, fn(...args));
+/** Only types that can be easily turned into strings */
+type P0 = string | number | boolean | RegExp | undefined;
+
+type Primitive = P0 | P0[];
+
+/**
+ * Memorize the result of a function call to be returned on later calls with the same parameters.
+ *
+ * Note: The parameters are converted into a string: `key = args.join('>!@[')`
+ *
+ * For speed, it keeps two caches, L0 and L1. Each cache can contain up to `size` values. But that actual number
+ * of cached values is between `size + 1` and `size * 2`.
+ *
+ * Caches are NOT sorted. Items are added to L0 until it is full. Once it is full, L1 takes over L0's values and L0 is cleared.
+ *
+ * If an item is not found in L0, L1 is checked before calling the `fn` and the resulting value store in L0.
+ *
+ * @param fn - function to be called.
+ * @param size - size of cache
+ */
+export function memorizer<
+    F extends (...args: Primitive[]) => any,
+    Args extends Parameters<F> = Parameters<F>,
+    R extends ReturnType<F> = ReturnType<F>
+>(fn: F, size?: number): (...args: Args) => R {
+    return memorizerKeyBy(fn, (...args: Args) => args.join('>!@['), size);
+}
+
+/**
+ * Memorize the result of a function call to be returned on later calls with the same parameters.
+ *
+ * Note: `keyFn` is use to convert the function parameters into a string to look up in the cache.
+ *
+ * For speed, it keeps two caches, L0 and L1. Each cache can contain up to `size` values. But that actual number
+ * of cached values is between `size + 1` and `size * 2`.
+ *
+ * Caches are NOT sorted. Items are added to L0 until it is full. Once it is full, L1 takes over L0's values and L0 is cleared.
+ *
+ * If an item is not found in L0, L1 is checked before calling the `fn` and the resulting value store in L0.
+ *
+ * @param fn - function to be memorized
+ * @param keyFn - extracts a `key` value from the arguments to `fn` to be used as the key to the cache
+ * @param size - size of the cache.
+ * @returns A function
+ */
+export function memorizerKeyBy<
+    F extends (...args: any[]) => any,
+    Args extends Parameters<F> = Parameters<F>,
+    R extends ReturnType<F> = ReturnType<F>
+>(fn: F, keyFn: (...args: Args) => string, size: number = defaultSize): (...args: Args) => R {
+    let count = 0;
+    let cacheL0: Record<string, R> = Object.create(null);
+    let cacheL1: Record<string, R> = Object.create(null);
+    return (...args: Args) => {
+        const key = keyFn(...args);
+        if (key in cacheL0) return cacheL0[key];
+
+        const v = key in cacheL1 ? cacheL1[key] : fn(...args);
+        if (count >= size) {
+            cacheL1 = cacheL0;
+            cacheL0 = Object.create(null);
+            count = 0;
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return cache.get(key)!;
+        cacheL0[key] = v;
+        ++count;
+        return v;
     };
 }

--- a/packages/cspell-lib/src/validator.ts
+++ b/packages/cspell-lib/src/validator.ts
@@ -1,16 +1,14 @@
-import * as Text from './util/text';
-import * as Dictionary from './SpellingDictionary';
+import { CSpellUserSettings } from '@cspell/cspell-types';
 import * as Settings from './Settings';
+import * as Dictionary from './SpellingDictionary';
+import { CompoundWordsMethod } from './SpellingDictionary';
+import * as TV from './textValidator';
 
 export const diagSource = 'cSpell Checker';
 
-import { CSpellUserSettings } from '@cspell/cspell-types';
-import * as TV from './textValidator';
-import { CompoundWordsMethod } from './SpellingDictionary';
-
 export { IncludeExcludeOptions } from './textValidator';
 
-export interface ValidationIssue extends Text.TextOffset {
+export interface ValidationIssue extends TV.ValidationResult {
     suggestions?: string[];
 }
 

--- a/packages/cspell/cSpell.json
+++ b/packages/cspell/cSpell.json
@@ -9,13 +9,13 @@
     ],
     "maxNumberOfProblems": 1000,
     "ignorePaths": [
+        "*.snap",
         "node_modules",
-        "**/*.d.ts",
+        "package-lock.json",
         "coverage/**",
         "dist/**",
         "package.json",
-        "**/package.json",
-        "**/.cspell.json",
+        ".cspell.json",
         ".vscode/**"
     ],
     "dictionaryDefinitions": [

--- a/packages/cspell/samples/.cspell.json
+++ b/packages/cspell/samples/.cspell.json
@@ -14,6 +14,7 @@
     ],
     "maxNumberOfProblems": 10000,
     "ignorePaths": [
+        "forbidden-words.txt",
         "dictionaries/**",
         "node_modules/**",
         "vscode-extension/**",
@@ -26,7 +27,15 @@
     "flagWords": [
         "hte"
     ],
-    "dictionaryDefinitions": [],
+    "dictionaryDefinitions": [
+        {
+            "name": "forbidden-words",
+            "path": "./forbidden-words.txt"
+        }
+    ],
+    "dictionaries": [
+        "forbidden-words"
+    ],
     "languageSettings": [
         {
             // VSCode languageId. i.e. typescript, java, go, cpp, javascript, markdown, latex

--- a/packages/cspell/samples/forbidden-words.txt
+++ b/packages/cspell/samples/forbidden-words.txt
@@ -1,0 +1,3 @@
+!behaviour
+!flavour
+!colour

--- a/packages/cspell/samples/src/sample-with-forbidden-words.md
+++ b/packages/cspell/samples/src/sample-with-forbidden-words.md
@@ -1,0 +1,5 @@
+# Sample of text with Forbidden Words
+
+- behaviour
+- flavour
+- colour

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -212,13 +212,13 @@ info	Config Files Found:
 info	    ./cspell.json
 info	
 info	Exclusion Globs: 
+info	    Glob: *.snap from ./cspell.json
 info	    Glob: node_modules from ./cspell.json
-info	    Glob: **/*.d.ts from ./cspell.json
+info	    Glob: package-lock.json from ./cspell.json
 info	    Glob: coverage/** from ./cspell.json
 info	    Glob: dist/** from ./cspell.json
 info	    Glob: package.json from ./cspell.json
-info	    Glob: **/package.json from ./cspell.json
-info	    Glob: **/.cspell.json from ./cspell.json
+info	    Glob: .cspell.json from ./cspell.json
 info	    Glob: .vscode/** from ./cspell.json
 info	    Glob: node_modules/** from command line
 info	
@@ -564,6 +564,16 @@ log	./samples/text.txt:3:23 - Unknown word (everyline)
 log	./samples/text.txt:5:24 - Unknown word (okkk)
 log	./samples/text.txt:5:32 - Unknown word (reead)
 error	CSpell: Files checked: 6, Issues found: 7 in 1 files"
+`;
+
+exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 1`] = `Array []`;
+
+exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 2`] = `
+"error	1/1 ./samples/src/sample-with-forbidden-words.md 0.00ms X
+log	./samples/src/sample-with-forbidden-words.md:3:3 - Forbidden word (behaviour)
+log	./samples/src/sample-with-forbidden-words.md:4:3 - Forbidden word (flavour)
+log	./samples/src/sample-with-forbidden-words.md:5:3 - Forbidden word (colour)
+error	CSpell: Files checked: 1, Issues found: 3 in 1 files"
 `;
 
 exports[`Validate cli app with spelling errors --debug Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -125,6 +125,7 @@ describe('Validate cli', () => {
         ${'check with spelling errors'}                | ${['check', pathSamples('Dutch.txt')]}                                     | ${app.CheckFailed} | ${false} | ${true}  | ${false}
         ${'LICENSE'}                                   | ${[pathRoot('LICENSE')]}                                                   | ${undefined}       | ${true}  | ${false} | ${false}
         ${'samples/Dutch.txt'}                         | ${[pathSamples('Dutch.txt')]}                                              | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
+        ${'with forbidden words'}                      | ${[pathSamples('src/sample-with-forbidden-words.md')]}                     | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
         ${'current_file --verbose'}                    | ${['--verbose', __filename]}                                               | ${undefined}       | ${true}  | ${false} | ${true}
         ${'bad config'}                                | ${['-c', __filename, __filename]}                                          | ${app.CheckFailed} | ${true}  | ${false} | ${false}
         ${'not found error by default'}                | ${['*.not']}                                                               | ${app.CheckFailed} | ${true}  | ${false} | ${false}

--- a/packages/cspell/src/emitters.ts
+++ b/packages/cspell/src/emitters.ts
@@ -3,6 +3,7 @@ import { TextDocumentOffset, TextOffset } from 'cspell-lib';
 export interface Issue extends TextDocumentOffset {
     /** text surrounding the issue text */
     context: TextOffset;
+    isFlagged?: boolean;
     suggestions?: string[];
 }
 

--- a/packages/cspell/src/lint.ts
+++ b/packages/cspell/src/lint.ts
@@ -11,6 +11,7 @@ import { measurePromise } from './util/timer';
 import { extractPatterns, buildGlobMatcher, normalizeGlobsToRoot, extractGlobsFromMatcher } from './util/glob';
 import { GlobMatcher, GlobPatternNormalized, GlobPatternWithRoot } from 'cspell-glob';
 import { URI } from 'vscode-uri';
+import { ValidationIssue } from '../../cspell-lib/dist/validator';
 
 export interface FileResult {
     fileInfo: FileInfo;
@@ -81,7 +82,7 @@ export function runLint(cfg: CSpellApplicationConfiguration): Promise<RunResult>
         return result;
     }
 
-    function mapIssue(tdo: TextDocumentOffset): Issue {
+    function mapIssue(tdo: TextDocumentOffset & ValidationIssue): Issue {
         const context = cfg.showContext
             ? extractContext(tdo, cfg.showContext)
             : { text: tdo.line.text.trimEnd(), offset: tdo.line.offset };


### PR DESCRIPTION
## Making Words Forbidden

There are several ways to mark a word as forbidden:

1. In a custom word list with words beginning with `!`.
    ```
    !forbiddenWord
    ```
2. In `words` section of `cspell` configuration:
    ```
    "words": [
        "!forbiddenWord",
        "configstore"
    ],
    ```
3. In `flagWords` section of `cspell` configuration:
    ```
    "flagWords": ["forbiddenWord"]
    ```

## Overriding Forbidden words
Sometimes it is necessary to allow a word even if it is forbidden.

### In a comment

```js
/**
 * Do not mark `forbiddenWord` as incorrect.
 * cspell:ignore forbiddenWord
 */
```

### In the `cspell` configuration

```jsonc
{
    "ignoreWords": ["forbiddenWord"]
}
```
