### PR TITLE
fix: fix slow suggestions with some dictionaries

### DIFF
--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -525,6 +525,8 @@ describe('Validate search/load config files', () => {
         ${s('js-config/cspell-no-export.js')} | ${cfg(s('js-config/cspell-no-export.js'))}
         ${s('js-config/cspell-bad.js')}       | ${cfg(readError(s('js-config/cspell-bad.js')))}
     `('ReadRawSettings from $file', async ({ file, expectedConfig }: TestLoadConfig) => {
+        // js-config/cspell-no-export.js logs a message.
+        jest.spyOn(console, 'log').mockImplementation(() => undefined);
         const searchResult = await readRawSettings(file);
         expect(searchResult).toEqual(expectedConfig ? expect.objectContaining(expectedConfig) : undefined);
     });

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryFromTrie.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryFromTrie.ts
@@ -170,8 +170,9 @@ export class SpellingDictionaryFromTrie implements SpellingDictionary {
 
     public genSuggestions(collector: SuggestionCollector, suggestOptions: SuggestOptions): void {
         if (this.options.noSuggest) return;
-        const { compoundMethod = CompoundWordsMethod.SEPARATE_WORDS } = suggestOptions;
-        const _compoundMethod = this.options.useCompounds ? CompoundWordsMethod.JOIN_WORDS : compoundMethod;
+        const _compoundMethod =
+            suggestOptions.compoundMethod ??
+            (this.options.useCompounds ? CompoundWordsMethod.JOIN_WORDS : CompoundWordsMethod.NONE);
         wordSuggestFormsArray(collector.word).forEach((w) =>
             this.trie.genSuggestions(impersonateCollector(collector, w), _compoundMethod)
         );


### PR DESCRIPTION
fix issue where some dictionaries (nl-nl) could cause slow suggestions

Using compound words can be very very slow to generate suggestions.
The current Dutch dictionary has compounds turned on. This caused very very slow suggestions to be generated.