### PR TITLE
fix: make config file version `0.2` by default.

### DIFF
--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -6,6 +6,7 @@ import {
     calcOverrideSettings,
     checkFilenameMatchesGlob,
     clearCachedSettingsFiles,
+    currentSettingsFileVersion,
     ENV_CSPELL_GLOB_ROOT,
     extractDependencies,
     extractImportErrors,
@@ -32,6 +33,7 @@ const root = path.resolve(rootCspellLib, '../..');
 const samplesDir = path.resolve(rootCspellLib, 'samples');
 const samplesSrc = path.join(samplesDir, 'src');
 const testFixtures = path.join(rootCspellLib, '../../test-fixtures');
+const oc = expect.objectContaining;
 
 jest.mock('../util/logger');
 
@@ -365,7 +367,8 @@ describe('Validate Glob resolution', () => {
         expect(settingsV1).not.toEqual(sampleSettingsV1);
 
         delete settingsV1.version;
-        expect(settingsV1).toEqual(sampleSettings);
+        const { version: _, ...sample } = sampleSettings;
+        expect(settingsV1).toEqual(sample);
     });
 
     test('Using ENV_CSPELL_GLOB_ROOT as without shared hierarchy', () => {
@@ -373,10 +376,14 @@ describe('Validate Glob resolution', () => {
         const settingsV = normalizeSettings(rawSampleSettings, __filename, {});
         const settingsV1 = normalizeSettings(rawSampleSettingsV1, __filename, {});
 
+        expect(settingsV.version).toEqual(currentSettingsFileVersion);
+
+        expect(settingsV1).toEqual(oc({ version: '0.1' }));
         expect(settingsV).not.toEqual(sampleSettings);
         expect(settingsV1).not.toEqual(sampleSettingsV1);
 
         delete settingsV1.version;
+        delete settingsV.version;
         expect(settingsV1).toEqual(settingsV);
     });
 
@@ -659,10 +666,6 @@ function p(...parts: string[]): string {
 
 function r(...parts: string[]): string {
     return path.resolve(__dirname, p(...parts));
-}
-
-function oc<T>(v: Partial<T>): T {
-    return expect.objectContaining(v);
 }
 
 function relSamples(file: string) {

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -28,7 +28,7 @@ type CSpellSettingsVersion = Exclude<CSpellSettings['version'], undefined>;
 const supportedCSpellConfigVersions: CSpellSettingsVersion[] = ['0.2'];
 const configSettingsFileVersion0_1 = '0.1';
 const configSettingsFileVersion0_2 = '0.2';
-const currentSettingsFileVersion = configSettingsFileVersion0_2;
+export const currentSettingsFileVersion = configSettingsFileVersion0_2;
 
 const setOfSupportedConfigVersions = new Set<string>(supportedCSpellConfigVersions);
 
@@ -151,6 +151,7 @@ function normalizeSettings(
 
     // Fix up dictionaryDefinitions
     const settings = {
+        version: defaultSettings.version,
         ...rawSettings,
         id,
         name,


### PR DESCRIPTION
This fixes issues with ignorePaths and overrides.