### PR TITLE
fix therefore typo

### DIFF
--- a/rfc/rfc-0002 improve dictionary suggestions/README.md
+++ b/rfc/rfc-0002 improve dictionary suggestions/README.md
@@ -94,7 +94,7 @@ costs:
 # The Algorithm
 
 The current algorithm uses a Levenshtein like algorithm to calculate the edit cost. This is different from
-Hunspell which tries to morph the misspelled word in many possible ways to see if it exists in the dictionary. This can be very expensive, therefor it is not used.
+Hunspell which tries to morph the misspelled word in many possible ways to see if it exists in the dictionary. This can be very expensive, therefore it is not used.
 
 ## A two step process
 


### PR DESCRIPTION
I think this maybe a typo and should be therefore.

REF: https://www.thefreedictionary.com/therefore-vs-therefor.htm

Also:
- https://github.com/streetsidesoftware/cspell/blob/b76fd122825f7ea1ef48dcf1d8da72a21ec0b17b/packages/cspell-lib/samples/forbid-words/README.md
- https://github.com/streetsidesoftware/cspell/blob/b76fd122825f7ea1ef48dcf1d8da72a21ec0b17b/packages/cspell-lib/samples/forbid-words/cspell.json