### PR TITLE
fix: Ignore directories when checking files

### DIFF
--- a/packages/cspell-pipe/src/operators/filter.ts
+++ b/packages/cspell-pipe/src/operators/filter.ts
@@ -1,12 +1,20 @@
 import { isAsyncIterable } from '../helpers/util';
 import { PipeFn } from '../internalTypes';
 
+// prettier-ignore
 export function opFilterAsync<T, S extends T>(filterFn: (v: T) => v is S): (iter: AsyncIterable<T>) => AsyncIterable<S>;
-export function opFilterAsync<T>(filterFn: (v: T) => boolean): (iter: AsyncIterable<T>) => AsyncIterable<T>;
-export function opFilterAsync<T>(filterFn: (v: T) => boolean): (iter: AsyncIterable<T>) => AsyncIterable<T> {
+// prettier-ignore
+export function opFilterAsync<T, S extends Awaited<T>>(filterFn: (v: Awaited<T>) => v is S): (iter: AsyncIterable<T>) => AsyncIterable<S>;
+// prettier-ignore
+export function opFilterAsync<T>(filterFn: (v: Awaited<T>) => boolean): (iter: AsyncIterable<T>) => AsyncIterable<Awaited<T>>;
+// prettier-ignore
+export function opFilterAsync<T>(filterFn: (v: Awaited<T>) => Promise<boolean>): (iter: AsyncIterable<T>) => AsyncIterable<Awaited<T>>;
+// prettier-ignore
+export function opFilterAsync<T>(filterFn: (v: Awaited<T>) => boolean | Promise<boolean>): (iter: AsyncIterable<T>) => AsyncIterable<Awaited<T>> {
     async function* fn(iter: Iterable<T> | AsyncIterable<T>) {
         for await (const v of iter) {
-            if (filterFn(v)) yield v;
+            const pass = await filterFn(v);
+            if (pass) yield v;
         }
     }
 

--- a/packages/cspell/src/lint/lint.ts
+++ b/packages/cspell/src/lint/lint.ts
@@ -1,4 +1,4 @@
-import { isAsyncIterable, opFilter, pipeAsync, pipeSync } from '@cspell/cspell-pipe';
+import { isAsyncIterable, operators, opFilter, pipeAsync, pipeSync } from '@cspell/cspell-pipe';
 import type { CSpellReporter, CSpellSettings, Glob, Issue, RunResult, TextDocumentOffset } from '@cspell/cspell-types';
 import { MessageTypes } from '@cspell/cspell-types';
 import { findRepoRoot, GitIgnore } from 'cspell-gitignore';
@@ -16,6 +16,7 @@ import {
     fileInfoToDocument,
     FileResult,
     findFiles,
+    isNotDir,
     readConfig,
     readFileInfo,
     readFileListFiles,
@@ -30,6 +31,8 @@ import chalk = require('chalk');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const npmPackage = require('../../package.json');
 const version = npmPackage.version;
+
+const { opFilterAsync } = operators;
 
 export async function runLint(cfg: LintRequest): Promise<RunResult> {
     let { reporter } = cfg;
@@ -515,7 +518,7 @@ async function useFileLists(
     }
     const globMatcher = new GlobMatcher(includeGlobPatterns, options);
 
-    const files = await readFileListFiles(fileListFiles);
     const filterFiles = (file: string) => globMatcher.match(file);
-    return files instanceof Array ? files.filter(filterFiles) : pipeAsync(files, opFilter(filterFiles));
+    const files = readFileListFiles(fileListFiles);
+    return pipeAsync(files, opFilter(filterFiles), opFilterAsync(isNotDir));
 }

--- a/packages/cspell/src/util/async.ts
+++ b/packages/cspell/src/util/async.ts
@@ -1,5 +1,16 @@
+import { operators } from '@cspell/cspell-pipe';
+
 export {
-    toAsyncIterable as mergeAsyncIterables,
+    helpers as asyncHelpers,
+    operators as asyncOperators,
+    pipeAsync as asyncPipe,
     toArray as asyncIterableToArray,
-    opMap as asyncMap,
+    toAsyncIterable as mergeAsyncIterables,
 } from '@cspell/cspell-pipe';
+
+export const {
+    opMapAsync: asyncMap,
+    opFilterAsync: asyncFilter,
+    opAwaitAsync: asyncAwait,
+    opFlattenAsync: asyncFlatten,
+} = operators;


### PR DESCRIPTION
The following would cause an error when there was a subdirectory.

```sh
ls -1 | cspell "**" --cache
```