### PR TITLE
added `SpellingDictionaryCollection` to cspell-lib exports

### DIFF
--- a/packages/cspell-lib/src/index.ts
+++ b/packages/cspell-lib/src/index.ts
@@ -35,6 +35,7 @@ export {
     SpellingDictionaryLoadError,
     SuggestionCollector,
     SuggestionResult,
+    SpellingDictionaryCollection,
 } from './SpellingDictionary';
 export * from './trace';
 export { getLogger, Logger, setLogger } from './util/logger';


### PR DESCRIPTION
I'm trying to use `cspell-lib` in our application (we're building a spell-checker service in node - more details here: https://github.com/streetsidesoftware/cspell/issues/1813). 

I need to use the `SpellingDictionaryCollection` class to be able to add custom dictionaries, but this class is not exported from `cspell-lib`. The only way to import it is:

``` js
import { SpellingDictionaryCollection } from 'cspell-lib/dist/SpellingDictionary';
```

But this isn't a good solution as it causes Webpack builds to fail because of non-static `require()` calls.

This PR adds `SpellingDictionaryCollection` to `packages/cspell-lib/src/index.ts` exports, thanks to this it can be imported this way:

``` js
import { SpellingDictionaryCollection } from 'cspell-lib';
```