### PR TITLE
fix: Fix `.gitignore` glob matching

### DIFF
--- a/packages/cspell-gitignore/src/GitIgnoreFile.ts
+++ b/packages/cspell-gitignore/src/GitIgnoreFile.ts
@@ -20,7 +20,8 @@ export class GitIgnoreFile {
 
     static async loadGitignore(gitignore: string): Promise<GitIgnoreFile> {
         const content = await fs.readFile(gitignore, 'utf8');
-        const globMatcher = new GlobMatcher(content, path.dirname(gitignore));
+        const options = { root: path.dirname(gitignore) };
+        const globMatcher = new GlobMatcher(content, options);
         return new GitIgnoreFile(globMatcher, gitignore);
     }
 }

--- a/packages/cspell/src/lint.ts
+++ b/packages/cspell/src/lint.ts
@@ -268,7 +268,10 @@ Options:
 
     function filterFiles(files: string[], globMatcher: GlobMatcher): string[] {
         const patterns = globMatcher.patterns;
-        const excludeInfo = patterns.map(extractGlobSource).map(({ glob, source }) => `Glob: ${glob} from ${source}`);
+        const excludeInfo = patterns
+            .map(extractGlobSource)
+            .map(({ glob, source }) => `Glob: ${glob} from ${source}`)
+            .filter(util.uniqueFn());
         reporter.info(`Exclusion Globs: \n    ${excludeInfo.join('\n    ')}\n`, MessageTypes.Info);
         const result = files.filter(util.uniqueFn()).filter((filename) => !isExcluded(filename, globMatcher));
         return result;

--- a/packages/cspell/src/util/glob.test.ts
+++ b/packages/cspell/src/util/glob.test.ts
@@ -93,16 +93,17 @@ describe('Validate internal functions', () => {
     }
 
     test.each`
-        glob               | globRoot          | root              | expectedGlobs                           | file                                | expectedToMatch
-        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                                   | ${''}                               | ${false}
-        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['**/{*.json,*.json/**}']}            | ${'./package.json'}                 | ${true}
-        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['**/{*.json,*.json/**}']}            | ${'./.git/package.json'}            | ${true}
-        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/{*.json,*.json/**}']} | ${'./project/p1/package.json'}      | ${true}
-        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/{*.json,*.json/**}']} | ${'./project/p1/src/package.json'}  | ${true}
-        ${'*.json'}        | ${'.'}            | ${'./project/p2'} | ${['**/{*.json,*.json/**}']}            | ${'./project/p2/package.json'}      | ${true}
-        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                                   | ${''}                               | ${false}
-        ${'**/src/*.json'} | ${'.'}            | ${'./project/p2'} | ${['**/src/*.json']}                    | ${'./project/p2/x/src/config.json'} | ${true}
-        ${'**/src/*.json'} | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/src/*.json']}         | ${'./project/p1/src/config.json'}   | ${true}
+        glob               | globRoot          | root              | expectedGlobs                                                  | file                                | expectedToMatch
+        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                                                          | ${''}                               | ${false}
+        ${'**'}            | ${'.'}            | ${'.'}            | ${['**']}                                                      | ${'./package.json'}                 | ${true}
+        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['**/*.json', '**/*.json/**']}                               | ${'./package.json'}                 | ${true}
+        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['**/*.json', '**/*.json/**']}                               | ${'./.git/package.json'}            | ${true}
+        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/*.json', 'project/p1/**/*.json/**']}         | ${'./project/p1/package.json'}      | ${true}
+        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/*.json', 'project/p1/**/*.json/**']}         | ${'./project/p1/src/package.json'}  | ${true}
+        ${'*.json'}        | ${'.'}            | ${'./project/p2'} | ${['**/*.json', '**/*.json/**']}                               | ${'./project/p2/package.json'}      | ${true}
+        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                                                          | ${''}                               | ${false}
+        ${'**/src/*.json'} | ${'.'}            | ${'./project/p2'} | ${['**/src/*.json', '**/src/*.json/**']}                       | ${'./project/p2/x/src/config.json'} | ${true}
+        ${'**/src/*.json'} | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/src/*.json', 'project/p1/**/src/*.json/**']} | ${'./project/p1/src/config.json'}   | ${true}
     `(
         'mapGlobToRoot exclude "$glob"@"$globRoot" -> "$root" = "$expectedGlobs"',
         ({ glob, globRoot, root, expectedGlobs, file, expectedToMatch }: TestMapGlobToRoot) => {


### PR DESCRIPTION
Fixes two issues:
- fix #1846
    ```gitignore
    *.py,cover
    ```
- And another where the following `.gitignore` lines were not matching directories:

    ```gitignore
    */node_modules
    **/coverage
    ```