### PR TITLE
docs: Add example of patterns configuration

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -98,4 +98,27 @@ Or you can specify a path to a config file with the `--config <path>` argument o
 - `includeRegExpList` - _(Advanced)_ limits the text checked to be only that matching the expressions in the list.
 - `patterns` - this allows you to define named patterns to be used with
   `ignoreRegExpList` and `includeRegExpList`.
+
+  **Example**
+
+  ```javascript
+  "patterns": [
+      {
+          "name": "comment-single-line",
+          "pattern": "/#.*/g"
+      },
+      {
+          "name": "comment-multi-line",
+          "pattern": "/(?:\\/\\*[\\s\\S]*?\\*\\/)/g"
+      },
+      // You can also combine multiple named patterns into one single named pattern
+      {
+          "name": "comments",
+          "pattern": ["comment-single-line", "comment-multi-line"]
+      }
+  ],
+
+  "ignoreRegExpList": ["comments"]
+  ```
+
 - `languageSettings` - this allow for per programming language configuration settings. See [LanguageSettings](./language-settings.md#LanguageSettings)


### PR DESCRIPTION
I think it will be nice if there is an example to setup `patterns` setting is the docs.

It may help us understand the structure of the `patterns` from a quick glance.

PS. The patterns used in the example is from the test file of this feature (https://github.com/streetsidesoftware/cspell/blob/5375c73e47/packages/cspell-lib/src/Settings/patterns.test.ts#L7-L18)