### PR TITLE
fix: Improve cli summary and progress

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
     "$schema": "./cspell.schema.json",
     "version": "0.2",
     "cache": {
+        "useCache": true,
         "cacheLocation": "./.cspell/.cspellcache",
         "cacheStrategy": "content"
     },

--- a/packages/cspell-types/src/CSpellReporter.ts
+++ b/packages/cspell-types/src/CSpellReporter.ts
@@ -29,21 +29,33 @@ export type ErrorEmitter = (message: string, error: ErrorLike) => void;
 
 export type SpellingErrorEmitter = (issue: Issue) => void;
 
-export type ProgressTypes = 'ProgressFileComplete';
-export type ProgressItem = ProgressFileComplete;
+export type ProgressTypes = 'ProgressFileBegin' | 'ProgressFileComplete';
+export type ProgressItem = ProgressFileBegin | ProgressFileComplete;
 
-interface ProgressBase {
+export interface ProgressBase {
     type: ProgressTypes;
 }
-export interface ProgressFileComplete extends ProgressBase {
-    type: 'ProgressFileComplete';
+
+export interface ProgressFileBase extends ProgressBase {
+    type: ProgressTypes;
     fileNum: number;
     fileCount: number;
     filename: string;
+}
+
+export interface ProgressFileComplete extends ProgressFileBase {
+    type: 'ProgressFileComplete';
     elapsedTimeMs: number | undefined;
     processed: boolean | undefined;
     numErrors: number | undefined;
     cached?: boolean;
+}
+
+/**
+ * Notification sent just before processing a file.
+ */
+export interface ProgressFileBegin extends ProgressFileBase {
+    type: 'ProgressFileBegin';
 }
 
 export type ProgressEmitter = (p: ProgressItem | ProgressFileComplete) => void;

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -10,6 +10,14 @@ log	./samples/fail-fast/second-fail.txt:1:1 - Unknown word (iamtypotoo)
 error	CSpell: Files checked: 2, Issues found: 2 in 2 files"
 `;
 
+exports[`Validate cli app --fail-fast no option Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/2 [90m./samples/fail-fast/first-fail.txt[39m ...
+2/2 [90m./samples/fail-fast/second-fail.txt[39m ...",
+]
+`;
+
 exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 2`] = `
@@ -18,12 +26,26 @@ log	./samples/fail-fast/first-fail.txt:1:1 - Unknown word (iamtypo)
 error	CSpell: Files checked: 1, Issues found: 1 in 1 files"
 `;
 
+exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/2 [90m./samples/fail-fast/first-fail.txt[39m ...",
+]
+`;
+
 exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 2`] = `
 "error	1/2 ./samples/fail-fast/first-fail.txt 0.00ms X
 log	./samples/fail-fast/first-fail.txt:1:1 - Unknown word (iamtypo)
 error	CSpell: Files checked: 1, Issues found: 1 in 1 files"
+`;
+
+exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/2 [90m./samples/fail-fast/first-fail.txt[39m ...",
+]
 `;
 
 exports[`Validate cli app --help Expect Error: outputHelp 1`] = `
@@ -53,6 +75,8 @@ Array [
 
 exports[`Validate cli app --help Expect Error: outputHelp 2`] = `""`;
 
+exports[`Validate cli app --help Expect Error: outputHelp 3`] = `Array []`;
+
 exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 2`] = `
@@ -63,11 +87,26 @@ log	./samples/fail-fast/second-fail.txt:1:1 - Unknown word (iamtypotoo)
 error	CSpell: Files checked: 2, Issues found: 2 in 2 files"
 `;
 
+exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/2 [90m./samples/fail-fast/first-fail.txt[39m ...
+2/2 [90m./samples/fail-fast/second-fail.txt[39m ...",
+]
+`;
+
 exports[`Validate cli app LICENSE Expect Error: undefined 1`] = `Array []`;
 
 exports[`Validate cli app LICENSE Expect Error: undefined 2`] = `
 "error	1/1 ./LICENSE 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
+`;
+
+exports[`Validate cli app LICENSE Expect Error: undefined 3`] = `
+Array [
+  "
+1/1 [90m./LICENSE[39m ...",
+]
 `;
 
 exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -76,6 +115,8 @@ exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 2`] = 
 "error	Configuration Error: Failed to find config file at: \\"./src/app.test.ts\\"
 error	CSpell: Files checked: 0, Issues found: 0 in 0 files"
 `;
+
+exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 3`] = `Array []`;
 
 exports[`Validate cli app check LICENSE Expect Error: undefined 1`] = `
 Array [
@@ -111,6 +152,8 @@ log
 log	"
 `;
 
+exports[`Validate cli app check LICENSE Expect Error: undefined 3`] = `Array []`;
+
 exports[`Validate cli app check help Expect Error: outputHelp 1`] = `
 Array [
   "Usage: cspell check [options] <files...>",
@@ -129,6 +172,8 @@ Array [
 
 exports[`Validate cli app check help Expect Error: outputHelp 2`] = `""`;
 
+exports[`Validate cli app check help Expect Error: outputHelp 3`] = `Array []`;
+
 exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 2`] = `
@@ -136,6 +181,8 @@ exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 2`]
 log	
 error	File not found \\"./missing-file.txt\\""
 `;
+
+exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 3`] = `Array []`;
 
 exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 1`] = `
 Array [
@@ -243,11 +290,20 @@ log
 log	"
 `;
 
+exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 3`] = `Array []`;
+
 exports[`Validate cli app cspell-bad.json Expect Error: undefined 1`] = `Array []`;
 
 exports[`Validate cli app cspell-bad.json Expect Error: undefined 2`] = `
 "error	1/1 ./src/app.test.ts 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
+`;
+
+exports[`Validate cli app cspell-bad.json Expect Error: undefined 3`] = `
+Array [
+  "
+1/1 [90m./src/app.test.ts[39m ...",
+]
 `;
 
 exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -256,6 +312,8 @@ exports[`Validate cli app cspell-import-missing.json Expect Error: [Function Che
 "error	Configuration Error: Failed to read config file: \\"./samples/intentionally-missing-file.json\\"
 error	CSpell: Files checked: 0, Issues found: 0 in 0 files"
 `;
+
+exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 3`] = `Array []`;
 
 exports[`Validate cli app current_file --verbose Expect Error: undefined 1`] = `Array []`;
 
@@ -293,6 +351,13 @@ error	1/1 ./src/app.test.ts 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
+exports[`Validate cli app current_file --verbose Expect Error: undefined 3`] = `
+Array [
+  "
+1/1 [90m./src/app.test.ts[39m ...",
+]
+`;
+
 exports[`Validate cli app current_file Expect Error: undefined 1`] = `Array []`;
 
 exports[`Validate cli app current_file Expect Error: undefined 2`] = `
@@ -300,11 +365,25 @@ exports[`Validate cli app current_file Expect Error: undefined 2`] = `
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
+exports[`Validate cli app current_file Expect Error: undefined 3`] = `
+Array [
+  "
+1/1 [90m./src/app.test.ts[39m ...",
+]
+`;
+
 exports[`Validate cli app current_file languageId Expect Error: undefined 1`] = `Array []`;
 
 exports[`Validate cli app current_file languageId Expect Error: undefined 2`] = `
 "error	1/1 ./src/app.test.ts 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
+`;
+
+exports[`Validate cli app current_file languageId Expect Error: undefined 3`] = `
+Array [
+  "
+1/1 [90m./src/app.test.ts[39m ...",
+]
 `;
 
 exports[`Validate cli app link 1`] = `Array []`;
@@ -321,9 +400,13 @@ exports[`Validate cli app must find force no error Expect Error: undefined 1`] =
 
 exports[`Validate cli app must find force no error Expect Error: undefined 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
+exports[`Validate cli app must find force no error Expect Error: undefined 3`] = `Array []`;
+
 exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
+
+exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 3`] = `Array []`;
 
 exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
 Array [
@@ -394,9 +477,13 @@ Array [
 
 exports[`Validate cli app no-args Expect Error: outputHelp 2`] = `""`;
 
+exports[`Validate cli app no-args Expect Error: outputHelp 3`] = `Array []`;
+
 exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
+
+exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 3`] = `Array []`;
 
 exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
@@ -592,6 +679,13 @@ log	./samples/Dutch.txt:77:71 - Unknown word (beogende)
 log	./samples/Dutch.txt:78:4 - Unknown word (instelling)
 log	./samples/Dutch.txt:78:18 - Unknown word (ANBI)
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
+`;
+
+exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/1 [90m./samples/Dutch.txt[39m ...",
+]
 `;
 
 exports[`Validate cli app success suggest run with ["suggest", "café", "--num-suggestions=1", "--no-include-ties"] 1`] = `Array []`;
@@ -1193,6 +1287,18 @@ log	./samples/text.txt:5:32 - Unknown word (reead)
 error	CSpell: Files checked: 6, Issues found: 7 in 1 files"
 `;
 
+exports[`Validate cli app with errors and excludes Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/6 [90m./samples/cspell-bad.json[39m ...
+2/6 [90m./samples/cspell-includes.json[39m ...
+3/6 [90m./samples/cspell-missing-dict.json[39m ...
+4/6 [90m./samples/sample.c[39m ...
+5/6 [90m./samples/sample.py[39m ...
+6/6 [90m./samples/text.txt[39m ...",
+]
+`;
+
 exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 2`] = `
@@ -1201,6 +1307,13 @@ log	./samples/src/sample-with-forbidden-words.md:3:3 - Forbidden word (behaviour
 log	./samples/src/sample-with-forbidden-words.md:4:3 - Forbidden word (flavour)
 log	./samples/src/sample-with-forbidden-words.md:5:3 - Forbidden word (colour)
 error	CSpell: Files checked: 1, Issues found: 3 in 1 files"
+`;
+
+exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/1 [90m./samples/src/sample-with-forbidden-words.md[39m ...",
+]
 `;
 
 exports[`Validate cli app with spelling errors --debug Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -1401,6 +1514,8 @@ exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: 
 
 exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 2`] = `""`;
 
+exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 3`] = `Array []`;
+
 exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 2`] = `
@@ -1595,6 +1710,13 @@ log	./samples/Dutch.txt[77, 71]: Unknown word: beogende
 log	./samples/Dutch.txt[78, 4]: Unknown word: instelling
 log	./samples/Dutch.txt[78, 18]: Unknown word: ANBI
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
+`;
+
+exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/1 [90m./samples/Dutch.txt[39m ...",
+]
 `;
 
 exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -1793,6 +1915,13 @@ log	./samples/Dutch.txt:78:18 - Unknown word (ANBI)
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
+exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/1 [90m./samples/Dutch.txt[39m ...",
+]
+`;
+
 exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 2`] = `
@@ -1987,4 +2116,11 @@ log	beogende
 log	instelling
 log	ANBI
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
+`;
+
+exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 3`] = `
+Array [
+  "
+1/1 [90m./samples/Dutch.txt[39m ...",
+]
 `;

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -11,11 +11,9 @@ error	CSpell: Files checked: 2, Issues found: 2 in 2 files"
 `;
 
 exports[`Validate cli app --fail-fast no option Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
+"
 1/2 [90m./samples/fail-fast/first-fail.txt[39m ...
-2/2 [90m./samples/fail-fast/second-fail.txt[39m ...",
-]
+2/2 [90m./samples/fail-fast/second-fail.txt[39m ..."
 `;
 
 exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -27,10 +25,8 @@ error	CSpell: Files checked: 1, Issues found: 1 in 1 files"
 `;
 
 exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/2 [90m./samples/fail-fast/first-fail.txt[39m ...",
-]
+"
+1/2 [90m./samples/fail-fast/first-fail.txt[39m ..."
 `;
 
 exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -42,10 +38,8 @@ error	CSpell: Files checked: 1, Issues found: 1 in 1 files"
 `;
 
 exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/2 [90m./samples/fail-fast/first-fail.txt[39m ...",
-]
+"
+1/2 [90m./samples/fail-fast/first-fail.txt[39m ..."
 `;
 
 exports[`Validate cli app --help Expect Error: outputHelp 1`] = `
@@ -75,7 +69,7 @@ Array [
 
 exports[`Validate cli app --help Expect Error: outputHelp 2`] = `""`;
 
-exports[`Validate cli app --help Expect Error: outputHelp 3`] = `Array []`;
+exports[`Validate cli app --help Expect Error: outputHelp 3`] = `""`;
 
 exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
@@ -88,11 +82,9 @@ error	CSpell: Files checked: 2, Issues found: 2 in 2 files"
 `;
 
 exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
+"
 1/2 [90m./samples/fail-fast/first-fail.txt[39m ...
-2/2 [90m./samples/fail-fast/second-fail.txt[39m ...",
-]
+2/2 [90m./samples/fail-fast/second-fail.txt[39m ..."
 `;
 
 exports[`Validate cli app LICENSE Expect Error: undefined 1`] = `Array []`;
@@ -103,10 +95,8 @@ error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
 exports[`Validate cli app LICENSE Expect Error: undefined 3`] = `
-Array [
-  "
-1/1 [90m./LICENSE[39m ...",
-]
+"
+1/1 [90m./LICENSE[39m ..."
 `;
 
 exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -116,7 +106,7 @@ exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 2`] = 
 error	CSpell: Files checked: 0, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app check LICENSE Expect Error: undefined 1`] = `
 Array [
@@ -152,7 +142,7 @@ log
 log	"
 `;
 
-exports[`Validate cli app check LICENSE Expect Error: undefined 3`] = `Array []`;
+exports[`Validate cli app check LICENSE Expect Error: undefined 3`] = `""`;
 
 exports[`Validate cli app check help Expect Error: outputHelp 1`] = `
 Array [
@@ -172,7 +162,7 @@ Array [
 
 exports[`Validate cli app check help Expect Error: outputHelp 2`] = `""`;
 
-exports[`Validate cli app check help Expect Error: outputHelp 3`] = `Array []`;
+exports[`Validate cli app check help Expect Error: outputHelp 3`] = `""`;
 
 exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
@@ -182,7 +172,7 @@ log
 error	File not found \\"./missing-file.txt\\""
 `;
 
-exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 1`] = `
 Array [
@@ -290,7 +280,7 @@ log
 log	"
 `;
 
-exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app cspell-bad.json Expect Error: undefined 1`] = `Array []`;
 
@@ -300,10 +290,8 @@ error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
 exports[`Validate cli app cspell-bad.json Expect Error: undefined 3`] = `
-Array [
-  "
-1/1 [90m./src/app.test.ts[39m ...",
-]
+"
+1/1 [90m./src/app.test.ts[39m ..."
 `;
 
 exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -313,7 +301,7 @@ exports[`Validate cli app cspell-import-missing.json Expect Error: [Function Che
 error	CSpell: Files checked: 0, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app current_file --verbose Expect Error: undefined 1`] = `Array []`;
 
@@ -352,10 +340,8 @@ error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
 exports[`Validate cli app current_file --verbose Expect Error: undefined 3`] = `
-Array [
-  "
-1/1 [90m./src/app.test.ts[39m ...",
-]
+"
+1/1 [90m./src/app.test.ts[39m ..."
 `;
 
 exports[`Validate cli app current_file Expect Error: undefined 1`] = `Array []`;
@@ -366,10 +352,8 @@ error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
 exports[`Validate cli app current_file Expect Error: undefined 3`] = `
-Array [
-  "
-1/1 [90m./src/app.test.ts[39m ...",
-]
+"
+1/1 [90m./src/app.test.ts[39m ..."
 `;
 
 exports[`Validate cli app current_file languageId Expect Error: undefined 1`] = `Array []`;
@@ -380,33 +364,31 @@ error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
 exports[`Validate cli app current_file languageId Expect Error: undefined 3`] = `
-Array [
-  "
-1/1 [90m./src/app.test.ts[39m ...",
-]
+"
+1/1 [90m./src/app.test.ts[39m ..."
 `;
 
-exports[`Validate cli app link 1`] = `Array []`;
+exports[`Validate cli app link 1`] = `""`;
 
-exports[`Validate cli app link add 1`] = `Array []`;
+exports[`Validate cli app link add 1`] = `""`;
 
-exports[`Validate cli app link list 1`] = `Array []`;
+exports[`Validate cli app link list 1`] = `""`;
 
-exports[`Validate cli app link ls 1`] = `Array []`;
+exports[`Validate cli app link ls 1`] = `""`;
 
-exports[`Validate cli app link remove 1`] = `Array []`;
+exports[`Validate cli app link remove 1`] = `""`;
 
 exports[`Validate cli app must find force no error Expect Error: undefined 1`] = `Array []`;
 
 exports[`Validate cli app must find force no error Expect Error: undefined 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
-exports[`Validate cli app must find force no error Expect Error: undefined 3`] = `Array []`;
+exports[`Validate cli app must find force no error Expect Error: undefined 3`] = `""`;
 
 exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
-exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
 Array [
@@ -477,13 +459,13 @@ Array [
 
 exports[`Validate cli app no-args Expect Error: outputHelp 2`] = `""`;
 
-exports[`Validate cli app no-args Expect Error: outputHelp 3`] = `Array []`;
+exports[`Validate cli app no-args Expect Error: outputHelp 3`] = `""`;
 
 exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
 exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
-exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
@@ -682,10 +664,8 @@ error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
 exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/1 [90m./samples/Dutch.txt[39m ...",
-]
+"
+1/1 [90m./samples/Dutch.txt[39m ..."
 `;
 
 exports[`Validate cli app success suggest run with ["suggest", "café", "--num-suggestions=1", "--no-include-ties"] 1`] = `Array []`;
@@ -1288,15 +1268,13 @@ error	CSpell: Files checked: 6, Issues found: 7 in 1 files"
 `;
 
 exports[`Validate cli app with errors and excludes Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
+"
 1/6 [90m./samples/cspell-bad.json[39m ...
 2/6 [90m./samples/cspell-includes.json[39m ...
 3/6 [90m./samples/cspell-missing-dict.json[39m ...
 4/6 [90m./samples/sample.c[39m ...
 5/6 [90m./samples/sample.py[39m ...
-6/6 [90m./samples/text.txt[39m ...",
-]
+6/6 [90m./samples/text.txt[39m ..."
 `;
 
 exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -1310,10 +1288,8 @@ error	CSpell: Files checked: 1, Issues found: 3 in 1 files"
 `;
 
 exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/1 [90m./samples/src/sample-with-forbidden-words.md[39m ...",
-]
+"
+1/1 [90m./samples/src/sample-with-forbidden-words.md[39m ..."
 `;
 
 exports[`Validate cli app with spelling errors --debug Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -1514,7 +1490,7 @@ exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: 
 
 exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 2`] = `""`;
 
-exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 3`] = `Array []`;
+exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 1`] = `Array []`;
 
@@ -1713,10 +1689,8 @@ error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
 exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/1 [90m./samples/Dutch.txt[39m ...",
-]
+"
+1/1 [90m./samples/Dutch.txt[39m ..."
 `;
 
 exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -1916,10 +1890,8 @@ error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
 exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/1 [90m./samples/Dutch.txt[39m ...",
-]
+"
+1/1 [90m./samples/Dutch.txt[39m ..."
 `;
 
 exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 1`] = `Array []`;
@@ -2119,8 +2091,6 @@ error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
 exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 3`] = `
-Array [
-  "
-1/1 [90m./samples/Dutch.txt[39m ...",
-]
+"
+1/1 [90m./samples/Dutch.txt[39m ..."
 `;

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -43,26 +43,27 @@ interface TestCase {
     eInfo: boolean;
 }
 
-class RecordStdout {
+class RecordStdStream {
     private static columnWidth = 80;
     private write = process.stdout.write.bind(process.stdout);
-    private stdoutWrite: StdoutWrite | undefined;
+    private streamWrite: StdoutWrite | undefined;
     private columns: number = process.stdout.columns;
     readonly text: string[] = [];
 
     startCapture() {
         this.stopCapture();
-        this.stdoutWrite = process.stdout.write;
-        process.stdout.write = this.capture.bind(this);
-        process.stdout.columns = RecordStdout.columnWidth;
+        this.streamWrite = process[this.stream].write;
+        this.columns = process[this.stream].columns;
+        process[this.stream].write = this.capture.bind(this);
+        process[this.stream].columns = RecordStdStream.columnWidth;
     }
 
     stopCapture() {
-        if (this.stdoutWrite) {
-            process.stdout.write = this.stdoutWrite;
-            process.stdout.columns = this.columns;
+        if (this.streamWrite) {
+            process[this.stream].write = this.streamWrite;
+            process[this.stream].columns = this.columns;
         }
-        this.stdoutWrite = undefined;
+        this.streamWrite = undefined;
     }
 
     private capture(buffer: Uint8Array | string, cb?: Callback): boolean;
@@ -82,6 +83,8 @@ class RecordStdout {
     clear() {
         this.text.length = 0;
     }
+
+    constructor(readonly stream: 'stdout' | 'stderr' = 'stdout') {}
 }
 
 const colorLevel = chalk.level;
@@ -96,14 +99,16 @@ describe('Validate cli', () => {
     const removePathsFromGlobalImports = jest
         .spyOn(Link, 'removePathsFromGlobalImports')
         .mockName('removePathsFromGlobalImports');
-    const capture = new RecordStdout();
+    const captureStdout = new RecordStdStream();
+    const captureStderr = new RecordStdStream('stderr');
 
     beforeEach(() => {
         log.mockClear();
         error.mockClear();
         mockCreateInterface.mockClear();
         logger.clear();
-        capture.startCapture();
+        captureStdout.startCapture();
+        captureStderr.startCapture();
         chalk.level = 3;
     });
 
@@ -114,8 +119,10 @@ describe('Validate cli', () => {
         listGlobalImports.mockClear();
         addPathsToGlobalImports.mockClear();
         removePathsFromGlobalImports.mockClear();
-        capture.stopCapture();
-        capture.clear();
+        captureStdout.stopCapture();
+        captureStdout.clear();
+        captureStderr.stopCapture();
+        captureStderr.clear();
         chalk.level = colorLevel;
     });
 
@@ -152,6 +159,7 @@ describe('Validate cli', () => {
         ${'--fail-fast with config'}                   | ${['-r', failFastRoot, '-c', failFastConfig, '*.txt']}                     | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
         ${'--no-fail-fast with config'}                | ${['-r', failFastRoot, '--no-fail-fast', '-c', failFastConfig, '*.txt']}   | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
     `('app $msg Expect Error: $errorCheck', async ({ testArgs, errorCheck, eError, eLog, eInfo }: TestCase) => {
+        chalk.level = 1;
         const commander = getCommander();
         const args = argv(...testArgs);
         const result = app.run(commander, args);
@@ -168,8 +176,9 @@ describe('Validate cli', () => {
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
         // eslint-disable-next-line jest/no-conditional-expect
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
-        expect(capture.text).toMatchSnapshot();
+        expect(captureStdout.text).toMatchSnapshot();
         expect(logger.normalizedHistory()).toMatchSnapshot();
+        expect(captureStderr.text).toMatchSnapshot();
     });
 
     test.each`
@@ -199,7 +208,7 @@ describe('Validate cli', () => {
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
         // eslint-disable-next-line jest/no-conditional-expect
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
-        expect(capture.text).toMatchSnapshot();
+        expect(captureStdout.text).toMatchSnapshot();
         expect(normalizeLogCalls(log.mock.calls)).toMatchSnapshot();
     });
 
@@ -214,7 +223,7 @@ describe('Validate cli', () => {
         const commander = getCommander();
         const args = argv(...testArgs);
         await app.run(commander, args);
-        expect(capture.text).toMatchSnapshot();
+        expect(captureStdout.text).toMatchSnapshot();
         expect(normalizeLogCalls(log.mock.calls)).toMatchSnapshot();
     });
 
@@ -245,7 +254,7 @@ describe('Validate cli', () => {
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
         // eslint-disable-next-line jest/no-conditional-expect
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
-        expect(capture.text).toMatchSnapshot();
+        expect(captureStdout.text).toMatchSnapshot();
     });
 
     test.each`
@@ -280,7 +289,7 @@ describe('Validate cli', () => {
             // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).rejects.toThrowError(errorCheck);
         }
-        expect(capture.text).toMatchSnapshot();
+        expect(captureStdout.text).toMatchSnapshot();
         expect(log.mock.calls.join('\n')).toMatchSnapshot();
         expect(error.mock.calls.join('\n')).toMatchSnapshot();
         expect(mockCreateInterface).toHaveBeenCalledTimes(stdin ? 1 : 0);
@@ -335,6 +344,7 @@ function makeLogger() {
     function normalizedHistory() {
         let t = history.join('\n');
         t = stripAnsi(t);
+        t = t.replace(/\r/gm, '');
         t = t.replace(RegExp(escapeRegExp(projectRootUri.toString()), 'gi'), '.');
         t = t.replace(RegExp(escapeRegExp(projectRoot), 'gi'), '.');
         t = t.replace(/\\/g, '/');

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -178,7 +178,7 @@ describe('Validate cli', () => {
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
         expect(captureStdout.text).toMatchSnapshot();
         expect(logger.normalizedHistory()).toMatchSnapshot();
-        expect(captureStderr.text).toMatchSnapshot();
+        expect(normalizeOutput(captureStderr.text)).toMatchSnapshot();
     });
 
     test.each`
@@ -254,7 +254,7 @@ describe('Validate cli', () => {
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
         // eslint-disable-next-line jest/no-conditional-expect
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
-        expect(captureStdout.text).toMatchSnapshot();
+        expect(normalizeOutput(captureStdout.text)).toMatchSnapshot();
     });
 
     test.each`
@@ -329,8 +329,11 @@ type StdoutWrite = typeof process.stdout.write;
 type Callback = (err?: Error) => void;
 
 function normalizeLogCalls(calls: string[][]): string {
-    const logOutput = calls.map((call) => Util.format(...call)).join('\n');
-    return logOutput.replace(/\\/g, '/');
+    return normalizeOutput(calls.map((call) => Util.format(...call)));
+}
+
+function normalizeOutput(lines: string[]): string {
+    return lines.join('\n').replace(/\\/g, '/');
 }
 
 function makeLogger() {

--- a/packages/cspell/src/cli-reporter.ts
+++ b/packages/cspell/src/cli-reporter.ts
@@ -1,5 +1,13 @@
 import chalk = require('chalk');
-import type { CSpellReporter, Issue, MessageType, ProgressItem, RunResult } from '@cspell/cspell-types';
+import type {
+    CSpellReporter,
+    Issue,
+    MessageType,
+    ProgressFileBegin,
+    ProgressFileComplete,
+    ProgressItem,
+    RunResult,
+} from '@cspell/cspell-types';
 import { ImportError, isSpellingDictionaryLoadError, SpellingDictionaryLoadError } from 'cspell-lib';
 import * as path from 'path';
 import { URI } from 'vscode-uri';
@@ -59,9 +67,23 @@ function relativeUriFilename(uri: string, fsPathRoot: string): string {
 }
 
 function reportProgress(p: ProgressItem) {
-    if (p.type !== 'ProgressFileComplete') {
-        return;
+    if (p.type === 'ProgressFileComplete') {
+        return reportProgressFileComplete(p);
     }
+    if (p.type === 'ProgressFileBegin') {
+        return reportProgressFileBegin(p);
+    }
+}
+
+function reportProgressFileBegin(p: ProgressFileBegin) {
+    const fc = '' + p.fileCount;
+    const fn = (' '.repeat(fc.length) + p.fileNum).slice(-fc.length);
+    const idx = fn + '/' + fc;
+    const filename = chalk.gray(relativeFilename(p.filename));
+    process.stderr.write(`\r${idx} ${filename} ...`);
+}
+
+function reportProgressFileComplete(p: ProgressFileComplete) {
     const fc = '' + p.fileCount;
     const fn = (' '.repeat(fc.length) + p.fileNum).slice(-fc.length);
     const idx = fn + '/' + fc;
@@ -69,7 +91,7 @@ function reportProgress(p: ProgressItem) {
     const time = reportTime(p.elapsedTimeMs, !!p.cached);
     const skipped = p.processed === false ? ' skipped' : '';
     const hasErrors = p.numErrors ? chalk.red` X` : '';
-    console.error(`${idx} ${filename} ${time}${skipped}${hasErrors}`);
+    console.error(`\r${idx} ${filename} ${time}${skipped}${hasErrors}`);
 }
 
 function reportTime(elapsedTimeMs: number | undefined, cached: boolean): string {

--- a/packages/cspell/src/cli-reporter.ts
+++ b/packages/cspell/src/cli-reporter.ts
@@ -139,6 +139,17 @@ export function getReporter(options: ReporterOptions): CSpellReporter {
         if (!fileGlobs.length && !result.files) {
             return;
         }
+        if (result.cachedFiles) {
+            console.error(
+                'CSpell: Files checked: %d (%d from cache), Issues found: %d in %d files',
+                result.files,
+                result.cachedFiles,
+                result.issues,
+                result.filesWithIssues.size
+            );
+            return;
+        }
+
         console.error(
             'CSpell: Files checked: %d, Issues found: %d in %d files',
             result.files,

--- a/packages/cspell/src/util/InMemoryReporter.ts
+++ b/packages/cspell/src/util/InMemoryReporter.ts
@@ -1,4 +1,4 @@
-import type { CSpellReporter, Issue, ProgressFileComplete, RunResult } from '@cspell/cspell-types';
+import type { CSpellReporter, Issue, ProgressItem, RunResult } from '@cspell/cspell-types';
 
 export interface InMemoryResult {
     log: string[];
@@ -43,7 +43,7 @@ export class InMemoryReporter implements CSpellReporter, InMemoryResult {
         this.log.push(`Debug: ${message}`);
     };
 
-    progress = (p: ProgressFileComplete): void => {
+    progress = (p: ProgressItem): void => {
         this.progressCount += 1;
         this.log.push(`Progress: ${p.type} ${p.fileNum} ${p.fileCount} ${p.filename}`);
     };

--- a/test-packages/test-cspell/src/index.ts
+++ b/test-packages/test-cspell/src/index.ts
@@ -1,6 +1,6 @@
 import type { CSpellReporter } from '@cspell/cspell-types';
 import { assert } from 'console';
-import { checkText, CSpellApplicationOptions, Issue, lint, ProgressFileComplete, RunResult, trace } from 'cspell';
+import { checkText, CSpellApplicationOptions, Issue, lint, ProgressItem, RunResult, trace } from 'cspell';
 import { run } from 'cspell/dist/app';
 
 async function test() {
@@ -59,7 +59,7 @@ class ConsoleLogger implements CSpellReporter {
         // console.debug(`Debug: ${message}`);
     };
 
-    progress = (p: ProgressFileComplete) => {
+    progress = (p: ProgressItem) => {
         this.progressCount += 1;
         console.error(`Progress: ${p.type} ${p.fileNum} ${p.fileCount} ${p.filename}`);
     };


### PR DESCRIPTION
- If caching is on, report number of cached files.
- if progress in on, signal the start of processing a file. This helps with finding very slow files.