### PR TITLE
dev: make sure cspell config files use version "0.2"

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -31,7 +31,7 @@
     },
     "DictionaryDefinitionAlternate": {
       "additionalProperties": false,
-      "deprecatedMessage": "Use `DictionaryDefinitionPreferred`",
+      "deprecationMessage": "Use `DictionaryDefinitionPreferred`",
       "description": "Only for legacy dictionary definitions",
       "properties": {
         "description": {
@@ -40,7 +40,7 @@
         },
         "file": {
           "$ref": "#/definitions/DictionaryPath",
-          "deprecatedMessage": "Use `path` instead.",
+          "deprecationMessage": "Use `path` instead.",
           "description": "Path to the file, only for legacy dictionary definitions"
         },
         "name": {
@@ -268,7 +268,7 @@
               "type": "array"
             }
           ],
-          "deprecatedMessage": "Use `locale` instead",
+          "deprecationMessage": "Use `locale` instead",
           "description": "Deprecated - The locale filter, matches against the language. This can be a comma separated list. \"*\" will match all locales."
         },
         "locale": {
@@ -587,6 +587,27 @@
     "SimpleGlob": {
       "description": "Simple Glob string, the root will be globRoot",
       "type": "string"
+    },
+    "Version": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VersionLatest"
+        },
+        {
+          "$ref": "#/definitions/VersionLegacy"
+        }
+      ]
+    },
+    "VersionLatest": {
+      "const": "0.2",
+      "description": "Configuration File Version",
+      "type": "string"
+    },
+    "VersionLegacy": {
+      "const": "0.1",
+      "deprecationMessage": "Use `0.2`",
+      "description": "Legacy Configuration File Versions",
+      "type": "string"
     }
   },
   "properties": {
@@ -797,13 +818,9 @@
       "type": "array"
     },
     "version": {
+      "$ref": "#/definitions/Version",
       "default": "0.2",
-      "description": "Configuration format version of the settings file.",
-      "enum": [
-        "0.2",
-        "0.1"
-      ],
-      "type": "string"
+      "description": "Configuration format version of the settings file."
     },
     "words": {
       "description": "list of words to be always considered correct",

--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -174,17 +174,17 @@
     },
     "LanguageIdMultiple": {
       "description": "This can be 'typescript,cpp,json,literal haskell', etc.",
-      "pattern": "^([\\w_\\-\\s]+)(,[\\w_\\-\\s]+)*$",
+      "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
       "type": "string"
     },
     "LanguageIdMultipleNeg": {
       "description": "This can be 'typescript,cpp,json,literal haskell', etc.",
-      "pattern": "^(![\\w_\\-\\s]+)(,![\\w_\\-\\s]+)*$",
+      "pattern": "^(![-\\w_\\s]+)(,![-\\w_\\s]+)*$",
       "type": "string"
     },
     "LanguageIdSingle": {
       "description": "This can be '*', 'typescript', 'cpp', 'json', etc.",
-      "pattern": "^(!?[\\w_\\-\\s]+)|(\\*)$",
+      "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
       "type": "string"
     },
     "LanguageSetting": {

--- a/integration-tests/cspell.json
+++ b/integration-tests/cspell.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "ignorePaths": [
         "repositories/**",
         "snapshots/**",

--- a/packages/Samples/tests/exclude_dictionary/cspell.json
+++ b/packages/Samples/tests/exclude_dictionary/cspell.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "language": "en",
     "dictionaries": [
         "!softwareTerms"

--- a/packages/cspell-lib/docs/configuration.md
+++ b/packages/cspell-lib/docs/configuration.md
@@ -1,4 +1,4 @@
-# cspell Configuration
+# CSpell Configuration Files
 
 ## Supported Configuration Files
 

--- a/packages/cspell-lib/samples/.cspell.json
+++ b/packages/cspell-lib/samples/.cspell.json
@@ -1,7 +1,7 @@
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "description": "Sample .cspell.json file with comments.",
     // language - current active spelling language
     "language": "en",

--- a/packages/cspell-lib/samples/comments_only/cpp_strings_and_comments.cspell.json
+++ b/packages/cspell-lib/samples/comments_only/cpp_strings_and_comments.cspell.json
@@ -1,10 +1,13 @@
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "dictionaryDefinitions": [
         // re-define the cpp dictionary to prevent it from loading (this is up to you)
-        {"name": "cpp", "file": ""}
+        {
+            "name": "cpp",
+            "file": ""
+        }
     ],
     // Settings per language
     "languageSettings": [

--- a/packages/cspell-lib/samples/linked/cspell-dutch.json
+++ b/packages/cspell-lib/samples/linked/cspell-dutch.json
@@ -1,6 +1,6 @@
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "words": [
         "leuk",
         "lopen",

--- a/packages/cspell-lib/samples/linked/cspell-imports.json
+++ b/packages/cspell-lib/samples/linked/cspell-imports.json
@@ -1,6 +1,6 @@
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "import": [
         "cspell-import.json",
         "./cspell-dutch.json"

--- a/packages/cspell-tools/cSpell.json
+++ b/packages/cspell-tools/cSpell.json
@@ -1,7 +1,7 @@
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     // language - current active spelling language
     "language": "en",
     // words - list of words to be always considered correct

--- a/packages/cspell-types/ajv.config.js
+++ b/packages/cspell-types/ajv.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const keywords = ['deprecatedMessage', 'markdownDescription', 'scope'];
+const keywords = ['deprecationMessage', 'markdownDescription', 'scope'];
 
 function addKeywords(ajv) {
     for (const keyword of keywords) {

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -31,7 +31,7 @@
     },
     "DictionaryDefinitionAlternate": {
       "additionalProperties": false,
-      "deprecatedMessage": "Use `DictionaryDefinitionPreferred`",
+      "deprecationMessage": "Use `DictionaryDefinitionPreferred`",
       "description": "Only for legacy dictionary definitions",
       "properties": {
         "description": {
@@ -40,7 +40,7 @@
         },
         "file": {
           "$ref": "#/definitions/DictionaryPath",
-          "deprecatedMessage": "Use `path` instead.",
+          "deprecationMessage": "Use `path` instead.",
           "description": "Path to the file, only for legacy dictionary definitions"
         },
         "name": {
@@ -268,7 +268,7 @@
               "type": "array"
             }
           ],
-          "deprecatedMessage": "Use `locale` instead",
+          "deprecationMessage": "Use `locale` instead",
           "description": "Deprecated - The locale filter, matches against the language. This can be a comma separated list. \"*\" will match all locales."
         },
         "locale": {
@@ -587,6 +587,27 @@
     "SimpleGlob": {
       "description": "Simple Glob string, the root will be globRoot",
       "type": "string"
+    },
+    "Version": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VersionLatest"
+        },
+        {
+          "$ref": "#/definitions/VersionLegacy"
+        }
+      ]
+    },
+    "VersionLatest": {
+      "const": "0.2",
+      "description": "Configuration File Version",
+      "type": "string"
+    },
+    "VersionLegacy": {
+      "const": "0.1",
+      "deprecationMessage": "Use `0.2`",
+      "description": "Legacy Configuration File Versions",
+      "type": "string"
     }
   },
   "properties": {
@@ -797,13 +818,9 @@
       "type": "array"
     },
     "version": {
+      "$ref": "#/definitions/Version",
       "default": "0.2",
-      "description": "Configuration format version of the settings file.",
-      "enum": [
-        "0.2",
-        "0.1"
-      ],
-      "type": "string"
+      "description": "Configuration format version of the settings file."
     },
     "words": {
       "description": "list of words to be always considered correct",

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -174,17 +174,17 @@
     },
     "LanguageIdMultiple": {
       "description": "This can be 'typescript,cpp,json,literal haskell', etc.",
-      "pattern": "^([\\w_\\-\\s]+)(,[\\w_\\-\\s]+)*$",
+      "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
       "type": "string"
     },
     "LanguageIdMultipleNeg": {
       "description": "This can be 'typescript,cpp,json,literal haskell', etc.",
-      "pattern": "^(![\\w_\\-\\s]+)(,![\\w_\\-\\s]+)*$",
+      "pattern": "^(![-\\w_\\s]+)(,![-\\w_\\s]+)*$",
       "type": "string"
     },
     "LanguageIdSingle": {
       "description": "This can be '*', 'typescript', 'cpp', 'json', etc.",
-      "pattern": "^(!?[\\w_\\-\\s]+)|(\\*)$",
+      "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
       "type": "string"
     },
     "LanguageSetting": {

--- a/packages/cspell-types/package.json
+++ b/packages/cspell-types/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rimraf dist coverage",
     "build": "npm run compile && npm run build-schema",
-    "build-schema": "ts-json-schema-generator --no-top-ref --path src/settings/CSpellSettingsDef.ts --type CSpellSettings --validation-keywords markdownDescription  --validation-keywords scope --validation-keywords deprecated --validation-keywords deprecatedMessage -o  ./cspell.schema.json && cp ./cspell.schema.json ../..",
+    "build-schema": "ts-json-schema-generator --no-top-ref --path src/settings/CSpellSettingsDef.ts --type CSpellSettings --validation-keywords markdownDescription  --validation-keywords scope --validation-keywords deprecated --validation-keywords deprecationMessage -o  ./cspell.schema.json && cp ./cspell.schema.json ../..",
     "clean-build": "npm run clean && npm run build",
     "compile": "tsc -p .",
     "test-schema": "ajv -s ./cspell.schema.json -d \"cspell.test.{json,yaml}\" -c ./ajv.config.js",

--- a/packages/cspell-types/src/settings/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/settings/CSpellSettingsDef.ts
@@ -29,7 +29,7 @@ export interface FileSettings extends ExtendableSettings {
      * Configuration format version of the settings file.
      * @default "0.2"
      */
-    version?: '0.2' | '0.1';
+    version?: Version;
 
     /** Words to add to global dictionary -- should only be in the user config file. */
     userWords?: string[];
@@ -318,7 +318,7 @@ export interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase 
     /**
      * Only for legacy dictionary definitions
      * @deprecated
-     * @deprecatedMessage Use `path` instead.
+     * @deprecationMessage Use `path` instead.
      * @hidden
      */
     file?: undefined;
@@ -327,7 +327,7 @@ export interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase 
 /**
  * Only for legacy dictionary definitions
  * @deprecated
- * @deprecatedMessage Use `DictionaryDefinitionPreferred`
+ * @deprecationMessage Use `DictionaryDefinitionPreferred`
  */
 export interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase {
     /** @hidden */
@@ -336,7 +336,7 @@ export interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase 
     /**
      * Path to the file, only for legacy dictionary definitions
      * @deprecated
-     * @deprecatedMessage Use `path` instead.
+     * @deprecationMessage Use `path` instead.
      */
     file: DictionaryPath;
 }
@@ -351,7 +351,7 @@ export interface DictionaryDefinitionLegacy extends DictionaryDefinitionBase {
     /**
      * File name
      * @deprecated
-     * @deprecatedMessage Use path instead.
+     * @deprecationMessage Use path instead.
      */
     file: FsPath;
     /**
@@ -413,7 +413,7 @@ export interface LanguageSettingFilterFieldsDeprecated {
     /**
      * Deprecated - The locale filter, matches against the language. This can be a comma separated list. "*" will match all locales.
      * @deprecated
-     * @deprecatedMessage Use `locale` instead
+     * @deprecationMessage Use `locale` instead
      */
     local?: LocaleId | LocaleId[];
 }
@@ -465,8 +465,22 @@ export type DictionaryId = string;
 export type LocaleId = string;
 
 /**
+ * Configuration File Version
+ */
+export type VersionLatest = '0.2';
+
+/**
+ * Legacy Configuration File Versions
  * @deprecated
- * @deprecatedMessage Use LocaleId instead
+ * @deprecationMessage Use `0.2`
+ */
+export type VersionLegacy = '0.1';
+
+export type Version = VersionLatest | VersionLegacy;
+
+/**
+ * @deprecated
+ * @deprecationMessage Use LocaleId instead
  */
 export type LocalId = LocaleId;
 

--- a/packages/cspell-types/src/settings/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/settings/CSpellSettingsDef.ts
@@ -498,19 +498,19 @@ export interface GlobDef {
 
 /**
  * This can be '*', 'typescript', 'cpp', 'json', etc.
- * @pattern ^(!?[\w_\-\s]+)|(\*)$
+ * @pattern ^(!?[-\w_\s]+)|(\*)$
  */
 export type LanguageIdSingle = string;
 
 /**
  * This can be 'typescript,cpp,json,literal haskell', etc.
- * @pattern ^([\w_\-\s]+)(,[\w_\-\s]+)*$
+ * @pattern ^([-\w_\s]+)(,[-\w_\s]+)*$
  */
 export type LanguageIdMultiple = string;
 
 /**
  * This can be 'typescript,cpp,json,literal haskell', etc.
- * @pattern ^(![\w_\-\s]+)(,![\w_\-\s]+)*$
+ * @pattern ^(![-\w_\s]+)(,![-\w_\s]+)*$
  */
 export type LanguageIdMultipleNeg = string;
 

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -406,21 +406,29 @@ const companyName = 'Lorem ipsum dolor sit amet';
 
 _cspell_'s behavior can be controlled through a config file. By default it looks for any of the following files:
 
-- `cspell.json`
 - `.cspell.json`
+- `cspell.json`
+- `.cSpell.json`
 - `cSpell.json`
+- `cspell.config.js`
+- `cspell.config.cjs`
+- `cspell.config.json`
+- `cspell.config.yaml`
+- `cspell.config.yml`
+- `cspell.yaml`
+- `cspell.yml`
 
 Or you can specify a path to a config file with the `--config <path>` argument on the command line.
 
-### cSpell.json
+### `cspell.json`
 
-#### Example _cSpell.json_ file
+#### Example `cspell.json` file
 
 ```javascript
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     // language - current active spelling language
     "language": "en",
     // words - list of words to be always considered correct

--- a/packages/cspell/samples/comments_only/cpp_strings_and_comments.cspell.json
+++ b/packages/cspell/samples/comments_only/cpp_strings_and_comments.cspell.json
@@ -1,10 +1,13 @@
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "dictionaryDefinitions": [
         // re-define the cpp dictionary to prevent it from loading (this is up to you)
-        {"name": "cpp", "file": ""}
+        {
+            "name": "cpp",
+            "file": ""
+        }
     ],
     // Settings per language
     "languageSettings": [

--- a/packages/cspell/samples/linked/cspell-dutch.json
+++ b/packages/cspell/samples/linked/cspell-dutch.json
@@ -1,6 +1,6 @@
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "words": [
         "leuk",
         "lopen",

--- a/packages/cspell/samples/linked/cspell-imports.json
+++ b/packages/cspell/samples/linked/cspell-imports.json
@@ -1,6 +1,6 @@
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     "import": [
         "cspell-import.json",
         "./cspell-dutch.json"


### PR DESCRIPTION
* dev: make sure cspell config file version is "0.2"
* fix: Improve config docs
* Use `deprecationMessage` instead of `deprecatedMessage`
   See: [deprecatedMessage renamed to deprecationMessage · Issue #16409 · microsoft/vscode](https://github.com/microsoft/vscode/issues/16409)