### PR TITLE
ci: Upgrade `typedoc`

### DIFF
--- a/packages/cspell-types/package-lock.json
+++ b/packages/cspell-types/package-lock.json
@@ -13,7 +13,7 @@
         "jest": "^27.4.7",
         "rimraf": "^3.0.2",
         "ts-json-schema-generator": "^0.97.0",
-        "typedoc": "0.22.10",
+        "typedoc": "^0.22.11",
         "typedoc-plugin-markdown": "^3.11.11",
         "typescript": "^4.5.4"
       },
@@ -3055,12 +3055,12 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -3558,9 +3558,9 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
-      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.0.0",
@@ -3891,16 +3891,16 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
       "dev": true,
       "dependencies": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "shiki": "^0.10.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -6561,9 +6561,9 @@
       }
     },
     "marked": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
-      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true
     },
     "merge-stream": {
@@ -6937,9 +6937,9 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
-      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+      "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
@@ -7190,16 +7190,16 @@
       }
     },
     "typedoc": {
-      "version": "0.22.10",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
-      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "version": "0.22.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+      "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
       "dev": true,
       "requires": {
         "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^3.0.8",
+        "marked": "^4.0.10",
         "minimatch": "^3.0.4",
-        "shiki": "^0.9.12"
+        "shiki": "^0.10.0"
       }
     },
     "typedoc-plugin-markdown": {

--- a/packages/cspell-types/package.json
+++ b/packages/cspell-types/package.json
@@ -53,7 +53,7 @@
     "jest": "^27.4.7",
     "rimraf": "^3.0.2",
     "ts-json-schema-generator": "^0.97.0",
-    "typedoc": "0.22.10",
+    "typedoc": "^0.22.11",
     "typedoc-plugin-markdown": "^3.11.11",
     "typescript": "^4.5.4"
   }


### PR DESCRIPTION
Waiting on fix to: [Crash after upgrading from `0.22.10` to `0.22.11` · Issue #1852 · TypeStrong/typedoc](https://github.com/TypeStrong/typedoc/issues/1852)