### PR TITLE
enable incremental typescript builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,7 @@ typings/
 # Do not check sensitive files.
 .coveralls.yml
 
+# typescript incremental builds cache
+.tsbuildinfo
+
 # cspell:ignore pids jscoverage wscript jspm dotenv eslintcache

--- a/packages/cspell-bundled-dicts/tsconfig.json
+++ b/packages/cspell-bundled-dicts/tsconfig.json
@@ -60,6 +60,8 @@
         // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
         /* Advanced Options */
         "skipLibCheck": true, /* Skip type checking of declaration files. */
-        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
     }
 }

--- a/packages/cspell-dynamic-loader/tsconfig.json
+++ b/packages/cspell-dynamic-loader/tsconfig.json
@@ -19,7 +19,9 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"outDir": "dist",
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/cspell-glob/.npmignore
+++ b/packages/cspell-glob/.npmignore
@@ -22,3 +22,6 @@
 tsconfig.json
 jest.config.js
 *.log
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-glob/tsconfig.json
+++ b/packages/cspell-glob/tsconfig.json
@@ -13,7 +13,9 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"outDir": "dist",
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/cspell-io/.npmignore
+++ b/packages/cspell-io/.npmignore
@@ -22,3 +22,6 @@
 tsconfig.json
 jest.config.js
 *.log
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-io/tsconfig.json
+++ b/packages/cspell-io/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/packages/cspell-lib/.npmignore
+++ b/packages/cspell-lib/.npmignore
@@ -4,3 +4,6 @@ __mocks__
 **/*.test.*
 **/*.spec.*
 **/*.map
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-lib/tsconfig.json
+++ b/packages/cspell-lib/tsconfig.json
@@ -14,7 +14,9 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"outDir": "dist",
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/cspell-tools/.npmignore
+++ b/packages/cspell-tools/.npmignore
@@ -22,3 +22,6 @@
 tsconfig.json
 jest.config.js
 *.log
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-tools/tsconfig.json
+++ b/packages/cspell-tools/tsconfig.json
@@ -11,7 +11,9 @@
 		"noImplicitAny": true,
 		"noImplicitThis": true,
 		"strictNullChecks": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/packages/cspell-trie-lib/.npmignore
+++ b/packages/cspell-trie-lib/.npmignore
@@ -22,3 +22,6 @@
 tsconfig.json
 jest.config.js
 *.log
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-trie-lib/tsconfig.json
+++ b/packages/cspell-trie-lib/tsconfig.json
@@ -13,7 +13,9 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/packages/cspell-trie/.npmignore
+++ b/packages/cspell-trie/.npmignore
@@ -22,3 +22,6 @@
 tsconfig.json
 jest.config.js
 *.log
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-trie/tsconfig.json
+++ b/packages/cspell-trie/tsconfig.json
@@ -13,7 +13,9 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/packages/cspell-trie2-lib/.npmignore
+++ b/packages/cspell-trie2-lib/.npmignore
@@ -22,3 +22,6 @@
 tsconfig.json
 jest.config.js
 *.log
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell-trie2-lib/tsconfig.json
+++ b/packages/cspell-trie2-lib/tsconfig.json
@@ -13,7 +13,9 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/packages/cspell-types/tsconfig.json
+++ b/packages/cspell-types/tsconfig.json
@@ -19,7 +19,9 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"outDir": "dist",
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/cspell/.npmignore
+++ b/packages/cspell/.npmignore
@@ -4,3 +4,6 @@ __mocks__
 **/*.test.*
 **/*.spec.*
 **/*.map
+
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/cspell/tsconfig.json
+++ b/packages/cspell/tsconfig.json
@@ -19,7 +19,9 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"outDir": "dist",
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/hunspell-reader/.npmignore
+++ b/packages/hunspell-reader/.npmignore
@@ -12,3 +12,5 @@ tsconfig.json
 tslint.json
 typings.json
 
+# typescript incremental builds cache
+.tsbuildinfo

--- a/packages/hunspell-reader/tsconfig.json
+++ b/packages/hunspell-reader/tsconfig.json
@@ -15,7 +15,9 @@
         "preserveConstEnums": false,
         "outDir": "dist",
         "lib": ["dom", "dom.iterable", "es2015"],
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
     },
     "exclude": ["node_modules", "dist"]
 }

--- a/test-packages/test-cspell-glob/tsconfig.json
+++ b/test-packages/test-cspell-glob/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/test-packages/test-cspell-io/tsconfig.json
+++ b/test-packages/test-cspell-io/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/test-packages/test-cspell-lib-webpack/tsconfig.json
+++ b/test-packages/test-cspell-lib-webpack/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/test-packages/test-cspell-lib/tsconfig.json
+++ b/test-packages/test-cspell-lib/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/test-packages/test-cspell-tools/tsconfig.json
+++ b/test-packages/test-cspell-tools/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"

--- a/test-packages/test-cspell/tsconfig.json
+++ b/test-packages/test-cspell/tsconfig.json
@@ -16,7 +16,9 @@
 		"forceConsistentCasingInFileNames": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"outDir": "dist"
+		"outDir": "dist",
+		"incremental": true,
+    	"tsBuildInfoFile": "./.tsbuildinfo"
 	},
 	"include": [
 		"src"


### PR DESCRIPTION
TypeScript support incremental build mode which caches build results in filesystem (see [here)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html)

Enabling this speeds up `npm run build` more than 2x on my machine.