### PR TITLE
Explicitly import `hrtime` from `process`

### DIFF
--- a/packages/cspell-trie-lib/src/lib/timer.ts
+++ b/packages/cspell-trie-lib/src/lib/timer.ts
@@ -1,3 +1,5 @@
+import { hrtime } from 'process';
+
 export interface Timer {
     /** Start / restart the timer. */
     start(): void;
@@ -8,15 +10,15 @@ export interface Timer {
     elapsed(): number;
 }
 
-export function createTimer(hrTime = process.hrtime): Timer {
-    let start = hrTime();
+export function createTimer(hrTimeFn = hrtime): Timer {
+    let start: HRTime = hrTimeFn();
 
     return {
         start() {
-            start = hrTime();
+            start = hrTimeFn();
         },
         elapsed() {
-            return toMilliseconds(hrTime(start));
+            return toMilliseconds(hrTimeFn(start));
         },
     };
 }


### PR DESCRIPTION
to allow Browserify/Webpack to work.

Related to #1704 