### PR TITLE
fix: Remove `.txt` restriction from dictionary files.

### DIFF
--- a/cspell.code-workspace
+++ b/cspell.code-workspace
@@ -73,10 +73,7 @@
                 "name": "Test: Jest current-file",
                 "program": "${fileWorkspaceFolder}/node_modules/.bin/jest",
                 "cwd": "${fileWorkspaceFolder}",
-                "args": [
-                    "--runInBand",
-                    "${fileBasename}"
-                ],
+                "args": ["--runInBand", "${fileBasename}"],
                 "console": "integratedTerminal",
                 "internalConsoleOptions": "neverOpen",
                 "disableOptimisticBPs": true,
@@ -90,9 +87,7 @@
                 "name": "Test: Jest Entire Folder",
                 "program": "${fileWorkspaceFolder}/node_modules/.bin/jest",
                 "cwd": "${fileWorkspaceFolder}",
-                "args": [
-                    "--runInBand"
-                ],
+                "args": ["--runInBand"],
                 "console": "integratedTerminal",
                 "internalConsoleOptions": "neverOpen",
                 "disableOptimisticBPs": true,
@@ -108,15 +103,10 @@
         "cSpell.customDictionaries": {
             "workspace": true
         },
-        "cSpell.enableFiletypes": [
-            "shellscript"
-        ]
+        "cSpell.enableFiletypes": ["shellscript"],
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "extensions": {
-        "recommendations": [
-            "streetsidesoftware.code-spell-checker",
-            "dbaeumer.vscode-eslint",
-            "esbenp.prettier-vscode"
-        ]
+        "recommendations": ["streetsidesoftware.code-spell-checker", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
     }
 }

--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -159,9 +159,8 @@
       "type": "object"
     },
     "CustomDictionaryPath": {
-      "description": "A File System Path to a dictionary file.",
-      "pattern": "^.*\\.txt$",
-      "type": "string"
+      "$ref": "#/definitions/FsPath",
+      "description": "A File System Path to a dictionary file."
     },
     "CustomDictionaryScope": {
       "description": "Specifies the scope of a dictionary.",

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -159,9 +159,8 @@
       "type": "object"
     },
     "CustomDictionaryPath": {
-      "description": "A File System Path to a dictionary file.",
-      "pattern": "^.*\\.txt$",
-      "type": "string"
+      "$ref": "#/definitions/FsPath",
+      "description": "A File System Path to a dictionary file."
     },
     "CustomDictionaryScope": {
       "description": "Specifies the scope of a dictionary.",

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -885,9 +885,8 @@ export type DictionaryPath = string;
 
 /**
  * A File System Path to a dictionary file.
- * @pattern ^.*\.txt$
  */
-export type CustomDictionaryPath = string;
+export type CustomDictionaryPath = FsPath;
 
 export interface RegExpPatternDefinition {
     /**


### PR DESCRIPTION
Related to: [Support dictionary files without a `.txt` ending. · Issue #2001 · streetsidesoftware/vscode-spell-checker](https://github.com/streetsidesoftware/vscode-spell-checker/issues/2001)