### PR TITLE
test: fix github-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         node-version:
           # Test the latest node version here, move older versions to `test-old-node-versions`
-          - 16.x
+          - "16.8.0" # Bug [`Check failed: !holder_map.has_named_interceptor().` when running `jest` · Issue #40030 · nodejs/node](https://github.com/nodejs/node/issues/40030)
 
         os:
           - ubuntu-latest


### PR DESCRIPTION
Related to:
* [`Check failed: !holder_map.has_named_interceptor().` when running `jest` · Issue #40030 · nodejs/node](https://github.com/nodejs/node/issues/40030)