### PR TITLE
fix: relative path name

### DIFF
--- a/packages/cspell/src/util/async.ts
+++ b/packages/cspell/src/util/async.ts
@@ -1,1 +1,5 @@
-export { toAsyncIterable as mergeAsyncIterables, toArray as asyncIterableToArray } from '@cspell/cspell-pipe';
+export {
+    toAsyncIterable as mergeAsyncIterables,
+    toArray as asyncIterableToArray,
+    opMap as asyncMap,
+} from '@cspell/cspell-pipe';


### PR DESCRIPTION
Fix relative path names when reading the file list from `stdin`.