### PR TITLE
chore: Add Dependabot for Gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
     schedule:
       interval: "daily"
 
+
+  - package-ecosystem: "bundler"
+    # The Gemfile used in for the Jekyll doc site
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
     schedule:
       interval: "daily"
 
-
   - package-ecosystem: "bundler"
     # The Gemfile used in for the Jekyll doc site
     directory: "/docs"


### PR DESCRIPTION
I didn't add it to the 4 branch, because the site can only run off one branch