### PR TITLE
fix: cspell-tools - limit memory usage when build dictionaries

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -47,6 +47,7 @@ repo
 repos
 retryable
 serializers
+sigs
 specberus
 streetsidesoftware
 submodule

--- a/packages/cspell-trie-lib/cspell.json
+++ b/packages/cspell-trie-lib/cspell.json
@@ -3,6 +3,7 @@
         "tsbuildinfo"
     ],
     "import": [
+        "../../cspell.json",
         "@cspell/dict-es-es/cspell-ext.json"
     ]
 }

--- a/packages/cspell-trie-lib/src/lib/TrieBuilder.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBuilder.test.ts
@@ -1,5 +1,8 @@
 import { countNodes, isCircular } from './util';
-import { TrieBuilder, buildTrie } from './TrieBuilder';
+import { TrieBuilder, buildTrie, __testing__ } from './TrieBuilder';
+import { TrieNode } from '.';
+
+const { trimSignatures, trimMap } = __testing__;
 
 describe('Validate TrieBuilder', () => {
     test('builder explicit consolidateSuffixes', () => {
@@ -30,6 +33,49 @@ describe('Validate TrieBuilder', () => {
     test('buildTrie', () => {
         const trie = buildTrie(sampleWords);
         expect([...trie.words()]).toEqual(sampleWords.sort());
+    });
+
+    test('trimSignatures', () => {
+        const n: TrieNode = {};
+        const sigs = sampleWords;
+        const soloSigs = sigs.filter((_, i) => !!(i & 1));
+        const signatures = new Map(sigs.map((w) => [w, n]));
+        const solo = new Set(soloSigs);
+
+        // verify preconditions
+        expect(signatures.size).toBe(sigs.length);
+        expect(solo.size).toBe(soloSigs.length);
+
+        // Nothing should change, solo is within bounds.
+        trimSignatures(signatures, solo, sampleWords.length);
+        expect(signatures.size).toBe(sigs.length);
+        expect(solo.size).toBe(soloSigs.length);
+
+        // trim and make sure the newest values are left.
+        trimSignatures(signatures, solo, 5, 10);
+        expect(signatures.size).toBe(sigs.length - soloSigs.length + 5);
+        expect(solo.size).toBe(5);
+        // verify newest are left
+        expect([...solo]).toEqual(soloSigs.slice(-5));
+    });
+
+    test('trimMap', () => {
+        const n: TrieNode = {};
+        const values = sampleWords;
+        const mapOfValues = new Map(values.map((w) => [w, n]));
+
+        // verify preconditions
+        expect(mapOfValues.size).toBe(values.length);
+
+        // Nothing should change, solo is within bounds.
+        trimMap(mapOfValues, sampleWords.length);
+        expect(mapOfValues.size).toBe(values.length);
+
+        // trim and make sure the newest values are left.
+        trimMap(mapOfValues, 5, 10);
+        expect(mapOfValues.size).toBe(5);
+        // verify newest are left
+        expect([...mapOfValues.keys()]).toEqual(values.slice(-5));
     });
 });
 

--- a/packages/cspell-trie-lib/src/lib/index.ts
+++ b/packages/cspell-trie-lib/src/lib/index.ts
@@ -3,7 +3,7 @@ export { TrieNode, FLAG_WORD, ChildMap, TrieRoot } from './TrieNode';
 export * from './util';
 export * from './walker';
 export * from './importExport';
-export * from './TrieBuilder';
+export { buildTrie, buildTrieFast, TrieBuilder } from './TrieBuilder';
 export * from './consolidate';
 export { SuggestionResult, MaxCost, suggestionCollector, SuggestionCollector } from './suggestCollector';
 export { parseDictionaryLines, parseDictionary } from './SimpleDictionaryParser';


### PR DESCRIPTION
When compiling Estonian, it would cause node to run out of keys due to caching highly repetitive suffixes.