### PR TITLE
fix: Patterns - only add `u` if no flags are given

### DIFF
--- a/packages/cspell-lib/src/Settings/InDocSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.test.ts
@@ -67,7 +67,7 @@ describe('Validate InDocSettings', () => {
         const matches = InDoc.getIgnoreRegExpFromDocument(sampleCode);
         expect(matches).toEqual(['/\\/\\/\\/.*/', 'w\\w+berry', '/', '\\w+s{4}\\w+', '/faullts[/]?/ */']);
         const regExpList = matches.map((s) => Text.stringToRegExp(s));
-        expect(regExpList).toEqual([/\/\/\/.*/gu, /w\w+berry/gimu, /\//gimu, /\w+s{4}\w+/gimu, /faullts[/]?\/ */gu]);
+        expect(regExpList).toEqual([/\/\/\/.*/g, /w\w+berry/gimu, /\//gimu, /\w+s{4}\w+/gimu, /faullts[/]?\/ */g]);
         const ranges = TextRange.findMatchingRangesForPatterns(matches, sampleCode);
         expect(ranges.length).toBe(39);
     });

--- a/packages/cspell-lib/src/util/text.test.ts
+++ b/packages/cspell-lib/src/util/text.test.ts
@@ -6,13 +6,16 @@ import { splitCamelCaseWord } from './text';
 
 describe('Util Text', () => {
     test.each`
-        pattern     | expected
-        ${''}       | ${undefined}
-        ${'a'}      | ${/a/gimu}
-        ${'/'}      | ${/\//gimu}
-        ${'/.*/'}   | ${/.*/gu}
-        ${'/.*/gi'} | ${/.*/giu}
-        ${/abc/}    | ${/abc/}
+        pattern      | expected
+        ${''}        | ${undefined}
+        ${'a'}       | ${/a/gimu}
+        ${'/'}       | ${/\//gimu}
+        ${'/.*/'}    | ${/.*/g}
+        ${'/.*/m'}   | ${/.*/gm}
+        ${'/.*/gi'}  | ${/.*/gi}
+        ${'/.*/giu'} | ${/.*/giu}
+        ${/abc/}     | ${/abc/}
+        ${/abc/gu}   | ${/abc/gu}
     `('tests build regexp from string', ({ pattern, expected }) => {
         expect(Text.stringToRegExp(pattern)).toEqual(expected);
     });

--- a/packages/cspell-lib/src/util/text.ts
+++ b/packages/cspell-lib/src/util/text.ts
@@ -175,7 +175,7 @@ function offsetMap(offset: number) {
     return <T extends OffsetMap>(xo: T) => ({ ...xo, offset: xo.offset + offset } as T);
 }
 
-export function stringToRegExp(pattern: string | RegExp, defaultFlags = 'gimu', forceFlags = 'gu'): RegExp | undefined {
+export function stringToRegExp(pattern: string | RegExp, defaultFlags = 'gimu', forceFlags = 'g'): RegExp | undefined {
     if (pattern instanceof RegExp) {
         return pattern;
     }


### PR DESCRIPTION
`u` is over 100x slower to run. So, only add it if no flags are given.
Logic: If they know enough to add flags, then they can add `u` if needed.

Related to: #1699