### PR TITLE
fix: Roll back update to `@cspell/dict-en-gb@2`

### DIFF
--- a/packages/cspell-bundled-dicts/package-lock.json
+++ b/packages/cspell-bundled-dicts/package-lock.json
@@ -4,6 +4,27 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@cspell/cspell-tools": {
+      "version": "5.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-tools/-/cspell-tools-5.10.0-alpha.6.tgz",
+      "integrity": "sha512-s9k0s68YqP6JXYaN/Y8TDqxHM8dqB8yU3IaL5ri6c0JICSYiPSIOyAqQiB/hwcMb2ycClLUulaGkUqcCphdacQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^8.2.0",
+        "cspell-io": "^5.10.0-alpha.6",
+        "cspell-trie-lib": "^5.10.0-alpha.6",
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1",
+        "glob": "^7.1.7",
+        "hunspell-reader": "^5.10.0-alpha.6"
+      }
+    },
+    "@cspell/cspell-types": {
+      "version": "5.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.10.0-alpha.6.tgz",
+      "integrity": "sha512-BZ2dB0+LutFQjwtZnS9F2vr2y1CyjsmLmCRkFUg1uMUWmvlMIXgQWhfWYnez9zXi8TiegX0wAchZ+sIPwiIe1w==",
+      "dev": true
+    },
     "@cspell/dict-ada": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
@@ -178,6 +199,182 @@
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
       "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
+      "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cspell-io": {
+      "version": "5.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.10.0-alpha.6.tgz",
+      "integrity": "sha512-YDx7dDVO+yZ1N8HwEAeY0lZI1zA5j/esqT3VIogQbIxHlSOksIzvgmowkCSJ2iQrwYpE2V7BQabYNKYyY6DRGQ==",
+      "dev": true
+    },
+    "cspell-trie-lib": {
+      "version": "5.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.10.0-alpha.6.tgz",
+      "integrity": "sha512-AGqWHhQuHQ9D05CjLsXHsX0rR7CO6bcFqdi+Kek1WQLx+vJc2WM9Iasn80eriZcnGHbfR+KTudjTnHWs1byoqA==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1"
+      }
+    },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "gensequence": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.1.1.tgz",
+      "integrity": "sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "dev": true
+    },
+    "hunspell-reader": {
+      "version": "5.10.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/hunspell-reader/-/hunspell-reader-5.10.0-alpha.6.tgz",
+      "integrity": "sha512-P+72OEN5W/VBiOuUpzjpxBOimuxnz++WDrvrGymNTXoKUmsBIndY/zM8sz7OU16rmimzlUnCWRiHf/yHjGIe8w==",
+      "dev": true,
+      "requires": {
+        "commander": "^8.2.0",
+        "fs-extra": "^10.0.0",
+        "gensequence": "^3.1.1",
+        "iconv-lite": "^0.6.3"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/packages/cspell-bundled-dicts/package.json
+++ b/packages/cspell-bundled-dicts/package.json
@@ -43,9 +43,6 @@
     "url": "https://github.com/streetsidesoftware/cspell/labels/cspell-bundled-dicts"
   },
   "homepage": "https://github.com/streetsidesoftware/cspell#readme",
-  "optionalDependencies": {
-    "@cspell/dict-en-gb": "^2.0.2"
-  },
   "dependencies": {
     "@cspell/dict-ada": "^1.1.2",
     "@cspell/dict-aws": "^1.0.14",


### PR DESCRIPTION
Related to #1709 