### PR TITLE
fix: Make dict-en-gb version 2 optional because of license.

### DIFF
--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1200,9 +1200,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1856,9 +1856,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-bundled-dicts/package-lock.json
+++ b/packages/cspell-bundled-dicts/package-lock.json
@@ -4,27 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@cspell/cspell-tools": {
-      "version": "5.10.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-tools/-/cspell-tools-5.10.0-alpha.5.tgz",
-      "integrity": "sha512-R3LGJXYEOg+Wmd5tZl//YkZg3DpEP2XUpy7SDJtgORSg+S4cq0fjBK8VVCAO9xqBqjEwEkZtceSUgFMI/utdBw==",
-      "dev": true,
-      "requires": {
-        "commander": "^8.2.0",
-        "cspell-io": "^5.10.0-alpha.3",
-        "cspell-trie-lib": "^5.10.0-alpha.5",
-        "fs-extra": "^10.0.0",
-        "gensequence": "^3.1.1",
-        "glob": "^7.1.7",
-        "hunspell-reader": "^5.10.0-alpha.3"
-      }
-    },
-    "@cspell/cspell-types": {
-      "version": "5.10.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.10.0-alpha.3.tgz",
-      "integrity": "sha512-x2L85Z5Z78ZFCKdsZFm42Z1fl7a+PIPaf9un6NwBGkmZ9JlaDyIyzqEpVXdxxlowTSTAC4UgRdITEJWl3W1mpw==",
-      "dev": true
-    },
     "@cspell/dict-ada": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
@@ -81,9 +60,9 @@
       "integrity": "sha512-ZmawoBYjM5k+8fNudRMkK+PpHjhyAFAZt2rUu1EGj2rbCvE3Fn2lhRbDjbreN7nWRvcLRTW+xuPXtKP11X0ahQ=="
     },
     "@cspell/dict-en-gb": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-2.0.2.tgz",
-      "integrity": "sha512-xpI0O/5nmf25BtJXC3ceN/k6NqhvFIcylhsgb0YtwIbNMA9MFt9L+zb16dfESXteNj5uJNPCkyI0kPhShnpxtg=="
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
+      "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g=="
     },
     "@cspell/dict-en_us": {
       "version": "2.1.1",
@@ -199,182 +178,6 @@
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
       "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A=="
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "commander": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
-      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "cspell-io": {
-      "version": "5.10.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.10.0-alpha.3.tgz",
-      "integrity": "sha512-huPsLrd/sNd1KIjsLxd12pJcCe8YkKIjT651cZNRmfch7Gn1WK5NsY/kzp4ts2BiyXTyYl48wqGmA/nkvSB83w==",
-      "dev": true
-    },
-    "cspell-trie-lib": {
-      "version": "5.10.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.10.0-alpha.5.tgz",
-      "integrity": "sha512-k5Dxv8/pRf4VLN1XXgvO7RrEPQyinwAypNpx0DCkhNxEQrJIJ+Ah1pHiVQezr9kYn+sovcmnwW5wB079pl225g==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "^10.0.0",
-        "gensequence": "^3.1.1"
-      }
-    },
-    "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "gensequence": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.1.1.tgz",
-      "integrity": "sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "dev": true
-    },
-    "hunspell-reader": {
-      "version": "5.10.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/hunspell-reader/-/hunspell-reader-5.10.0-alpha.3.tgz",
-      "integrity": "sha512-c4jWoo6d28h0sQivBcc8ctokAQ+bQnCIQvJMaf6cqUhuFJ/LW2o4DzM9t0en6N4C/4UN4snsblXWlCErf+dLuA==",
-      "dev": true,
-      "requires": {
-        "commander": "^8.2.0",
-        "fs-extra": "^10.0.0",
-        "gensequence": "^3.1.1",
-        "iconv-lite": "^0.6.3"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
     }
   }
 }

--- a/packages/cspell-bundled-dicts/package.json
+++ b/packages/cspell-bundled-dicts/package.json
@@ -43,6 +43,9 @@
     "url": "https://github.com/streetsidesoftware/cspell/labels/cspell-bundled-dicts"
   },
   "homepage": "https://github.com/streetsidesoftware/cspell#readme",
+  "optionalDependencies": {
+    "@cspell/dict-en-gb": "^2.0.2"
+  },
   "dependencies": {
     "@cspell/dict-ada": "^1.1.2",
     "@cspell/dict-aws": "^1.0.14",
@@ -55,7 +58,7 @@
     "@cspell/dict-django": "^1.0.26",
     "@cspell/dict-dotnet": "^1.0.31",
     "@cspell/dict-elixir": "^1.0.25",
-    "@cspell/dict-en-gb": "^2.0.2",
+    "@cspell/dict-en-gb": "^1.1.33",
     "@cspell/dict-en_us": "^2.1.1",
     "@cspell/dict-filetypes": "^1.1.8",
     "@cspell/dict-fonts": "^1.0.14",

--- a/packages/cspell-dynamic-loader/package-lock.json
+++ b/packages/cspell-dynamic-loader/package-lock.json
@@ -1055,9 +1055,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/parse-json": {
@@ -1719,9 +1719,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-glob/package-lock.json
+++ b/packages/cspell-glob/package-lock.json
@@ -766,9 +766,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1249,9 +1249,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-io/package-lock.json
+++ b/packages/cspell-io/package-lock.json
@@ -760,9 +760,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1250,9 +1250,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-json-reporter/package-lock.json
+++ b/packages/cspell-json-reporter/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/parse-json": {

--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -387,23 +387,117 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspell/cspell-bundled-dicts": {
+      "version": "5.10.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.10.0-alpha.5.tgz",
+      "integrity": "sha512-WZcQE2FKPdql3w5uGFOsNd1CRriecWLclX0UuDacmbXvI1AErd2Z9fvNCNj2P5EQRu9uy66V5gQLHbv6nzN0hQ==",
+      "requires": {
+        "@cspell/dict-ada": "^1.1.2",
+        "@cspell/dict-aws": "^1.0.14",
+        "@cspell/dict-bash": "^1.0.15",
+        "@cspell/dict-companies": "^1.0.40",
+        "@cspell/dict-cpp": "^1.1.40",
+        "@cspell/dict-cryptocurrencies": "^1.0.10",
+        "@cspell/dict-csharp": "^1.0.11",
+        "@cspell/dict-css": "^1.0.12",
+        "@cspell/dict-django": "^1.0.26",
+        "@cspell/dict-dotnet": "^1.0.31",
+        "@cspell/dict-elixir": "^1.0.25",
+        "@cspell/dict-en-gb": "^2.0.2",
+        "@cspell/dict-en_us": "^2.1.1",
+        "@cspell/dict-filetypes": "^1.1.8",
+        "@cspell/dict-fonts": "^1.0.14",
+        "@cspell/dict-fullstack": "^1.0.38",
+        "@cspell/dict-golang": "^1.1.24",
+        "@cspell/dict-haskell": "^1.0.13",
+        "@cspell/dict-html": "^1.1.9",
+        "@cspell/dict-html-symbol-entities": "^1.0.23",
+        "@cspell/dict-java": "^1.0.23",
+        "@cspell/dict-latex": "^1.0.25",
+        "@cspell/dict-lorem-ipsum": "^1.0.22",
+        "@cspell/dict-lua": "^1.0.16",
+        "@cspell/dict-node": "^1.0.12",
+        "@cspell/dict-npm": "^1.0.16",
+        "@cspell/dict-php": "^1.0.24",
+        "@cspell/dict-powershell": "^1.0.18",
+        "@cspell/dict-public-licenses": "^1.0.3",
+        "@cspell/dict-python": "^1.0.37",
+        "@cspell/dict-ruby": "^1.0.14",
+        "@cspell/dict-rust": "^1.0.23",
+        "@cspell/dict-scala": "^1.0.21",
+        "@cspell/dict-software-terms": "^1.0.42",
+        "@cspell/dict-typescript": "^1.0.19"
+      }
+    },
+    "@cspell/cspell-types": {
+      "version": "5.10.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.10.0-alpha.3.tgz",
+      "integrity": "sha512-x2L85Z5Z78ZFCKdsZFm42Z1fl7a+PIPaf9un6NwBGkmZ9JlaDyIyzqEpVXdxxlowTSTAC4UgRdITEJWl3W1mpw=="
+    },
+    "@cspell/dict-ada": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
+      "integrity": "sha512-UDrcYcKIVyXDz5mInJabRNQpJoehjBFvja5W+GQyu9pGcx3BS3cAU8mWENstGR0Qc/iFTxB010qwF8F3cHA/aA=="
+    },
+    "@cspell/dict-aws": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-1.0.14.tgz",
+      "integrity": "sha512-K21CfB4ZpKYwwDQiPfic2zJA/uxkbsd4IQGejEvDAhE3z8wBs6g6BwwqdVO767M9NgZqc021yAVpr79N5pWe3w=="
+    },
+    "@cspell/dict-bash": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-1.0.15.tgz",
+      "integrity": "sha512-rY5Bq4RWTgJTioG8vqFbCmnalc/UEM+iBuAZBYvBfT3nU/6SN00Zjyvlh823ir2ODkUryT29CwRYwXcPnuM04w=="
+    },
+    "@cspell/dict-companies": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-1.0.40.tgz",
+      "integrity": "sha512-Aw07qiTroqSST2P5joSrC4uOA05zTXzI2wMb+me3q4Davv1D9sCkzXY0TGoC2vzhNv5ooemRi9KATGaBSdU1sw=="
+    },
     "@cspell/dict-cpp": {
       "version": "1.1.40",
       "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-1.1.40.tgz",
-      "integrity": "sha512-sscfB3woNDNj60/yGXAdwNtIRWZ89y35xnIaJVDMk5TPMMpaDvuk0a34iOPIq0g4V+Y8e3RyAg71SH6ADwSjGw==",
-      "dev": true
+      "integrity": "sha512-sscfB3woNDNj60/yGXAdwNtIRWZ89y35xnIaJVDMk5TPMMpaDvuk0a34iOPIq0g4V+Y8e3RyAg71SH6ADwSjGw=="
+    },
+    "@cspell/dict-cryptocurrencies": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-1.0.10.tgz",
+      "integrity": "sha512-47ABvDJOkaST/rXipNMfNvneHUzASvmL6K/CbOFpYKfsd0x23Jc9k1yaOC7JAm82XSC/8a7+3Yu+Fk2jVJNnsA=="
     },
     "@cspell/dict-csharp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-1.0.11.tgz",
-      "integrity": "sha512-nub+ZCiTgmT87O+swI+FIAzNwaZPWUGckJU4GN402wBq420V+F4ZFqNV7dVALJrGaWH7LvADRtJxi6cZVHJKeA==",
-      "dev": true
+      "integrity": "sha512-nub+ZCiTgmT87O+swI+FIAzNwaZPWUGckJU4GN402wBq420V+F4ZFqNV7dVALJrGaWH7LvADRtJxi6cZVHJKeA=="
     },
     "@cspell/dict-css": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-1.0.12.tgz",
-      "integrity": "sha512-K6yuxej7n454O7dwKG6lHacHrAOMZ0PhMEbmV6qH2JH0U4TtWXfBASYugHvXZCDDx1UObpiJP+3tQJiBqfGpHA==",
-      "dev": true
+      "integrity": "sha512-K6yuxej7n454O7dwKG6lHacHrAOMZ0PhMEbmV6qH2JH0U4TtWXfBASYugHvXZCDDx1UObpiJP+3tQJiBqfGpHA=="
+    },
+    "@cspell/dict-django": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-1.0.26.tgz",
+      "integrity": "sha512-mn9bd7Et1L2zuibc08GVHTiD2Go3/hdjyX5KLukXDklBkq06r+tb0OtKtf1zKodtFDTIaYekGADhNhA6AnKLkg=="
+    },
+    "@cspell/dict-dotnet": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-1.0.31.tgz",
+      "integrity": "sha512-65yZTMcEdYkNx9sNs18OxcE0zfbZ5VsAZ0KgDvl/1YCkTomxr9vmtnrzFz4+vxfjV4eSuaL1SPRMZODaM7SSTg=="
+    },
+    "@cspell/dict-elixir": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-1.0.25.tgz",
+      "integrity": "sha512-ZmawoBYjM5k+8fNudRMkK+PpHjhyAFAZt2rUu1EGj2rbCvE3Fn2lhRbDjbreN7nWRvcLRTW+xuPXtKP11X0ahQ=="
+    },
+    "@cspell/dict-en-gb": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-2.0.2.tgz",
+      "integrity": "sha512-xpI0O/5nmf25BtJXC3ceN/k6NqhvFIcylhsgb0YtwIbNMA9MFt9L+zb16dfESXteNj5uJNPCkyI0kPhShnpxtg=="
+    },
+    "@cspell/dict-en_us": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-2.1.1.tgz",
+      "integrity": "sha512-7kHOqve9DVFsb1e/wKME3CZhj48zOqvXNaA1Cd82ZkaHf3aL7pUBx3cxI7Xopj/dcK1ZkhUKh+2nBxPIWIibNg=="
     },
     "@cspell/dict-fa-ir": {
       "version": "1.0.17",
@@ -411,17 +505,66 @@
       "integrity": "sha512-+Bq9hAe07Vwl2gJHHKyArLbFEk8EMlxewd5+E2rESgwk6yE+4aKGnMbDw9t59jx/D8MGja1lFBilvcf/CfX0LQ==",
       "dev": true
     },
+    "@cspell/dict-filetypes": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-1.1.8.tgz",
+      "integrity": "sha512-EllahNkhzvLWo0ptwu0l3oEeAJOQSUpZnDfnKRIh6mJVehuSovNHwA9vrdZ8jBUjuqcfaN2e7c32zN0D/qvWJQ=="
+    },
+    "@cspell/dict-fonts": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-1.0.14.tgz",
+      "integrity": "sha512-VhIX+FVYAnqQrOuoFEtya6+H72J82cIicz9QddgknsTqZQ3dvgp6lmVnsQXPM3EnzA8n1peTGpLDwHzT7ociLA=="
+    },
     "@cspell/dict-fr-fr": {
       "version": "1.2.21",
       "resolved": "https://registry.npmjs.org/@cspell/dict-fr-fr/-/dict-fr-fr-1.2.21.tgz",
       "integrity": "sha512-RGBRIjTAm2QAlYbw1MkbxK9CgeSkdaKfpM1lNPDJmuN/Ds5JB5itCkVHa0r8BGa5dPfYK5bm02AlM7iBeOvDQA==",
       "dev": true
     },
+    "@cspell/dict-fullstack": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-1.0.38.tgz",
+      "integrity": "sha512-4reajWiUxwWrSyZaWm9e15kaWzjYcZbzlB+CVcxE1+0NqdIoqlEESDhbnrAjKPSq+jspKtes7nQ1CdZEOj1gCA=="
+    },
+    "@cspell/dict-golang": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-1.1.24.tgz",
+      "integrity": "sha512-qq3Cjnx2U1jpeWAGJL1GL0ylEhUMqyaR36Xij6Y6Aq4bViCRp+HRRqk0x5/IHHbOrti45h3yy7ii1itRFo+Xkg=="
+    },
+    "@cspell/dict-haskell": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-1.0.13.tgz",
+      "integrity": "sha512-kvl8T84cnYRPpND/P3D86P6WRSqebsbk0FnMfy27zo15L5MLAb3d3MOiT1kW3vEWfQgzUD7uddX/vUiuroQ8TA=="
+    },
     "@cspell/dict-html": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-1.1.9.tgz",
-      "integrity": "sha512-vvnYia0tyIS5Fdoz+gEQm77MGZZE66kOJjuNpIYyRHCXFAhWdYz3SmkRm6YKJSWSvuO+WBJYTKDvkOxSh3Fx/w==",
-      "dev": true
+      "integrity": "sha512-vvnYia0tyIS5Fdoz+gEQm77MGZZE66kOJjuNpIYyRHCXFAhWdYz3SmkRm6YKJSWSvuO+WBJYTKDvkOxSh3Fx/w=="
+    },
+    "@cspell/dict-html-symbol-entities": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-1.0.23.tgz",
+      "integrity": "sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw=="
+    },
+    "@cspell/dict-java": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-1.0.23.tgz",
+      "integrity": "sha512-LcOg9srYLDoNGd8n3kbfDBlZD+LOC9IVcnFCdua1b/luCHNVmlgBx7e677qPu7olpMYOD5TQIVW2OmM1+/6MFA=="
+    },
+    "@cspell/dict-latex": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-1.0.25.tgz",
+      "integrity": "sha512-cEgg91Migqcp1SdVV7dUeMxbPDhxdNo6Fgq2eygAXQjIOFK520FFvh/qxyBvW90qdZbIRoU2AJpchyHfGuwZFA=="
+    },
+    "@cspell/dict-lorem-ipsum": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-1.0.22.tgz",
+      "integrity": "sha512-yqzspR+2ADeAGUxLTfZ4pXvPl7FmkENMRcGDECmddkOiuEwBCWMZdMP5fng9B0Q6j91hQ8w9CLvJKBz10TqNYg=="
+    },
+    "@cspell/dict-lua": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-1.0.16.tgz",
+      "integrity": "sha512-YiHDt8kmHJ8nSBy0tHzaxiuitYp+oJ66ffCYuFWTNB3//Y0SI4OGHU3omLsQVeXIfCeVrO4DrVvRDoCls9B5zQ=="
     },
     "@cspell/dict-nl-nl": {
       "version": "2.0.1",
@@ -429,11 +572,60 @@
       "integrity": "sha512-XxYhl/roKAEx8vSWn6AvbNpOSRBmD2Iu+1qBI3zK8NdItMGJgUY2vHwDis/1JrUwXMLNlZkhO44H2irWfaYy0Q==",
       "dev": true
     },
+    "@cspell/dict-node": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-1.0.12.tgz",
+      "integrity": "sha512-RPNn/7CSkflAWk0sbSoOkg0ORrgBARUjOW3QjB11KwV1gSu8f5W/ij/S50uIXtlrfoBLqd4OyE04jyON+g/Xfg=="
+    },
+    "@cspell/dict-npm": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-1.0.16.tgz",
+      "integrity": "sha512-RwkuZGcYBxL3Yux3cSG/IOWGlQ1e9HLCpHeyMtTVGYKAIkFAVUnGrz20l16/Q7zUG7IEktBz5O42kAozrEnqMQ=="
+    },
+    "@cspell/dict-php": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-1.0.24.tgz",
+      "integrity": "sha512-vHCqETX1idT9tN1plkxUFnXMIHjbbrNOINZh1PYSvVlBrOdahSaL/g6dOJZC5QTaaidoU4WXUlgnNb/7JN4Plg=="
+    },
+    "@cspell/dict-powershell": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-1.0.18.tgz",
+      "integrity": "sha512-LAfCJBy1hga8/KI/IpAg/GrnoP+b4SbNGdiXiXrejeZ7ZTVfj4qYsTCkZ2p7eYUu92FLyJT4jGex0fGZn/PtVw=="
+    },
+    "@cspell/dict-public-licenses": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-1.0.3.tgz",
+      "integrity": "sha512-sXjxOHJ9Q4rZvE1UbwpwJQ8EXO3fadKBjJIWmz0z+dZAbvTrmz5Ln1Ef9ruJvLPfwAps8m3TCV6Diz60RAQqHg=="
+    },
     "@cspell/dict-python": {
       "version": "1.0.37",
       "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-1.0.37.tgz",
-      "integrity": "sha512-RPeYJxC7t6k9uL4aQp5kLarOddEAqfRw9VBTt+cOVSlMqEtEtxJGm8w91V28fwnRX4hQR0yhiHPEYcdLpMtpfQ==",
-      "dev": true
+      "integrity": "sha512-RPeYJxC7t6k9uL4aQp5kLarOddEAqfRw9VBTt+cOVSlMqEtEtxJGm8w91V28fwnRX4hQR0yhiHPEYcdLpMtpfQ=="
+    },
+    "@cspell/dict-ruby": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-1.0.14.tgz",
+      "integrity": "sha512-XHBGN4U1y9rjRuqrCA+3yIm2TCdhwwHXpOEcWkNeyXm8K03yPnIrKFS+kap8GTTrLpfNDuFsrmkkQTa7ssXLRA=="
+    },
+    "@cspell/dict-rust": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-1.0.23.tgz",
+      "integrity": "sha512-lR4boDzs79YD6+30mmiSGAMMdwh7HTBAPUFSB0obR3Kidibfc3GZ+MHWZXay5dxZ4nBKM06vyjtanF9VJ8q1Iw=="
+    },
+    "@cspell/dict-scala": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-1.0.21.tgz",
+      "integrity": "sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA=="
+    },
+    "@cspell/dict-software-terms": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-1.0.42.tgz",
+      "integrity": "sha512-VRIq7b6NnWVHeO0pzpHT10btQNYcRCyiSZc162xGlyO8+IMXq9Noemyqv+POS9oRknhtlF0rL1Hrg4ypHP3B+w=="
+    },
+    "@cspell/dict-typescript": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
+      "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1063,9 +1255,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/parse-json": {
@@ -1340,7 +1532,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -1590,6 +1781,28 @@
         }
       }
     },
+    "cspell-glob": {
+      "version": "5.10.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-5.10.0-alpha.3.tgz",
+      "integrity": "sha512-+eA1PmZ9intm3hOVK8f6srnWXA6mynqPpR0+HlDUwo7lmdzsnOZGOBvCy9ZGJQIwZ8tjIo6KPCjO2zTN8wri5Q==",
+      "requires": {
+        "micromatch": "^4.0.4"
+      }
+    },
+    "cspell-io": {
+      "version": "5.10.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.10.0-alpha.3.tgz",
+      "integrity": "sha512-huPsLrd/sNd1KIjsLxd12pJcCe8YkKIjT651cZNRmfch7Gn1WK5NsY/kzp4ts2BiyXTyYl48wqGmA/nkvSB83w=="
+    },
+    "cspell-trie-lib": {
+      "version": "5.10.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.10.0-alpha.5.tgz",
+      "integrity": "sha512-k5Dxv8/pRf4VLN1XXgvO7RrEPQyinwAypNpx0DCkhNxEQrJIJ+Ah1pHiVQezr9kYn+sovcmnwW5wB079pl225g==",
+      "requires": {
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1"
+      }
+    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -1701,9 +1914,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {
@@ -1837,7 +2050,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -2121,8 +2333,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-obj": {
       "version": "2.0.0",
@@ -3652,7 +3863,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -3861,8 +4071,7 @@
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
     },
     "pirates": {
       "version": "4.0.1",
@@ -4251,7 +4460,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/packages/cspell-tools/package-lock.json
+++ b/packages/cspell-tools/package-lock.json
@@ -786,9 +786,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1306,9 +1306,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-trie-lib/package-lock.json
+++ b/packages/cspell-trie-lib/package-lock.json
@@ -772,9 +772,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1256,9 +1256,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-trie/package-lock.json
+++ b/packages/cspell-trie/package-lock.json
@@ -760,9 +760,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1258,9 +1258,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-trie2-lib/package-lock.json
+++ b/packages/cspell-trie2-lib/package-lock.json
@@ -751,9 +751,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1235,9 +1235,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell-types/package-lock.json
+++ b/packages/cspell-types/package-lock.json
@@ -757,9 +757,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1274,9 +1274,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/cspell/package-lock.json
+++ b/packages/cspell/package-lock.json
@@ -1043,9 +1043,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/parse-json": {
@@ -1641,9 +1641,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/packages/hunspell-reader/package-lock.json
+++ b/packages/hunspell-reader/package-lock.json
@@ -770,9 +770,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/prettier": {
@@ -1268,9 +1268,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {

--- a/test-packages/test-cspell-lib-webpack/package-lock.json
+++ b/test-packages/test-cspell-lib-webpack/package-lock.json
@@ -1254,9 +1254,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.2.tgz",
+      "integrity": "sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==",
       "dev": true
     },
     "@types/parse-json": {
@@ -2148,9 +2148,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.840",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.840.tgz",
-      "integrity": "sha512-yRoUmTLDJnkIJx23xLY7GbSvnmDCq++NSuxHDQ0jiyDJ9YZBUGJcrdUqm+ZwZFzMbCciVzfem2N2AWiHJcWlbw==",
+      "version": "1.3.842",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
+      "integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
       "dev": true
     },
     "emittery": {


### PR DESCRIPTION
Related to #1709 