### PR TITLE
refactor: imports of `cspell-types` should be type only

### DIFF
--- a/cspell.code-workspace
+++ b/cspell.code-workspace
@@ -42,6 +42,9 @@
         },
         {
             "path": "docs"
+        },
+        {
+            "path": "packages/cspell-json-reporter"
         }
     ],
     "launch": {

--- a/packages/cspell-json-reporter/package.json
+++ b/packages/cspell-json-reporter/package.json
@@ -25,8 +25,9 @@
     "url": "git+https://github.com/streetsidesoftware/cspell.git"
   },
   "scripts": {
-    "clean": "rimraf dist temp coverage",
+    "clean": "rimraf dist temp coverage .tsbuildinfo",
     "build": "npm run compile",
+    "build-dev": "tsc -p tsconfig.dev.json",
     "clean-build": "npm run clean && npm run build",
     "compile": "tsc -p .",
     "watch": "tsc --watch -p .",

--- a/packages/cspell-json-reporter/src/CSpellJSONReporterOutput.ts
+++ b/packages/cspell-json-reporter/src/CSpellJSONReporterOutput.ts
@@ -1,4 +1,11 @@
-import { ErrorLike, Issue, MessageType, ProgressFileComplete, ProgressItem, RunResult } from '@cspell/cspell-types';
+import type {
+    ErrorLike,
+    Issue,
+    MessageType,
+    ProgressFileComplete,
+    ProgressItem,
+    RunResult,
+} from '@cspell/cspell-types';
 
 export type CSpellJSONReporterOutput = {
     /**

--- a/packages/cspell-json-reporter/src/index.test.ts
+++ b/packages/cspell-json-reporter/src/index.test.ts
@@ -1,6 +1,8 @@
-import { getReporter } from '.';
-import { CSpellReporter, MessageTypes } from '@cspell/cspell-types';
+import type { CSpellReporter } from '@cspell/cspell-types';
+import { MessageTypes } from '@cspell/cspell-types';
+import { promises as fs } from 'fs';
 import * as path from 'path';
+import { getReporter } from '.';
 
 jest.mock('fs', () => ({
     promises: {
@@ -8,8 +10,6 @@ jest.mock('fs', () => ({
     },
 }));
 jest.mock('mkdirp', () => jest.fn().mockResolvedValue(undefined));
-
-import { promises as fs } from 'fs';
 
 describe('getReporter', () => {
     beforeEach(() => {

--- a/packages/cspell-json-reporter/tsconfig.dev.json
+++ b/packages/cspell-json-reporter/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": ".tsbuildinfo"
+    }
+}

--- a/packages/cspell-json-reporter/tsconfig.json
+++ b/packages/cspell-json-reporter/tsconfig.json
@@ -1,34 +1,10 @@
 {
-	"compilerOptions": {
-		"target": "es2019",
-		"lib": [
-			"es2019",
-			"es2020.promise",
-			"es2020.bigint",
-			"es2020.string"
-		],
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"sourceMap": true,
-		"alwaysStrict": true,
-		"declaration": true,
-		"noImplicitAny": true,
-		"noImplicitThis": true,
-		"esModuleInterop": true,
-		"strictNullChecks": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"outDir": "dist",
-		"forceConsistentCasingInFileNames": true
-	},
-	"include": [
-		"src/**/*.ts",
-		"src/**/*.test.ts"
-	],
-	"exclude": [
-		"node_modules/**",
-		"dist/**",
-		"dictionaries/**",
-		"samples"
-	]
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.test.ts"
+    ]
 }

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -1,29 +1,29 @@
+import type { CSpellSettingsWithSourceTrace, CSpellUserSettings, ImportFileRef } from '@cspell/cspell-types';
+import * as path from 'path';
+import { mocked } from 'ts-jest/utils';
+import { URI } from 'vscode-uri';
+import { logError, logWarning } from '../util/logger';
 import {
-    mergeSettings,
-    readSettings,
-    getGlobalSettings,
-    clearCachedSettingsFiles,
-    getCachedFileSize,
-    checkFilenameMatchesGlob,
     calcOverrideSettings,
-    getSources,
-    extractImportErrors,
-    searchForConfig,
-    loadConfig,
-    ImportFileRefWithError,
-    readRawSettings,
-    __testing__,
+    checkFilenameMatchesGlob,
+    clearCachedSettingsFiles,
     ENV_CSPELL_GLOB_ROOT,
+    extractImportErrors,
+    getCachedFileSize,
+    getGlobalSettings,
+    getSources,
+    ImportFileRefWithError,
+    loadConfig,
     loadPnP,
     loadPnPSync,
+    mergeSettings,
+    readRawSettings,
+    readSettings,
     readSettingsFiles,
+    searchForConfig,
+    __testing__,
 } from './CSpellSettingsServer';
 import { getDefaultSettings, _defaultSettings } from './DefaultSettings';
-import { CSpellSettingsWithSourceTrace, CSpellUserSettings, ImportFileRef } from '@cspell/cspell-types';
-import { logError, logWarning } from '../util/logger';
-import { mocked } from 'ts-jest/utils';
-import * as path from 'path';
-import { URI } from 'vscode-uri';
 
 const { normalizeSettings, validateRawConfigVersion, validateRawConfigExports } = __testing__;
 

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     CSpellSettingsWithSourceTrace,
     CSpellUserSettings,
     Glob,

--- a/packages/cspell-lib/src/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/Settings/DefaultSettings.ts
@@ -1,14 +1,14 @@
-import {
+import type {
     CSpellSettings,
-    RegExpPatternDefinition,
     CSpellSettingsWithSourceTrace,
     PredefinedPatterns,
+    RegExpPatternDefinition,
 } from '@cspell/cspell-types';
-import * as LanguageSettings from './LanguageSettings';
-import * as RegPat from './RegExpPatterns';
+import { resolveFile } from '../util/resolveFile';
 import { readSettings } from './CSpellSettingsServer';
 import { mergeSettings } from './index';
-import { resolveFile } from '../util/resolveFile';
+import * as LanguageSettings from './LanguageSettings';
+import * as RegPat from './RegExpPatterns';
 
 const defaultConfigFileModuleRef = '@cspell/cspell-bundled-dicts/cspell-default.json';
 

--- a/packages/cspell-lib/src/Settings/DictionaryReferenceCollection.ts
+++ b/packages/cspell-lib/src/Settings/DictionaryReferenceCollection.ts
@@ -1,4 +1,4 @@
-import { DictionaryId, DictionaryReference } from '@cspell/cspell-types';
+import type { DictionaryId, DictionaryReference } from '@cspell/cspell-types';
 
 export interface DictionaryReferenceCollection {
     isEnabled(name: DictionaryId): boolean | undefined;

--- a/packages/cspell-lib/src/Settings/DictionarySettings.test.ts
+++ b/packages/cspell-lib/src/Settings/DictionarySettings.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import * as DictSettings from './DictionarySettings';
+import type { DictionaryDefinition, DictionaryDefinitionLegacy } from '@cspell/cspell-types';
 import * as fsp from 'fs-extra';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 import { getDefaultSettings } from './DefaultSettings';
-import { DictionaryDefinition, DictionaryDefinitionLegacy } from '@cspell/cspell-types';
+import * as DictSettings from './DictionarySettings';
 
 const defaultSettings = getDefaultSettings();
 

--- a/packages/cspell-lib/src/Settings/DictionarySettings.ts
+++ b/packages/cspell-lib/src/Settings/DictionarySettings.ts
@@ -1,4 +1,4 @@
-import { DictionaryDefinition, DictionaryDefinitionPreferred, DictionaryReference } from '@cspell/cspell-types';
+import type { DictionaryDefinition, DictionaryDefinitionPreferred, DictionaryReference } from '@cspell/cspell-types';
 import * as path from 'path';
 import { resolveFile } from '../util/resolveFile';
 import { createDictionaryReferenceCollection } from './DictionaryReferenceCollection';

--- a/packages/cspell-lib/src/Settings/GlobalSettings.ts
+++ b/packages/cspell-lib/src/Settings/GlobalSettings.ts
@@ -1,8 +1,8 @@
-import { CSpellSettings, CSpellSettingsWithSourceTrace } from '@cspell/cspell-types';
+import type { CSpellSettings, CSpellSettingsWithSourceTrace } from '@cspell/cspell-types';
 import ConfigStore from 'configstore';
-import { logError } from '../util/logger';
-import { isErrnoException } from '../util/errors';
 import { format } from 'util';
+import { isErrnoException } from '../util/errors';
+import { logError } from '../util/logger';
 
 const packageName = 'cspell';
 

--- a/packages/cspell-lib/src/Settings/InDocSettings.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.ts
@@ -1,6 +1,6 @@
+import type { CSpellUserSettings } from '@cspell/cspell-types';
 import { genSequence, Sequence } from 'gensequence';
 import * as Text from '../util/text';
-import { CSpellUserSettings } from '@cspell/cspell-types';
 import { mergeInDocSettings } from './CSpellSettingsServer';
 
 // cspell:ignore gimuy

--- a/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { calcSettingsForLanguage, calcUserSettingsForLanguage } from './LanguageSettings';
+import type { CSpellUserSettings } from '@cspell/cspell-types';
 import { getGlobalSettings, mergeSettings } from './CSpellSettingsServer';
 import { getDefaultSettings } from './DefaultSettings';
-import { CSpellUserSettings } from '@cspell/cspell-types';
-
 import * as LS from './LanguageSettings';
+import { calcSettingsForLanguage, calcUserSettingsForLanguage } from './LanguageSettings';
 
 const extraSettings: CSpellUserSettings = {
     ignoreRegExpList: ['binary'],

--- a/packages/cspell-lib/src/Settings/LanguageSettings.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.ts
@@ -1,4 +1,4 @@
-import { LanguageSetting, CSpellUserSettings, LocaleId, LanguageId, BaseSetting } from '@cspell/cspell-types';
+import type { LanguageSetting, CSpellUserSettings, LocaleId, LanguageId, BaseSetting } from '@cspell/cspell-types';
 import * as SpellSettings from './CSpellSettingsServer';
 
 // LanguageSettings are a collection of LanguageSetting.  They are applied in order, matching against the languageId.

--- a/packages/cspell-lib/src/Settings/RegExpPatterns.test.ts
+++ b/packages/cspell-lib/src/Settings/RegExpPatterns.test.ts
@@ -1,10 +1,10 @@
-import * as TextRange from '../util/TextRange';
-import { regExMatchUrls, regExMatchCommonHexFormats } from './RegExpPatterns';
-import * as RegPat from './RegExpPatterns';
-import { calculateTextDocumentOffsets } from '../util/text';
+import type { TextOffset } from '@cspell/cspell-types';
 import fs from 'fs';
 import Path from 'path';
-import { TextOffset } from '@cspell/cspell-types';
+import { calculateTextDocumentOffsets } from '../util/text';
+import * as TextRange from '../util/TextRange';
+import * as RegPat from './RegExpPatterns';
+import { regExMatchCommonHexFormats, regExMatchUrls } from './RegExpPatterns';
 
 const matchUrl = regExMatchUrls.source;
 const matchHexValues = regExMatchCommonHexFormats.source;

--- a/packages/cspell-lib/src/Settings/TextDocumentSettings.ts
+++ b/packages/cspell-lib/src/Settings/TextDocumentSettings.ts
@@ -1,7 +1,7 @@
-import { calcSettingsForLanguageId } from './LanguageSettings';
-import { CSpellSettings, CSpellUserSettings } from '@cspell/cspell-types';
+import type { CSpellSettings, CSpellUserSettings } from '@cspell/cspell-types';
 import * as CSpellSettingsServer from './CSpellSettingsServer';
 import { getInDocumentSettings } from './InDocSettings';
+import { calcSettingsForLanguageId } from './LanguageSettings';
 
 export function combineTextAndLanguageSettings(
     settings: CSpellUserSettings,

--- a/packages/cspell-lib/src/Settings/index.ts
+++ b/packages/cspell-lib/src/Settings/index.ts
@@ -1,4 +1,4 @@
+export * from '@cspell/cspell-types';
 export * from './CSpellSettingsServer';
 export * from './DefaultSettings';
-export * from '@cspell/cspell-types';
 export * from './ImportError';

--- a/packages/cspell-lib/src/Settings/link.ts
+++ b/packages/cspell-lib/src/Settings/link.ts
@@ -1,6 +1,6 @@
-import * as Path from 'path';
+import type { CSpellSettingsWithSourceTrace } from '@cspell/cspell-types';
 import * as fs from 'fs';
-import { CSpellSettingsWithSourceTrace } from '@cspell/cspell-types';
+import * as Path from 'path';
 import { readRawSettings } from './CSpellSettingsServer';
 import { getRawGlobalSettings, writeRawGlobalSettings } from './GlobalSettings';
 

--- a/packages/cspell-lib/src/SpellingDictionary/Dictionaries.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/Dictionaries.test.ts
@@ -1,8 +1,8 @@
-import * as Dictionaries from './Dictionaries';
-import { getDefaultSettings, loadConfig } from '../Settings';
-import * as path from 'path';
+import type { CSpellUserSettings } from '@cspell/cspell-types';
 import * as fs from 'fs-extra';
-import { CSpellUserSettings } from '@cspell/cspell-types';
+import * as path from 'path';
+import { getDefaultSettings, loadConfig } from '../Settings';
+import * as Dictionaries from './Dictionaries';
 import { isSpellingDictionaryLoadError } from './SpellingDictionaryError';
 
 // cspell:ignore café rhône

--- a/packages/cspell-lib/src/SpellingDictionary/Dictionaries.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/Dictionaries.ts
@@ -1,4 +1,4 @@
-import { CSpellUserSettings, DictionaryDefinition, DictionaryReference } from '@cspell/cspell-types';
+import type { CSpellUserSettings, DictionaryDefinition, DictionaryReference } from '@cspell/cspell-types';
 import { createDictionaryReferenceCollection } from '../Settings/DictionaryReferenceCollection';
 import { filterDictDefsToLoad } from '../Settings/DictionarySettings';
 import { createForbiddenWordsDictionary, createSpellingDictionary } from './createSpellingDictionary';

--- a/packages/cspell-lib/src/SpellingDictionary/DictionaryLoader.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/DictionaryLoader.ts
@@ -1,11 +1,11 @@
-import { createSpellingDictionaryTrie } from './SpellingDictionaryFromTrie';
-import { createFailedToLoadDictionary, createSpellingDictionary } from './createSpellingDictionary';
-import { SpellingDictionary } from './SpellingDictionary';
+import type { DictionaryDefinitionPreferred } from '@cspell/cspell-types';
+import { stat } from 'fs-extra';
 import * as path from 'path';
 import { readLines } from '../util/fileReader';
-import { stat } from 'fs-extra';
+import { createFailedToLoadDictionary, createSpellingDictionary } from './createSpellingDictionary';
+import { SpellingDictionary } from './SpellingDictionary';
 import { SpellingDictionaryLoadError } from './SpellingDictionaryError';
-import { DictionaryDefinitionPreferred } from '@cspell/cspell-types';
+import { createSpellingDictionaryTrie } from './SpellingDictionaryFromTrie';
 
 const MAX_AGE = 10000;
 

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionary.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionary.ts
@@ -1,5 +1,5 @@
-import { SuggestionCollector, SuggestionResult, CompoundWordsMethod } from 'cspell-trie-lib';
-import { ReplaceMap } from '@cspell/cspell-types';
+import type { ReplaceMap } from '@cspell/cspell-types';
+import { CompoundWordsMethod, SuggestionCollector, SuggestionResult } from 'cspell-trie-lib';
 
 export { CompoundWordsMethod, SuggestionCollector, SuggestionResult } from 'cspell-trie-lib';
 

--- a/packages/cspell-lib/src/exclusionHelper.test.ts
+++ b/packages/cspell-lib/src/exclusionHelper.test.ts
@@ -1,4 +1,4 @@
-import { Glob } from '@cspell/cspell-types';
+import type { Glob } from '@cspell/cspell-types';
 import { extractGlobsFromExcludeFilesGlobMap, generateExclusionFunctionForUri } from './exclusionHelper';
 
 describe('Verify Exclusion Helper functions', () => {

--- a/packages/cspell-lib/src/exclusionHelper.ts
+++ b/packages/cspell-lib/src/exclusionHelper.ts
@@ -1,5 +1,5 @@
 import { URI as Uri } from 'vscode-uri';
-import { Glob } from '@cspell/cspell-types';
+import type { Glob } from '@cspell/cspell-types';
 import { GlobMatcher } from 'cspell-glob';
 
 const defaultAllowedSchemes = new Set(['file', 'untitled']);

--- a/packages/cspell-lib/src/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/spellCheckFile.test.ts
@@ -1,4 +1,4 @@
-import { CSpellUserSettings } from '@cspell/cspell-types';
+import type { CSpellUserSettings } from '@cspell/cspell-types';
 import * as Path from 'path';
 import { posix } from 'path';
 import { URI } from 'vscode-uri';
@@ -6,11 +6,11 @@ import { ImportError } from './Settings/ImportError';
 import {
     determineFinalDocumentSettings,
     Document,
+    fileToDocument,
     spellCheckDocument,
     spellCheckFile,
     SpellCheckFileOptions,
     SpellCheckFileResult,
-    fileToDocument,
 } from './spellCheckFile';
 
 const samples = Path.resolve(__dirname, '../samples');

--- a/packages/cspell-lib/src/spellCheckFile.ts
+++ b/packages/cspell-lib/src/spellCheckFile.ts
@@ -1,5 +1,7 @@
-import { CSpellSettingsWithSourceTrace, CSpellUserSettings, PnPSettings } from '@cspell/cspell-types';
+import type { CSpellSettingsWithSourceTrace, CSpellUserSettings, PnPSettings } from '@cspell/cspell-types';
+import { GlobMatcher } from 'cspell-glob';
 import { readFile } from 'fs-extra';
+import * as path from 'path';
 import { URI, Utils as UriUtils } from 'vscode-uri';
 import { getLanguagesForExt as _getLanguagesForExt, isGenerated } from './LanguageIds';
 import {
@@ -10,12 +12,10 @@ import {
     mergeSettings,
     searchForConfig,
 } from './Settings';
-import { validateText, ValidateTextOptions, ValidationIssue } from './validator';
-import * as path from 'path';
 import { combineTextAndLanguageSettings } from './Settings/TextDocumentSettings';
-import { GlobMatcher } from 'cspell-glob';
-import { memorizer } from './util/Memorizer';
 import { isError } from './util/errors';
+import { memorizer } from './util/Memorizer';
+import { validateText, ValidateTextOptions, ValidationIssue } from './validator';
 
 const getLanguagesForExt = memorizer(_getLanguagesForExt);
 

--- a/packages/cspell-lib/src/textValidator.ts
+++ b/packages/cspell-lib/src/textValidator.ts
@@ -1,9 +1,9 @@
-import * as Text from './util/text';
-import { TextOffset } from '@cspell/cspell-types';
-import * as TextRange from './util/TextRange';
-import { SpellingDictionary, HasOptions } from './SpellingDictionary/SpellingDictionary';
+import type { TextOffset } from '@cspell/cspell-types';
 import { Sequence } from 'gensequence';
 import * as RxPat from './Settings/RegExpPatterns';
+import { HasOptions, SpellingDictionary } from './SpellingDictionary/SpellingDictionary';
+import * as Text from './util/text';
+import * as TextRange from './util/TextRange';
 import { split } from './util/wordSplitter';
 
 export interface ValidationOptions extends IncludeExcludeOptions {

--- a/packages/cspell-lib/src/trace.test.ts
+++ b/packages/cspell-lib/src/trace.test.ts
@@ -1,5 +1,5 @@
-import { traceWords, getDefaultSettings } from '.';
-import { CSpellSettings } from '@cspell/cspell-types';
+import type { CSpellSettings } from '@cspell/cspell-types';
+import { getDefaultSettings, traceWords } from '.';
 import { mergeSettings } from './Settings';
 import { TraceResult } from './trace';
 

--- a/packages/cspell-lib/src/trace.ts
+++ b/packages/cspell-lib/src/trace.ts
@@ -1,4 +1,4 @@
-import { CSpellSettings, DictionaryId, LocaleId } from '@cspell/cspell-types';
+import type { CSpellSettings, DictionaryId, LocaleId } from '@cspell/cspell-types';
 import { genSequence } from 'gensequence';
 import { LanguageId } from './LanguageIds';
 import { finalizeSettings, mergeSettings } from './Settings';

--- a/packages/cspell-lib/src/util/repMap.ts
+++ b/packages/cspell-lib/src/util/repMap.ts
@@ -1,4 +1,4 @@
-import { ReplaceMap } from '@cspell/cspell-types';
+import type { ReplaceMap } from '@cspell/cspell-types';
 import { escapeRegEx } from './regexHelper';
 
 export type ReplaceMapper = (src: string) => string;

--- a/packages/cspell-lib/src/util/text.test.ts
+++ b/packages/cspell-lib/src/util/text.test.ts
@@ -1,6 +1,6 @@
-import { splitCamelCaseWord } from './text';
+import type { TextOffset } from '@cspell/cspell-types';
 import * as Text from './text';
-import { TextOffset } from '@cspell/cspell-types';
+import { splitCamelCaseWord } from './text';
 
 // cSpell:ignore Ápple DBAs ctrip γάμμα
 

--- a/packages/cspell-lib/src/util/text.ts
+++ b/packages/cspell-lib/src/util/text.ts
@@ -1,21 +1,21 @@
+import type { TextDocumentOffset, TextOffset } from '@cspell/cspell-types';
 import { Sequence, sequenceFromRegExpMatch } from 'gensequence';
 import { binarySearch } from './search';
 import {
+    regExAccents,
+    regExAllLower,
+    regExAllUpper,
+    regExFirstUpper,
+    regExIgnoreCharacters,
     regExLines,
-    regExUpperSOrIng,
+    regExMatchRegExParts,
     regExSplitWords,
     regExSplitWords2,
+    regExUpperSOrIng,
     regExWords,
     regExWordsAndDigits,
-    regExIgnoreCharacters,
-    regExFirstUpper,
-    regExAllUpper,
-    regExAllLower,
-    regExMatchRegExParts,
-    regExAccents,
 } from './textRegex';
 import { scanMap } from './util';
-import { TextOffset, TextDocumentOffset } from '@cspell/cspell-types';
 
 // CSpell:ignore ings ning gimuy tsmerge
 

--- a/packages/cspell-lib/src/util/wordSplitter.test.ts
+++ b/packages/cspell-lib/src/util/wordSplitter.test.ts
@@ -1,4 +1,4 @@
-import { TextOffset } from '@cspell/cspell-types';
+import type { TextOffset } from '@cspell/cspell-types';
 import { SortedBreaks, split, __testing__ } from './wordSplitter';
 
 const generateWordBreaks = __testing__.generateWordBreaks;

--- a/packages/cspell-lib/src/util/wordSplitter.ts
+++ b/packages/cspell-lib/src/util/wordSplitter.ts
@@ -1,6 +1,6 @@
+import type { TextOffset } from '@cspell/cspell-types';
 import { PairingHeap } from './PairingHeap';
 import { escapeRegEx } from './regexHelper';
-import { TextOffset } from '@cspell/cspell-types';
 import {
     regExDanglingQuote,
     regExEscapeCharacters,

--- a/packages/cspell-lib/src/validator.test.ts
+++ b/packages/cspell-lib/src/validator.test.ts
@@ -1,10 +1,8 @@
-import * as Validator from './validator';
+import type { CSpellSettings } from '@cspell/cspell-types';
 import { loremIpsum } from 'lorem-ipsum';
-import { CSpellSettings } from '@cspell/cspell-types';
-import * as tds from './Settings/TextDocumentSettings';
-
 import { getDefaultSettings } from './Settings/DefaultSettings';
-
+import * as tds from './Settings/TextDocumentSettings';
+import * as Validator from './validator';
 import { IncludeExcludeFlag } from './validator';
 
 // cSpell:ignore brouwn jumpped lazzy wrongg mispelled ctrip nmove mischecked

--- a/packages/cspell-lib/src/validator.ts
+++ b/packages/cspell-lib/src/validator.ts
@@ -1,4 +1,4 @@
-import { CSpellUserSettings } from '@cspell/cspell-types';
+import type { CSpellUserSettings } from '@cspell/cspell-types';
 import * as Settings from './Settings';
 import * as Dictionary from './SpellingDictionary';
 import { CompoundWordsMethod } from './SpellingDictionary';

--- a/packages/cspell/src/CSpellApplicationConfiguration.ts
+++ b/packages/cspell/src/CSpellApplicationConfiguration.ts
@@ -1,9 +1,9 @@
-import { GlobSrcInfo, calcExcludeGlobInfo } from './util/glob';
+import type { CSpellReporter, Issue } from '@cspell/cspell-types';
 import * as path from 'path';
-import * as util from './util/util';
-import { IOptions } from './util/IOptions';
-import { CSpellReporter, Issue } from '@cspell/cspell-types';
 import { CSpellApplicationOptions } from './options';
+import { calcExcludeGlobInfo, GlobSrcInfo } from './util/glob';
+import { IOptions } from './util/IOptions';
+import * as util from './util/util';
 
 const defaultContextRange = 20;
 

--- a/packages/cspell/src/application.test.ts
+++ b/packages/cspell/src/application.test.ts
@@ -1,6 +1,6 @@
+import type { Issue } from '@cspell/cspell-types';
 import * as path from 'path';
 import * as App from './application';
-import { Issue } from '@cspell/cspell-types';
 import { CSpellApplicationOptions } from './options';
 import { InMemoryReporter } from './util/InMemoryReporter';
 

--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -1,13 +1,14 @@
+import type { CSpellReporter, RunResult } from '@cspell/cspell-types';
 import * as cspell from 'cspell-lib';
+import { CheckTextInfo, TraceResult, traceWords } from 'cspell-lib';
 import * as path from 'path';
-import * as util from './util/util';
-import { traceWords, TraceResult, CheckTextInfo } from 'cspell-lib';
-export { TraceResult, IncludeExcludeFlag } from 'cspell-lib';
-import { CSpellReporter, RunResult } from '@cspell/cspell-types';
 import { CSpellApplicationConfiguration } from './CSpellApplicationConfiguration';
-import { BaseOptions, CSpellApplicationOptions, TraceOptions } from './options';
-import { runLint } from './lint';
 import { calcFinalConfigInfo, readConfig, readFile } from './fileHelper';
+import { runLint } from './lint';
+import { BaseOptions, CSpellApplicationOptions, TraceOptions } from './options';
+import * as util from './util/util';
+export type { TraceResult } from 'cspell-lib';
+export { IncludeExcludeFlag } from 'cspell-lib';
 
 export type AppError = NodeJS.ErrnoException;
 

--- a/packages/cspell/src/cli-reporter.ts
+++ b/packages/cspell/src/cli-reporter.ts
@@ -1,7 +1,7 @@
 import chalk = require('chalk');
+import type { CSpellReporter, Issue, MessageType, ProgressItem, RunResult } from '@cspell/cspell-types';
+import { ImportError, isSpellingDictionaryLoadError, SpellingDictionaryLoadError } from 'cspell-lib';
 import * as path from 'path';
-import { CSpellReporter, MessageType, ProgressItem, Issue, RunResult } from '@cspell/cspell-types';
-import { isSpellingDictionaryLoadError, SpellingDictionaryLoadError, ImportError } from 'cspell-lib';
 import { Options } from './app';
 
 const templateIssue = `{green $uri}:{yellow $row:$col} - $message ({red $text})`;

--- a/packages/cspell/src/index.ts
+++ b/packages/cspell/src/index.ts
@@ -1,3 +1,3 @@
-export * from './application';
 export * from '@cspell/cspell-types';
-export { BaseOptions, CSpellApplicationOptions, TraceOptions } from './options';
+export * from './application';
+export type { BaseOptions, CSpellApplicationOptions, TraceOptions } from './options';

--- a/packages/cspell/src/lint.ts
+++ b/packages/cspell/src/lint.ts
@@ -1,4 +1,5 @@
-import type { CSpellReporter, CSpellSettings, Glob, TextDocumentOffset } from '@cspell/cspell-types';
+import type { CSpellReporter, CSpellSettings, Glob, Issue, RunResult, TextDocumentOffset } from '@cspell/cspell-types';
+import { MessageTypes } from '@cspell/cspell-types';
 import * as commentJson from 'comment-json';
 import type { GlobMatcher, GlobPatternNormalized, GlobPatternWithRoot } from 'cspell-glob';
 import type { ValidationIssue } from 'cspell-lib';
@@ -8,13 +9,12 @@ import * as path from 'path';
 import { format } from 'util';
 import { URI } from 'vscode-uri';
 import { CSpellApplicationConfiguration } from './CSpellApplicationConfiguration';
-import { Issue, MessageTypes, RunResult } from '@cspell/cspell-types';
 import { ConfigInfo, FileInfo, fileInfoToDocument, findFiles, readConfig, readFileInfo } from './fileHelper';
+import { toError } from './util/errors';
 import { buildGlobMatcher, extractGlobsFromMatcher, extractPatterns, normalizeGlobsToRoot } from './util/glob';
+import { loadReporters, mergeReporters } from './util/reporters';
 import { measurePromise } from './util/timer';
 import * as util from './util/util';
-import { loadReporters, mergeReporters } from './util/reporters';
-import { toError } from './util/errors';
 
 export interface FileResult {
     fileInfo: FileInfo;

--- a/packages/cspell/src/util/InMemoryReporter.ts
+++ b/packages/cspell/src/util/InMemoryReporter.ts
@@ -1,9 +1,15 @@
-import { CSpellReporter, Issue, ProgressFileComplete, RunResult } from '@cspell/cspell-types';
+import type { CSpellReporter, Issue, ProgressFileComplete, RunResult } from '@cspell/cspell-types';
+
+export interface InMemoryResult {
+    log: string[];
+    issues: Issue[];
+    runResult: RunResult | undefined;
+}
 
 /**
  * Simple reporter for test purposes
  */
-export class InMemoryReporter implements CSpellReporter {
+export class InMemoryReporter implements CSpellReporter, InMemoryResult {
     log: string[] = [];
     issueCount = 0;
     errorCount = 0;
@@ -44,5 +50,5 @@ export class InMemoryReporter implements CSpellReporter {
         this.runResult = r;
     };
 
-    dump = () => ({ log: this.log, issues: this.issues, result: this.runResult });
+    dump = (): InMemoryResult => ({ log: this.log, issues: this.issues, runResult: this.runResult });
 }

--- a/packages/cspell/src/util/__snapshots__/reporters.test.ts.snap
+++ b/packages/cspell/src/util/__snapshots__/reporters.test.ts.snap
@@ -30,7 +30,7 @@ Object {
     "Issue: text.txt[1, 14]: Unknown word: fulll",
     "Progress: ProgressFileComplete 1 1 text.txt",
   ],
-  "result": Object {
+  "runResult": Object {
     "errors": 1,
     "files": 1,
     "filesWithIssues": Set {
@@ -71,7 +71,7 @@ Object {
     "Issue: text.txt[1, 14]: Unknown word: fulll",
     "Progress: ProgressFileComplete 1 1 text.txt",
   ],
-  "result": Object {
+  "runResult": Object {
     "errors": 1,
     "files": 1,
     "filesWithIssues": Set {
@@ -112,7 +112,7 @@ Object {
     "Issue: text.txt[1, 14]: Unknown word: fulll",
     "Progress: ProgressFileComplete 1 1 text.txt",
   ],
-  "result": Object {
+  "runResult": Object {
     "errors": 1,
     "files": 1,
     "filesWithIssues": Set {
@@ -153,7 +153,7 @@ Object {
     "Issue: text.txt[1, 14]: Unknown word: fulll",
     "Progress: ProgressFileComplete 1 1 text.txt",
   ],
-  "result": Object {
+  "runResult": Object {
     "errors": 1,
     "files": 1,
     "filesWithIssues": Set {

--- a/packages/cspell/src/util/glob.ts
+++ b/packages/cspell/src/util/glob.ts
@@ -1,8 +1,8 @@
+import type { CSpellUserSettings, Glob } from '@cspell/cspell-types';
+import { fileOrGlobToGlob, GlobMatcher, GlobPatternWithRoot } from 'cspell-glob';
 import glob, { IGlob } from 'glob';
 import * as path from 'path';
 import { IOptions } from './IOptions';
-import { GlobMatcher, GlobPatternWithRoot, fileOrGlobToGlob } from 'cspell-glob';
-import type { CSpellUserSettings, Glob } from '@cspell/cspell-types';
 
 export interface GlobOptions extends IOptions {
     cwd?: string;

--- a/packages/cspell/src/util/reporters.test.ts
+++ b/packages/cspell/src/util/reporters.test.ts
@@ -1,4 +1,5 @@
-import { CSpellReporter, MessageTypes } from '@cspell/cspell-types';
+import type { CSpellReporter } from '@cspell/cspell-types';
+import { MessageTypes } from '@cspell/cspell-types';
 import { InMemoryReporter } from './InMemoryReporter';
 import { mergeReporters } from './reporters';
 

--- a/packages/cspell/src/util/reporters.ts
+++ b/packages/cspell/src/util/reporters.ts
@@ -1,4 +1,10 @@
-import { CSpellReporter, RunResult, CSpellReporterModule, FileSettings, ReporterSettings } from '@cspell/cspell-types';
+import type {
+    CSpellReporter,
+    CSpellReporterModule,
+    FileSettings,
+    ReporterSettings,
+    RunResult,
+} from '@cspell/cspell-types';
 import { ApplicationError, toError } from './errors';
 
 function mergeEmitters<T extends keyof Omit<CSpellReporter, 'result'>>(

--- a/test-packages/test-cspell/src/index.ts
+++ b/test-packages/test-cspell/src/index.ts
@@ -1,6 +1,6 @@
+import type { CSpellReporter } from '@cspell/cspell-types';
 import { assert } from 'console';
-import { checkText, lint, trace, Issue, ProgressFileComplete, CSpellApplicationOptions, RunResult } from 'cspell';
-import { CSpellReporter } from '@cspell/cspell-types';
+import { checkText, CSpellApplicationOptions, Issue, lint, ProgressFileComplete, RunResult, trace } from 'cspell';
 import { run } from 'cspell/dist/app';
 
 async function test() {


### PR DESCRIPTION
Where possible, make importing from `@cspell/cspell-types` a `type` only import.