### PR TITLE
chore: unpin setup-node and bump leftover actions/checkout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/cspell-cli.yml
+++ b/.github/workflows/cspell-cli.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/cspell5-update-dependencies.yml
+++ b/.github/workflows/cspell5-update-dependencies.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
       - name: Setup NPM

--- a/.github/workflows/cspell5-update-dictionaries.yml
+++ b/.github/workflows/cspell5-update-dictionaries.yml
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ env.REF_BRANCH }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ env.REF_BRANCH }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/cspell5-update-integration-repositories.yml
+++ b/.github/workflows/cspell5-update-integration-repositories.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
       - name: Setup NPM

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3.3.0
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: npm

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
       - run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/reuseable-build-dist-cache.yml
+++ b/.github/workflows/reuseable-build-dist-cache.yml
@@ -67,7 +67,7 @@ jobs:
           echo "$PATCH" | git apply
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/reuseable-load-integrations-repo-list.yml
+++ b/.github/workflows/reuseable-load-integrations-repo-list.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ env.REF_BRANCH }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/test-build-docs.yml
+++ b/.github/workflows/test-build-docs.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ env.REF_BRANCH }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/update-dictionaries.yml
+++ b/.github/workflows/update-dictionaries.yml
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ env.REF_BRANCH }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 
@@ -148,7 +148,7 @@ jobs:
           echo "$PATCH" | git apply
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
       - name: Setup NPM

--- a/.github/workflows/update-integration-repositories.yml
+++ b/.github/workflows/update-integration-repositories.yml
@@ -79,7 +79,7 @@ jobs:
           ref: ${{ env.REF_BRANCH }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/website-lint.yml
+++ b/.github/workflows/website-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v3
         with:
           cache: npm
 

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3.3.0
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
           cache: npm


### PR DESCRIPTION
Unpin to match the other core actions and noticed a few old checkout ones