### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,13 +55,13 @@ jobs:
       - run: npm run coverage
 
       - name: Upload coverage Coveralls
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@9ba913c152ae4be1327bfb9085dc806cedb44057 # 1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71 # v3
         with:
           directory: "."
           files: ./lcov.info

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -22,4 +22,4 @@ jobs:
       - run: npm -v
 
       - run: npm run prepare-cspell-action
-      - uses: streetsidesoftware/cspell-action@v1
+      - uses: streetsidesoftware/cspell-action@2036cf1974b01e0f4b175feec78c6f496020aa80 # v1

--- a/.github/workflows/cspell4-integration-update.yml
+++ b/.github/workflows/cspell4-integration-update.yml
@@ -43,7 +43,7 @@ jobs:
           echo 'DIFF' >> $GITHUB_ENV
       - name: Echo git_status
         run: echo ${{ env.git_status }}
-      - uses: tibdex/github-app-token@v1.5 # cspell:ignore tibdex
+      - uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4 # v1.5 # cspell:ignore tibdex
         if: env.git_status == 'dirty'
         id: generate-token
         with:
@@ -51,7 +51,7 @@ jobs:
           private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Create Pull Request
         if: env.git_status == 'dirty'
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@f1a7646cead32c950d90344a4fb5d4e926972a8f # v4
         with:
           commit-message: "ci: Workflow Bot -- Update Integration Snapshots"
           branch: ${{ env.NEW_BRANCH }}

--- a/.github/workflows/issues-lock.yml
+++ b/.github/workflows/issues-lock.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write # for dessant/lock-threads to lock issues
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3.0.0
+      - uses: dessant/lock-threads@e460dfeb36e731f3aeb214be6b0c9a9d9a67eda6 # v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-comment: "This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs."

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,7 +28,7 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@e9ee02fbac03d922bac6212003695e8358dd88b0 # v5
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml
@@ -52,7 +52,7 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@e9ee02fbac03d922bac6212003695e8358dd88b0 # v5
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/update-dependencies-cspell4.yml
+++ b/.github/workflows/update-dependencies-cspell4.yml
@@ -63,7 +63,7 @@ jobs:
           echo 'DIFF' >> $GITHUB_ENV
       - name: Echo git_status
         run: echo ${{ env.git_status }}
-      - uses: tibdex/github-app-token@v1.5 # cspell:ignore tibdex
+      - uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4 # v1.5 # cspell:ignore tibdex
         if: env.git_status == 'dirty'
         id: generate-token
         with:
@@ -71,7 +71,7 @@ jobs:
           private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Create Pull Request
         if: env.git_status == 'dirty'
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@f1a7646cead32c950d90344a4fb5d4e926972a8f # v4
         with:
           commit-message: "ci: Workflow Bot -- Update ALL Dependencies"
           branch: ${{ env.NEW_BRANCH }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -71,7 +71,7 @@ jobs:
           echo 'DIFF' >> $GITHUB_ENV
       - name: Echo git_status
         run: echo ${{ env.git_status }}
-      - uses: tibdex/github-app-token@v1.5 # cspell:ignore tibdex
+      - uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4 # v1.5 # cspell:ignore tibdex
         if: env.git_status == 'dirty'
         id: generate-token
         with:
@@ -79,7 +79,7 @@ jobs:
           private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Create Pull Request
         if: env.git_status == 'dirty'
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@f1a7646cead32c950d90344a4fb5d4e926972a8f # v4
         with:
           commit-message: "ci: Workflow Bot -- Update ALL Dependencies"
           branch: ${{ env.NEW_BRANCH }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -42,7 +42,7 @@ jobs:
           echo 'DIFF' >> $GITHUB_ENV
       - name: Echo git_status
         run: echo ${{ env.git_status }}
-      - uses: tibdex/github-app-token@v1.5 # cspell:ignore tibdex
+      - uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4 # v1.5 # cspell:ignore tibdex
         if: env.git_status == 'dirty'
         id: generate-token
         with:
@@ -50,7 +50,7 @@ jobs:
           private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Create Pull Request
         if: env.git_status == 'dirty'
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@f1a7646cead32c950d90344a4fb5d4e926972a8f # v4
         with:
           commit-message: "ci: Workflow Bot -- Build Docs"
           branch: ${{ env.NEW_BRANCH }}

--- a/.github/workflows/update-integration-snapshots.yml
+++ b/.github/workflows/update-integration-snapshots.yml
@@ -50,7 +50,7 @@ jobs:
           echo 'DIFF' >> $GITHUB_ENV
       - name: Echo git_status
         run: echo ${{ env.git_status }}
-      - uses: tibdex/github-app-token@v1.5 # cspell:ignore tibdex
+      - uses: tibdex/github-app-token@7ce9ffdcdeb2ba82b01b51d6584a6a85872336d4 # v1.5 # cspell:ignore tibdex
         if: env.git_status == 'dirty'
         id: generate-token
         with:
@@ -58,7 +58,7 @@ jobs:
           private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
       - name: Create Pull Request
         if: env.git_status == 'dirty'
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@f1a7646cead32c950d90344a4fb5d4e926972a8f # v4
         with:
           commit-message: "ci: Workflow Bot -- Update Integration Snapshots"
           branch: ${{ env.NEW_BRANCH }}


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

[How do I validate these pinned actions?](https://gist.github.com/naveensrinivasan/ca008c07279176acce28969fb77d056f)

Also, dependabot supports upgrading based on SHA. https://github.com/ossf/scorecard/pull/1700

GitHub's own repository pin's their checkout actions by SHA and doesn't use the version tag
https://github.com/github/docs/blob/ea7f218c91ecbae9a700a8702b51a7d2736e0d2c/.github/workflows/docs-review-collect.yml#L23

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
