### PR TITLE
ci:Revert - Disable Coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,11 +23,11 @@ jobs:
       - run: npm run build
       - run: npm run coverage
 
-      # - name: Upload coverage Coveralls
-      #   uses: coverallsapp/github-action@1.1.3
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     path-to-lcov: ./lcov.info
+      - name: Upload coverage Coveralls
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
When the Coveralls API is back online, land this diff.

> "ci: Disable Coveralls - their API has been down for a couple of days. (#1731)"
This reverts commit 9922998daebaec204cbd0dd3890888fdd24267a1.