### PR TITLE
fix: Handle missing files when spell checking from a file list.

### DIFF
--- a/packages/cspell/src/lint/lint.test.ts
+++ b/packages/cspell/src/lint/lint.test.ts
@@ -8,6 +8,7 @@ const samples = path.resolve(root, 'samples');
 const latexSamples = path.resolve(samples, 'latex');
 const hiddenSamples = path.resolve(samples, 'hidden-test');
 const filesToCheck = path.resolve(root, 'fixtures/features/file-list/files-to-check.txt');
+const filesToCheckWithMissing = path.resolve(root, 'fixtures/features/file-list/files-to-check-missing.txt');
 
 const oc = expect.objectContaining;
 const j = path.join;
@@ -24,23 +25,25 @@ describe('Linter Validation Tests', () => {
 
     // cspell:ignore Tufte
     test.each`
-        files               | options                                                                           | expectedRunResult              | expectedReport
-        ${[]}               | ${{ root: latexSamples }}                                                         | ${oc({ errors: 0, files: 4 })} | ${oc({ errorCount: 0, issues: [oc({ text: 'Tufte' })] })}
-        ${['**/ebook.tex']} | ${{ root: latexSamples }}                                                         | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/ebook.tex']} | ${{ root: latexSamples, gitignore: true }}                                        | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/hidden.md']} | ${{ root: hiddenSamples }}                                                        | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/hidden.md']} | ${{ root: hiddenSamples, dot: true }}                                             | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/*.md']}      | ${{ root: hiddenSamples, dot: false }}                                            | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/*.md']}      | ${{ root: hiddenSamples }}                                                        | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/*.md']}      | ${{ root: hiddenSamples, dot: true }}                                             | ${oc({ errors: 0, files: 2 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**']}           | ${{ root: samples, config: j(samples, 'cspell-not-found.json') }}                 | ${oc({ errors: 1, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(Error)], issues: [] })}
-        ${['**']}           | ${{ root: samples, config: j(samples, 'linked/cspell-import-missing.json') }}     | ${oc({ errors: 1, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(Error)], issues: [] })}
-        ${['**/ebook.tex']} | ${{ root: samples, config: j(samples, 'cspell-missing-dict.json') }}              | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
-        ${['**/ebook.tex']} | ${{ root: samples, config: j(samples, 'linked/cspell-import.json') }}             | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${[]}               | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheck], dot: true }} | ${oc({ errors: 0, files: 2 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/*.md']}      | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheck] }}            | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${['**/*.ts']}      | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheck] }}            | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, issues: [] })}
-        ${[]}               | ${{ root, config: j(root, 'cspell.json'), fileLists: ['missing-file.txt'] }}      | ${oc({ errors: 1, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(Error)], issues: [] })}
+        files               | options                                                                                                | expectedRunResult              | expectedReport
+        ${[]}               | ${{ root: latexSamples }}                                                                              | ${oc({ errors: 0, files: 4 })} | ${oc({ errorCount: 0, errors: [], issues: [oc({ text: 'Tufte' })] })}
+        ${['**/ebook.tex']} | ${{ root: latexSamples }}                                                                              | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/ebook.tex']} | ${{ root: latexSamples, gitignore: true }}                                                             | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/hidden.md']} | ${{ root: hiddenSamples }}                                                                             | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/hidden.md']} | ${{ root: hiddenSamples, dot: true }}                                                                  | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/*.md']}      | ${{ root: hiddenSamples, dot: false }}                                                                 | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/*.md']}      | ${{ root: hiddenSamples }}                                                                             | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/*.md']}      | ${{ root: hiddenSamples, dot: true }}                                                                  | ${oc({ errors: 0, files: 2 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**']}           | ${{ root: samples, config: j(samples, 'cspell-not-found.json') }}                                      | ${oc({ errors: 1, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(Error)], issues: [] })}
+        ${['**']}           | ${{ root: samples, config: j(samples, 'linked/cspell-import-missing.json') }}                          | ${oc({ errors: 1, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(Error)], issues: [] })}
+        ${['**/ebook.tex']} | ${{ root: samples, config: j(samples, 'cspell-missing-dict.json') }}                                   | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/ebook.tex']} | ${{ root: samples, config: j(samples, 'linked/cspell-import.json') }}                                  | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${[]}               | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheck], dot: true }}                      | ${oc({ errors: 0, files: 2 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/*.md']}      | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheck] }}                                 | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**/*.ts']}      | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheck] }}                                 | ${oc({ errors: 0, files: 1 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${[]}               | ${{ root, config: j(root, 'cspell.json'), fileLists: ['missing-file.txt'] }}                           | ${oc({ errors: 1, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(Error)], issues: [] })}
+        ${['**']}           | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheckWithMissing] }}                      | ${oc({ errors: 0, files: 3 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
+        ${['**']}           | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheckWithMissing], mustFindFiles: true }} | ${oc({ errors: 1, files: 3 })} | ${oc({ errorCount: 1, errors: [expect.anything()], issues: [] })}
     `('runLint $files $options', async ({ files, options, expectedRunResult, expectedReport }) => {
         const reporter = new InMemoryReporter();
         const runResult = await runLint(new LintRequest(files, options, reporter));

--- a/packages/cspell/src/options.ts
+++ b/packages/cspell/src/options.ts
@@ -57,6 +57,11 @@ export interface LinterOptions extends BaseOptions, CacheOptions {
      * - an entry of `stdin` means to read the file list from **`stdin`**
      */
     fileLists?: string[] | undefined;
+
+    /**
+     * Files must be found and processed otherwise it is considered an error.
+     */
+    mustFindFiles?: boolean;
 }
 
 export interface TraceOptions extends BaseOptions {

--- a/packages/cspell/src/util/errors.test.ts
+++ b/packages/cspell/src/util/errors.test.ts
@@ -1,5 +1,7 @@
 import { CheckFailed, ApplicationError, toError, isError, toApplicationError } from './errors';
 
+const oc = expect.objectContaining;
+
 describe('errors', () => {
     test.each`
         ErrorClass          | params
@@ -27,12 +29,12 @@ describe('errors', () => {
         error                                | expected
         ${new CheckFailed('CheckFailed')}    | ${new Error('CheckFailed')}
         ${new ApplicationError('App Error')} | ${new Error('App Error')}
-        ${{ message: 'msg', name: 'error' }} | ${{ message: 'msg', name: 'error' }}
-        ${'hello'}                           | ${{ name: 'error', message: 'hello' }}
-        ${null}                              | ${{ name: 'error', message: 'null' }}
-        ${undefined}                         | ${{ name: 'error', message: 'undefined' }}
-        ${42}                                | ${{ name: 'error', message: '42' }}
-        ${{}}                                | ${{ name: 'error', message: '{}' }}
+        ${{ message: 'msg', name: 'error' }} | ${oc({ message: 'msg', name: 'error' })}
+        ${'hello'}                           | ${oc({ name: 'error', message: 'hello' })}
+        ${null}                              | ${oc({ name: 'error', message: 'null' })}
+        ${undefined}                         | ${oc({ name: 'error', message: 'undefined' })}
+        ${42}                                | ${oc({ name: 'error', message: '42' })}
+        ${{}}                                | ${oc({ name: 'error', message: '{}' })}
     `('toError $error', ({ error, expected }) => {
         expect(toError(error)).toEqual(expected);
     });

--- a/packages/cspell/src/util/errors.ts
+++ b/packages/cspell/src/util/errors.ts
@@ -11,11 +11,27 @@ export class ApplicationError extends Error {
     }
 }
 
-export function toError(e: unknown): Error {
+export class IOError extends ApplicationError {
+    constructor(message: string, readonly cause: NodeError) {
+        super(message, undefined, cause);
+    }
+
+    get code(): string | undefined {
+        return this.cause.code;
+    }
+
+    isNotFound() {
+        return this.cause.code === 'ENOENT';
+    }
+}
+
+export function toError(e: unknown): NodeError {
     if (isError(e)) return e;
+    const message = format(e);
     return {
         name: 'error',
-        message: format(e),
+        message,
+        toString: () => message,
     };
 }
 
@@ -32,6 +48,7 @@ export function toApplicationError(e: unknown, message?: string): ApplicationErr
     return new ApplicationError(message ?? err.message, undefined, err);
 }
 
-interface NodeError extends Error {
+export interface NodeError extends Error {
     code?: string;
+    toString?: () => string;
 }


### PR DESCRIPTION
fix: #2285 

- Continue processing the list of files even if some are missing.
- Report on any missing files.
- error code is based upon `--no-must-file-files` option.