### PR TITLE
feat: Support global globs

### DIFF
--- a/integration-tests/src/repositoryHelper.ts
+++ b/integration-tests/src/repositoryHelper.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import Chalk from 'chalk';
 import { ShouldCheckOptions, shouldCheckRepo } from './shouldCheckRepo';
 import { Logger } from './types';
-import simpleGit from 'simple-git';
+import { simpleGit } from 'simple-git';
 import mkdirp from 'mkdirp';
 import { Octokit } from '@octokit/rest';
 import { Repository } from './configDef';

--- a/packages/cspell-glob/src/GlobMatcher.test.ts
+++ b/packages/cspell-glob/src/GlobMatcher.test.ts
@@ -5,7 +5,6 @@ import {
     GlobPattern,
     GlobPatternNormalized,
     GlobPatternWithOptionalRoot,
-    GlobPatternWithRoot,
     PathInterface,
 } from './GlobMatcherTypes';
 

--- a/packages/cspell-glob/src/GlobMatcherTypes.ts
+++ b/packages/cspell-glob/src/GlobMatcherTypes.ts
@@ -50,6 +50,10 @@ export interface GlobPatternWithOptionalRoot {
 
 export interface GlobPatternWithRoot extends GlobPatternWithOptionalRoot {
     root: string;
+    /**
+     * Global patterns do not need to be relative to the root.
+     */
+    isGlobalPattern: boolean;
 }
 
 export interface GlobPatternNormalized extends GlobPatternWithRoot {

--- a/packages/cspell-glob/src/globHelper.test.ts
+++ b/packages/cspell-glob/src/globHelper.test.ts
@@ -210,24 +210,24 @@ describe('Validate Glob Normalization to root', () => {
     }
 
     test.each`
-        globPath                                                  | file                      | root                             | expected                                                                      | comment
-        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.', ...relGlob }, path)}                        | ${'matching root'}
-        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                               | ${'matching root'}
-        ${gp('*.json', '.', pathWin32)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathWin32)}                               | ${'matching root'}
-        ${gp('*.json')}                                           | ${'cspell-glob/cfg.json'} | ${'..'}                          | ${eg({ glob: 'cspell-glob/*.json', root: '..' }, path)}                       | ${'root above'}
-        ${gp('*.json', '.', pathPosix)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathPosix)}                       | ${'root above'}
-        ${gp('*.json', '.', pathWin32)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathWin32)}                       | ${'root above'}
-        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, path)}                                    | ${'root below, cannot change'}
-        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                               | ${'root below, cannot change'}
-        ${gp('**/*.json', '.', pathWin32)}                        | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '**/*.json', root: '.', ...globalGlob }, pathWin32)}             | ${'root below, globstar'}
-        ${gp('deeper/*.json')}                                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, path)}                               | ${'root below, matching'}
-        ${gp('deeper/*.json', '.', pathPosix)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathPosix)}                          | ${'root below, matching'}
-        ${gp('deeper/*.json', '.', pathWin32)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathWin32)}                          | ${'root below, matching'}
-        ${gp('deeper/*.json', 'e:/user/Test/project', pathWin32)} | ${'cfg.json'}             | ${'E:/user/test/project/deeper'} | ${eg({ glob: '*.json', root: 'E:/user/test/project/deeper' }, pathWin32)}     | ${'root below, matching'}
-        ${gp('**/deeper/*.json')}                                 | ${'deeper/cfg.json'}      | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: '.', ...globalGlob }, path)}           | ${'root below, not matching'}
-        ${gp('**/deeper/*.json', 'proj/nested')}                  | ${'deeper/cfg.json'}      | ${'proj'}                        | ${eg({ glob: '**/deeper/*.json', root: 'proj/nested', ...globalGlob }, path)} | ${'root below, not matching'}
-        ${gp('**/deeper/*.json')}                                 | ${'!cfg.json'}            | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: '.', ...globalGlob }, path)}           | ${'root below, not matching'}
-        ${gp('deeper/project/*/*.json')}                          | ${'cfg.json'}             | ${'deeper/project/a'}            | ${eg({ glob: '*.json', root: 'deeper/project/a' }, path)}                     | ${'root below, not matching'}
+        globPath                                                  | file                      | root                             | expected                                                                  | comment
+        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.', ...relGlob }, path)}                    | ${'matching root'}
+        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                           | ${'matching root'}
+        ${gp('*.json', '.', pathWin32)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathWin32)}                           | ${'matching root'}
+        ${gp('*.json')}                                           | ${'cspell-glob/cfg.json'} | ${'..'}                          | ${eg({ glob: 'cspell-glob/*.json', root: '..' }, path)}                   | ${'root above'}
+        ${gp('*.json', '.', pathPosix)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathPosix)}                   | ${'root above'}
+        ${gp('*.json', '.', pathWin32)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathWin32)}                   | ${'root above'}
+        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, path)}                                | ${'root below, cannot change'}
+        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                           | ${'root below, cannot change'}
+        ${gp('**/*.json', '.', pathWin32)}                        | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '**/*.json', root: 'deeper', ...globalGlob }, pathWin32)}    | ${'root below, globstar'}
+        ${gp('deeper/*.json')}                                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, path)}                           | ${'root below, matching'}
+        ${gp('deeper/*.json', '.', pathPosix)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathPosix)}                      | ${'root below, matching'}
+        ${gp('deeper/*.json', '.', pathWin32)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathWin32)}                      | ${'root below, matching'}
+        ${gp('deeper/*.json', 'e:/user/Test/project', pathWin32)} | ${'cfg.json'}             | ${'E:/user/test/project/deeper'} | ${eg({ glob: '*.json', root: 'E:/user/test/project/deeper' }, pathWin32)} | ${'root below, matching'}
+        ${gp('**/deeper/*.json')}                                 | ${'deeper/cfg.json'}      | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: 'deeper', ...globalGlob }, path)}  | ${'root below, not matching'}
+        ${gp('**/deeper/*.json', 'proj/nested')}                  | ${'deeper/cfg.json'}      | ${'proj'}                        | ${eg({ glob: '**/deeper/*.json', root: 'proj', ...globalGlob }, path)}    | ${'root below, not matching'}
+        ${gp('**/deeper/*.json')}                                 | ${'!cfg.json'}            | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: 'deeper', ...globalGlob }, path)}  | ${'root below, not matching'}
+        ${gp('deeper/project/*/*.json')}                          | ${'cfg.json'}             | ${'deeper/project/a'}            | ${eg({ glob: '*.json', root: 'deeper/project/a' }, path)}                 | ${'root below, not matching'}
     `(
         'normalizeGlobToRoot orig {$globPath.glob.glob, $globPath.glob.root} $root $comment',
         ({ globPath, file, root, expected }: TestNormalizeGlobToRoot) => {
@@ -308,7 +308,7 @@ describe('Validate Glob Normalization to root', () => {
         ${j(mg('*.json', 'project/a'))}                   | ${'project'}     | ${e(mGlob(gg('a/*.json'), { rawGlob: '*.json' }))}                     | ${'Root in the middle.'}
         ${j(mg('/node_modules', 'project/a'))}            | ${'project'}     | ${e(mGlob(gg('a/node_modules'), { rawGlob: '/node_modules' }))}        | ${'Root in the middle. /node_modules'}
         ${j(mg('*.json', '../tests/a'))}                  | ${'project'}     | ${e({ glob: '*.json', root: '../tests/a' })}                           | ${'Glob not in root is not changed.'}
-        ${j(mg('**/*.ts', '.'))}                          | ${'project'}     | ${e({ glob: '**/*.ts', root: '.' })}                                   | ${'Glob not in root is not changed.'}
+        ${j(mg('**/*.ts', '.'))}                          | ${'project'}     | ${e({ glob: '**/*.ts', root: 'project' })}                             | ${'Glob not in root is not changed.'}
         ${j(mg('/**/*.ts', '.'))}                         | ${'project'}     | ${e({ glob: '**/*.ts', root: 'project' })}                             | ${'Glob not in root is not changed.'}
         ${j(mg('*/*.json', '../tests/a'))}                | ${'project'}     | ${e({ glob: '*/*.json', root: '../tests/a' })}                         | ${'Glob not in root is not changed.'}
         ${j(mg('*/*.json', 'project/a'))}                 | ${'project'}     | ${e({ glob: 'a/*/*.json', root: 'project' })}                          | ${'nested a/*/*.json'}

--- a/packages/cspell-glob/src/globHelper.test.ts
+++ b/packages/cspell-glob/src/globHelper.test.ts
@@ -80,6 +80,7 @@ describe('Validate fileOrGlobToGlob', () => {
 
 describe('Validate Glob Normalization to root', () => {
     const globalGlob: Partial<GlobPatternNormalized> = { isGlobalPattern: true };
+    const relGlob: Partial<GlobPatternNormalized> = { isGlobalPattern: false };
 
     function g(
         pattern: GlobPattern,
@@ -209,23 +210,24 @@ describe('Validate Glob Normalization to root', () => {
     }
 
     test.each`
-        globPath                                                  | file                      | root                             | expected                                                                  | comment
-        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, path)}                                | ${'matching root'}
-        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                           | ${'matching root'}
-        ${gp('*.json', '.', pathWin32)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathWin32)}                           | ${'matching root'}
-        ${gp('*.json')}                                           | ${'cspell-glob/cfg.json'} | ${'..'}                          | ${eg({ glob: 'cspell-glob/*.json', root: '..' }, path)}                   | ${'root above'}
-        ${gp('*.json', '.', pathPosix)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathPosix)}                   | ${'root above'}
-        ${gp('*.json', '.', pathWin32)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathWin32)}                   | ${'root above'}
-        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, path)}                                | ${'root below, cannot change'}
-        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                           | ${'root below, cannot change'}
-        ${gp('**/*.json', '.', pathWin32)}                        | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '**/*.json', root: 'deeper' }, pathWin32)}                   | ${'root below, globstar'}
-        ${gp('deeper/*.json')}                                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, path)}                           | ${'root below, matching'}
-        ${gp('deeper/*.json', '.', pathPosix)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathPosix)}                      | ${'root below, matching'}
-        ${gp('deeper/*.json', '.', pathWin32)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathWin32)}                      | ${'root below, matching'}
-        ${gp('deeper/*.json', 'e:/user/Test/project', pathWin32)} | ${'cfg.json'}             | ${'E:/user/test/project/deeper'} | ${eg({ glob: '*.json', root: 'E:/user/test/project/deeper' }, pathWin32)} | ${'root below, matching'}
-        ${gp('**/deeper/*.json')}                                 | ${'deeper/cfg.json'}      | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: 'deeper' }, path)}                 | ${'root below, not matching'}
-        ${gp('**/deeper/*.json')}                                 | ${'!cfg.json'}            | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: 'deeper' }, path)}                 | ${'root below, not matching'}
-        ${gp('deeper/project/*/*.json')}                          | ${'cfg.json'}             | ${'deeper/project/a'}            | ${eg({ glob: '*.json', root: 'deeper/project/a' }, path)}                 | ${'root below, not matching'}
+        globPath                                                  | file                      | root                             | expected                                                                      | comment
+        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.', ...relGlob }, path)}                        | ${'matching root'}
+        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                               | ${'matching root'}
+        ${gp('*.json', '.', pathWin32)}                           | ${'cfg.json'}             | ${'.'}                           | ${eg({ glob: '*.json', root: '.' }, pathWin32)}                               | ${'matching root'}
+        ${gp('*.json')}                                           | ${'cspell-glob/cfg.json'} | ${'..'}                          | ${eg({ glob: 'cspell-glob/*.json', root: '..' }, path)}                       | ${'root above'}
+        ${gp('*.json', '.', pathPosix)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathPosix)}                       | ${'root above'}
+        ${gp('*.json', '.', pathWin32)}                           | ${'cspell/cfg.json'}      | ${'..'}                          | ${eg({ glob: 'cspell/*.json', root: '..' }, pathWin32)}                       | ${'root above'}
+        ${gp('*.json')}                                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, path)}                                    | ${'root below, cannot change'}
+        ${gp('*.json', '.', pathPosix)}                           | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: '.' }, pathPosix)}                               | ${'root below, cannot change'}
+        ${gp('**/*.json', '.', pathWin32)}                        | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '**/*.json', root: '.', ...globalGlob }, pathWin32)}             | ${'root below, globstar'}
+        ${gp('deeper/*.json')}                                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, path)}                               | ${'root below, matching'}
+        ${gp('deeper/*.json', '.', pathPosix)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathPosix)}                          | ${'root below, matching'}
+        ${gp('deeper/*.json', '.', pathWin32)}                    | ${'cfg.json'}             | ${'deeper'}                      | ${eg({ glob: '*.json', root: 'deeper' }, pathWin32)}                          | ${'root below, matching'}
+        ${gp('deeper/*.json', 'e:/user/Test/project', pathWin32)} | ${'cfg.json'}             | ${'E:/user/test/project/deeper'} | ${eg({ glob: '*.json', root: 'E:/user/test/project/deeper' }, pathWin32)}     | ${'root below, matching'}
+        ${gp('**/deeper/*.json')}                                 | ${'deeper/cfg.json'}      | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: '.', ...globalGlob }, path)}           | ${'root below, not matching'}
+        ${gp('**/deeper/*.json', 'proj/nested')}                  | ${'deeper/cfg.json'}      | ${'proj'}                        | ${eg({ glob: '**/deeper/*.json', root: 'proj/nested', ...globalGlob }, path)} | ${'root below, not matching'}
+        ${gp('**/deeper/*.json')}                                 | ${'!cfg.json'}            | ${'deeper'}                      | ${eg({ glob: '**/deeper/*.json', root: '.', ...globalGlob }, path)}           | ${'root below, not matching'}
+        ${gp('deeper/project/*/*.json')}                          | ${'cfg.json'}             | ${'deeper/project/a'}            | ${eg({ glob: '*.json', root: 'deeper/project/a' }, path)}                     | ${'root below, not matching'}
     `(
         'normalizeGlobToRoot orig {$globPath.glob.glob, $globPath.glob.root} $root $comment',
         ({ globPath, file, root, expected }: TestNormalizeGlobToRoot) => {
@@ -306,7 +308,8 @@ describe('Validate Glob Normalization to root', () => {
         ${j(mg('*.json', 'project/a'))}                   | ${'project'}     | ${e(mGlob(gg('a/*.json'), { rawGlob: '*.json' }))}                     | ${'Root in the middle.'}
         ${j(mg('/node_modules', 'project/a'))}            | ${'project'}     | ${e(mGlob(gg('a/node_modules'), { rawGlob: '/node_modules' }))}        | ${'Root in the middle. /node_modules'}
         ${j(mg('*.json', '../tests/a'))}                  | ${'project'}     | ${e({ glob: '*.json', root: '../tests/a' })}                           | ${'Glob not in root is not changed.'}
-        ${j(mg('**/*.ts', '.'))}                          | ${'project'}     | ${e({ glob: '**/*.ts', root: 'project' })}                             | ${'Glob not in root is not changed.'}
+        ${j(mg('**/*.ts', '.'))}                          | ${'project'}     | ${e({ glob: '**/*.ts', root: '.' })}                                   | ${'Glob not in root is not changed.'}
+        ${j(mg('/**/*.ts', '.'))}                         | ${'project'}     | ${e({ glob: '**/*.ts', root: 'project' })}                             | ${'Glob not in root is not changed.'}
         ${j(mg('*/*.json', '../tests/a'))}                | ${'project'}     | ${e({ glob: '*/*.json', root: '../tests/a' })}                         | ${'Glob not in root is not changed.'}
         ${j(mg('*/*.json', 'project/a'))}                 | ${'project'}     | ${e({ glob: 'a/*/*.json', root: 'project' })}                          | ${'nested a/*/*.json'}
         ${j(mg('*/*.json', '.'))}                         | ${'project'}     | ${e({ glob: '*.json', root: 'project' })}                              | ${'nested */*.json'}

--- a/packages/cspell-glob/src/globHelper.ts
+++ b/packages/cspell-glob/src/globHelper.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-irregular-whitespace */
-import assert from 'assert';
 import * as Path from 'path';
 import {
     GlobPattern,
@@ -28,9 +27,11 @@ export function fileOrGlobToGlob(
     const pathToGlob = path.sep === '\\' ? (p: string) => p.replace(/\\/g, '/') : (p: string) => p;
 
     const isGlobalPattern = false;
-    if (typeof fileOrGlob !== 'string') {
+    if (isGlobPatternWithOptionalRoot(fileOrGlob)) {
         const useRoot = fileOrGlob.root ?? root;
-        const isGlobalPattern = isGlobalPatternRegExp.test(fileOrGlob.glob);
+        const isGlobalPattern = isGlobPatternWithRoot(fileOrGlob)
+            ? fileOrGlob.isGlobalPattern
+            : isGlobalGlob(fileOrGlob.glob);
         return { ...fileOrGlob, root: useRoot, isGlobalPattern };
     }
 
@@ -193,7 +194,7 @@ export function normalizeGlobToRoot<Glob extends GlobPatternWithRoot>(
         return path.sep === '\\' ? relativePath.replace(/\\/g, '/') : relativePath;
     }
 
-    if (glob.root === root || glob.isGlobalPattern) {
+    if (glob.root === root) {
         return glob;
     }
 
@@ -201,6 +202,10 @@ export function normalizeGlobToRoot<Glob extends GlobPatternWithRoot>(
 
     if (!relFromRootToGlob) {
         return glob;
+    }
+
+    if (glob.isGlobalPattern) {
+        return { ...glob, root };
     }
 
     const relFromGlobToRoot = path.relative(glob.root, root);

--- a/packages/cspell-glob/src/globHelper.ts
+++ b/packages/cspell-glob/src/globHelper.ts
@@ -193,9 +193,7 @@ export function normalizeGlobToRoot<Glob extends GlobPatternWithRoot>(
         return path.sep === '\\' ? relativePath.replace(/\\/g, '/') : relativePath;
     }
 
-    assert('isGlobalPattern' in glob);
-
-    if (glob.root === root) {
+    if (glob.root === root || glob.isGlobalPattern) {
         return glob;
     }
 

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -315,7 +315,8 @@ describe('Validate Overrides', () => {
         ${'nested/dir/spell.test.ts'}      | ${['**/dir/**/*.ts']}                     | ${true}
         ${'nested/dir/spell.test.js'}      | ${['**/*.ts']}                            | ${false}
         ${'nested/dir/spell.test.js'}      | ${['*.ts', '*.test.js']}                  | ${true}
-        ${'/cspell-dicts/nl_NL/Dutch.txt'} | ${'**/nl_NL/**'}                          | ${false /* the file is a root filename */}
+        ${'/cspell-dicts/nl_NL/Dutch.txt'} | ${'**/nl_NL/**'}                          | ${true /* the file is a root filename but the glob is global */}
+        ${'/cspell-dicts/nl_NL/Dutch.txt'} | ${'/**/nl_NL/**'}                         | ${false /* the file is a root filename */}
         ${'cspell-dicts/nl_NL/Dutch.txt'}  | ${'**/nl_NL/**'}                          | ${true}
     `('checkFilenameMatchesGlob "$file" against "$glob" expect: $expected', ({ file, glob, expected }) => {
         file = path.resolve(__dirname, file);

--- a/packages/cspell-lib/src/exclusionHelper.test.ts
+++ b/packages/cspell-lib/src/exclusionHelper.test.ts
@@ -41,7 +41,7 @@ describe('Verify Exclusion Helper functions', () => {
     });
 
     test('the generated matching function for nested projects', () => {
-        const globs = ['**/node_modules', '**/typings', '.vscode'];
+        const globs = ['/**/node_modules', '**/typings', '.vscode'];
         const filesMatching = [
             'file:///User/projects/myProject/node_modules/test/test.js',
             'file:///User/projects/myProject/node_modules/test/test.json',

--- a/packages/cspell/src/util/glob.test.ts
+++ b/packages/cspell/src/util/glob.test.ts
@@ -93,17 +93,18 @@ describe('Validate internal functions', () => {
     }
 
     test.each`
-        glob               | globRoot          | root              | expectedGlobs                                                  | file                                | expectedToMatch
-        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                                                          | ${''}                               | ${false}
-        ${'**'}            | ${'.'}            | ${'.'}            | ${['**']}                                                      | ${'./package.json'}                 | ${true}
-        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['**/*.json', '**/*.json/**']}                               | ${'./package.json'}                 | ${true}
-        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['**/*.json', '**/*.json/**']}                               | ${'./.git/package.json'}            | ${true}
-        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/*.json', 'project/p1/**/*.json/**']}         | ${'./project/p1/package.json'}      | ${true}
-        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/*.json', 'project/p1/**/*.json/**']}         | ${'./project/p1/src/package.json'}  | ${true}
-        ${'*.json'}        | ${'.'}            | ${'./project/p2'} | ${['**/*.json', '**/*.json/**']}                               | ${'./project/p2/package.json'}      | ${true}
-        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                                                          | ${''}                               | ${false}
-        ${'**/src/*.json'} | ${'.'}            | ${'./project/p2'} | ${['**/src/*.json', '**/src/*.json/**']}                       | ${'./project/p2/x/src/config.json'} | ${true}
-        ${'**/src/*.json'} | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/src/*.json', 'project/p1/**/src/*.json/**']} | ${'./project/p1/src/config.json'}   | ${true}
+        glob                | globRoot          | root              | expectedGlobs                                                  | file                                | expectedToMatch
+        ${'src/*.json'}     | ${'.'}            | ${'./project/p2'} | ${[]}                                                          | ${''}                               | ${false}
+        ${'**'}             | ${'.'}            | ${'.'}            | ${['**']}                                                      | ${'./package.json'}                 | ${true}
+        ${'*.json'}         | ${'.'}            | ${'.'}            | ${['**/*.json', '**/*.json/**']}                               | ${'./package.json'}                 | ${true}
+        ${'*.json'}         | ${'.'}            | ${'.'}            | ${['**/*.json', '**/*.json/**']}                               | ${'./.git/package.json'}            | ${true}
+        ${'*.json'}         | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/*.json', 'project/p1/**/*.json/**']}         | ${'./project/p1/package.json'}      | ${true}
+        ${'*.json'}         | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/*.json', 'project/p1/**/*.json/**']}         | ${'./project/p1/src/package.json'}  | ${true}
+        ${'*.json'}         | ${'.'}            | ${'./project/p2'} | ${['**/*.json', '**/*.json/**']}                               | ${'./project/p2/package.json'}      | ${true}
+        ${'src/*.json'}     | ${'.'}            | ${'./project/p2'} | ${[]}                                                          | ${''}                               | ${false}
+        ${'**/src/*.json'}  | ${'.'}            | ${'./project/p2'} | ${['**/src/*.json', '**/src/*.json/**']}                       | ${'./project/p2/x/src/config.json'} | ${true}
+        ${'**/src/*.json'}  | ${'./project/p1'} | ${'.'}            | ${['**/src/*.json', '**/src/*.json/**']}                       | ${'./project/p1/src/config.json'}   | ${true}
+        ${'/**/src/*.json'} | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/src/*.json', 'project/p1/**/src/*.json/**']} | ${'./project/p1/src/config.json'}   | ${true}
     `(
         'mapGlobToRoot exclude "$glob"@"$globRoot" -> "$root" = "$expectedGlobs"',
         ({ glob, globRoot, root, expectedGlobs, file, expectedToMatch }: TestMapGlobToRoot) => {
@@ -126,16 +127,18 @@ describe('Validate internal functions', () => {
     );
 
     test.each`
-        glob               | globRoot          | root              | expectedGlobs                   | file                                | expectedToMatch
-        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['*.json']}                   | ${'./package.json'}                 | ${true}
-        ${'*.json'}        | ${'.'}            | ${'.'}            | ${['*.json']}                   | ${'./.git/package.json'}            | ${false}
-        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/*.json']}        | ${'./project/p1/package.json'}      | ${true}
-        ${'*.json'}        | ${'./project/p1'} | ${'.'}            | ${['project/p1/*.json']}        | ${'./project/p1/src/package.json'}  | ${false}
-        ${'*.json'}        | ${'.'}            | ${'./project/p2'} | ${[]}                           | ${'./project/p2/package.json'}      | ${false}
-        ${'**/*.json'}     | ${'.'}            | ${'./project/p2'} | ${['**/*.json']}                | ${'./project/p2/package.json'}      | ${true}
-        ${'src/*.json'}    | ${'.'}            | ${'./project/p2'} | ${[]}                           | ${''}                               | ${false}
-        ${'**/src/*.json'} | ${'.'}            | ${'./project/p2'} | ${['**/src/*.json']}            | ${'./project/p2/x/src/config.json'} | ${true}
-        ${'**/src/*.json'} | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/src/*.json']} | ${'./project/p1/src/config.json'}   | ${true}
+        glob                | globRoot          | root              | expectedGlobs                   | file                                | expectedToMatch
+        ${'*.json'}         | ${'.'}            | ${'.'}            | ${['*.json']}                   | ${'./package.json'}                 | ${true}
+        ${'*.json'}         | ${'.'}            | ${'.'}            | ${['*.json']}                   | ${'./.git/package.json'}            | ${false}
+        ${'*.json'}         | ${'./project/p1'} | ${'.'}            | ${['project/p1/*.json']}        | ${'./project/p1/package.json'}      | ${true}
+        ${'*.json'}         | ${'./project/p1'} | ${'.'}            | ${['project/p1/*.json']}        | ${'./project/p1/src/package.json'}  | ${false}
+        ${'*.json'}         | ${'.'}            | ${'./project/p2'} | ${[]}                           | ${'./project/p2/package.json'}      | ${false}
+        ${'/**/*.json'}     | ${'.'}            | ${'./project/p2'} | ${['**/*.json']}                | ${'./project/p2/package.json'}      | ${true}
+        ${'**/*.json'}      | ${'.'}            | ${'./project/p2'} | ${['**/*.json']}                | ${'./project/p2/package.json'}      | ${true}
+        ${'src/*.json'}     | ${'.'}            | ${'./project/p2'} | ${[]}                           | ${''}                               | ${false}
+        ${'**/src/*.json'}  | ${'.'}            | ${'./project/p2'} | ${['**/src/*.json']}            | ${'./project/p2/x/src/config.json'} | ${true}
+        ${'**/src/*.json'}  | ${'./project/p1'} | ${'.'}            | ${['**/src/*.json']}            | ${'./project/p1/src/config.json'}   | ${true}
+        ${'/**/src/*.json'} | ${'./project/p1'} | ${'.'}            | ${['project/p1/**/src/*.json']} | ${'./project/p1/src/config.json'}   | ${true}
     `(
         'mapGlobToRoot include "$glob"@"$globRoot" -> "$root" = "$expectedGlobs"',
         ({ glob, globRoot, root, expectedGlobs, file, expectedToMatch }: TestMapGlobToRoot) => {


### PR DESCRIPTION
**Minor Breakage**

Globs starting with `**` are considered global and will not be evaluated relative to the containing configuration file's path.

To make a relative glob, start it with `/`, like `/**`.
