### PR TITLE
fix: Pull out `plugins` to avoid conflict

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -1103,7 +1103,9 @@
             {
               "type": "string"
             },
-            {}
+            {
+              "$ref": "#/definitions/Serializable"
+            }
           ],
           "maxItems": 2,
           "minItems": 2,
@@ -1111,6 +1113,25 @@
         }
       ],
       "description": "Reporter name or reporter name + reporter config."
+    },
+    "Serializable": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "object"
+        }
+      ]
     },
     "SimpleGlob": {
       "description": "Simple Glob string, the root will be globRoot.",

--- a/packages/cspell-bundled-dicts/cspell-default.config.ts
+++ b/packages/cspell-bundled-dicts/cspell-default.config.ts
@@ -1,9 +1,9 @@
 /* eslint-disable node/no-missing-import */
 /* eslint-disable import/no-unresolved */
-import type { CSpellSettings } from '@cspell/cspell-types';
+import type { AdvancedCSpellSettings } from '@cspell/cspell-types';
 import { parser as parserTypeScript } from 'cspell-grammar/parsers/typescript/index.js';
 
-const settings: CSpellSettings = {
+const settings: AdvancedCSpellSettings = {
     version: '0.2',
     name: 'cspell default settings .js',
     id: 'cspell-default-js',

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { Glob, CSpellSettingsWithSourceTrace, ReplaceMap, DictionaryInformation, Parser, DictionaryDefinitionPreferred, DictionaryDefinitionAugmented, DictionaryDefinitionCustom, TextOffset, TextDocumentOffset, PnPSettings as PnPSettings$1, ImportFileRef, CSpellUserSettings, MappedText, ParsedText, LocaleId, CSpellSettings } from '@cspell/cspell-types';
+import { Glob, CSpellSettingsWithSourceTrace, ReplaceMap, DictionaryInformation, AdvancedCSpellSettingsWithSourceTrace, Parser, DictionaryDefinitionPreferred, DictionaryDefinitionAugmented, DictionaryDefinitionCustom, TextOffset, TextDocumentOffset, PnPSettings as PnPSettings$1, ImportFileRef, CSpellUserSettings, MappedText, ParsedText, LocaleId, CSpellSettings } from '@cspell/cspell-types';
 export * from '@cspell/cspell-types';
 import { CompoundWordsMethod, SuggestionResult, SuggestionCollector, WeightMap } from 'cspell-trie-lib';
 export { CompoundWordsMethod, SuggestionCollector, SuggestionResult } from 'cspell-trie-lib';
@@ -222,7 +222,7 @@ declare type OptionalOrUndefined<T> = {
 };
 
 declare const SymbolCSpellSettingsInternal: unique symbol;
-interface CSpellSettingsInternal extends Omit<CSpellSettingsWithSourceTrace, 'dictionaryDefinitions'> {
+interface CSpellSettingsInternal extends Omit<AdvancedCSpellSettingsWithSourceTrace, 'dictionaryDefinitions'> {
     [SymbolCSpellSettingsInternal]: true;
     dictionaryDefinitions?: DictionaryDefinitionInternal[];
 }
@@ -476,8 +476,8 @@ interface ImportFileRefWithError$1 extends ImportFileRef {
 }
 declare function extractImportErrors(settings: CSpellSettingsWST$1): ImportFileRefWithError$1[];
 
-declare type CSpellSettingsWST = CSpellSettingsWithSourceTrace;
-declare type CSpellSettingsWSTO = OptionalOrUndefined<CSpellSettingsWithSourceTrace>;
+declare type CSpellSettingsWST = AdvancedCSpellSettingsWithSourceTrace;
+declare type CSpellSettingsWSTO = OptionalOrUndefined<AdvancedCSpellSettingsWithSourceTrace>;
 declare type CSpellSettingsI = CSpellSettingsInternal;
 declare const currentSettingsFileVersion = "0.2";
 declare const ENV_CSPELL_GLOB_ROOT = "CSPELL_GLOB_ROOT";

--- a/packages/cspell-lib/src/Models/CSpellSettingsInternalDef.ts
+++ b/packages/cspell-lib/src/Models/CSpellSettingsInternalDef.ts
@@ -1,4 +1,5 @@
 import {
+    AdvancedCSpellSettingsWithSourceTrace,
     CSpellSettingsWithSourceTrace,
     DictionaryDefinitionAugmented,
     DictionaryDefinitionCustom,
@@ -11,7 +12,7 @@ import { clean } from '../util/util';
 
 export const SymbolCSpellSettingsInternal = Symbol('CSpellSettingsInternal');
 
-export interface CSpellSettingsInternal extends Omit<CSpellSettingsWithSourceTrace, 'dictionaryDefinitions'> {
+export interface CSpellSettingsInternal extends Omit<AdvancedCSpellSettingsWithSourceTrace, 'dictionaryDefinitions'> {
     [SymbolCSpellSettingsInternal]: true;
     dictionaryDefinitions?: DictionaryDefinitionInternal[];
 }

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -1,4 +1,5 @@
 import type {
+    AdvancedCSpellSettingsWithSourceTrace,
     CSpellSettingsWithSourceTrace,
     CSpellUserSettings,
     Glob,
@@ -21,8 +22,8 @@ import * as util from '../util/util';
 import { calcDictionaryDefsToLoad, mapDictDefsToInternal } from './DictionarySettings';
 import { resolvePatterns } from './patterns';
 
-type CSpellSettingsWST = CSpellSettingsWithSourceTrace;
-type CSpellSettingsWSTO = OptionalOrUndefined<CSpellSettingsWithSourceTrace>;
+type CSpellSettingsWST = AdvancedCSpellSettingsWithSourceTrace;
+type CSpellSettingsWSTO = OptionalOrUndefined<AdvancedCSpellSettingsWithSourceTrace>;
 type CSpellSettingsI = CSpellSettingsInternal;
 
 export const configSettingsFileVersion0_1 = '0.1';

--- a/packages/cspell-lib/src/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-lib/src/__snapshots__/index.test.ts.snap
@@ -46,7 +46,6 @@ Object {
     "overrides": "overrides",
     "parser": "parser",
     "patterns": "patterns",
-    "plugins": "plugins",
     "pnpFiles": "pnpFiles",
     "readonly": "readonly",
     "reporters": "reporters",

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -1103,7 +1103,9 @@
             {
               "type": "string"
             },
-            {}
+            {
+              "$ref": "#/definitions/Serializable"
+            }
           ],
           "maxItems": 2,
           "minItems": 2,
@@ -1111,6 +1113,25 @@
         }
       ],
       "description": "Reporter name or reporter name + reporter config."
+    },
+    "Serializable": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "object"
+        }
+      ]
     },
     "SimpleGlob": {
       "description": "Simple Glob string, the root will be globRoot.",

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -1,6 +1,7 @@
 import type { DictionaryInformation } from './DictionaryInformation';
 import type { Features } from './features';
 import { Parser, ParserName } from './Parser';
+import { Serialize, Serializable } from './types';
 
 export type ReplaceEntry = [string, string];
 export type ReplaceMap = ReplaceEntry[];
@@ -12,13 +13,7 @@ export type CSpellPackageSettings = CSpellUserSettings;
 
 export type CSpellUserSettings = CSpellSettings;
 
-export interface CSpellSettings extends FileSettings, LegacySettings {
-    /**
-     * Url to JSON Schema
-     * @default "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json"
-     */
-    $schema?: string;
-}
+export interface CSpellSettings extends FileSettings, LegacySettings {}
 
 export interface ImportFileRef {
     filename: string;
@@ -32,7 +27,17 @@ export interface CSpellSettingsWithSourceTrace extends CSpellSettings {
     __imports?: Map<string, ImportFileRef>;
 }
 
-export interface FileSettings extends ExtendableSettings, CommandLineSettings, ExperimentalFileSettings {
+export interface AdvancedCSpellSettingsWithSourceTrace
+    extends CSpellSettingsWithSourceTrace,
+        ExperimentalFileSettings {}
+
+export interface FileSettings extends ExtendableSettings, CommandLineSettings {
+    /**
+     * Url to JSON Schema
+     * @default "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json"
+     */
+    $schema?: string;
+
     /**
      * Configuration format version of the settings file.
      *
@@ -957,7 +962,7 @@ interface BaseSource {
 /**
  * Reporter name or reporter name + reporter config.
  */
-export type ReporterSettings = string | [string] | [string, unknown];
+export type ReporterSettings = string | [string] | [string, Serializable];
 
 /**
  * Experimental Configuration / Options
@@ -972,8 +977,15 @@ export interface ExperimentalFileSettings {
      * @experimental
      * @version 6.2.0
      */
-    plugins?: Plugin[] | undefined;
+    plugins?: Plugin[];
 }
+
+/**
+ * Extends CSpellSettings with ExperimentalFileSettings
+ * @experimental
+ * @hidden
+ */
+export interface AdvancedCSpellSettings extends CSpellSettings, ExperimentalFileSettings {}
 
 /**
  * Experimental Configuration / Options
@@ -988,7 +1000,7 @@ export interface ExperimentalBaseSettings {
      * @experimental
      * @version 6.2.0
      */
-    parser?: ParserName | undefined;
+    parser?: ParserName;
 }
 
 /**
@@ -997,5 +1009,5 @@ export interface ExperimentalBaseSettings {
  * @version 6.2.0
  */
 export interface Plugin {
-    parsers?: Parser[] | undefined;
+    parsers?: Parser[];
 }

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -1,7 +1,7 @@
 import type { DictionaryInformation } from './DictionaryInformation';
 import type { Features } from './features';
 import { Parser, ParserName } from './Parser';
-import { Serialize, Serializable } from './types';
+import { Serializable } from './types';
 
 export type ReplaceEntry = [string, string];
 export type ReplaceMap = ReplaceEntry[];

--- a/packages/cspell-types/src/configFields.ts
+++ b/packages/cspell-types/src/configFields.ts
@@ -55,7 +55,6 @@ export const ConfigFields: CSpellUserSettingsFields = {
 
     // Experimental
     parser: 'parser',
-    plugins: 'plugins',
 };
 
 // export const ConfigKeysNames = Object.values(ConfigKeysByField);

--- a/packages/cspell-types/src/types.ts
+++ b/packages/cspell-types/src/types.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/ban-types */
+
+export type Serialize<T> = T extends Function
+    ? never
+    : T extends null
+    ? null
+    : // : T extends undefined
+    // ? undefined
+    T extends any[]
+    ? SerializeArray<T>
+    : T extends object
+    ? SerializeObj<T>
+    : Primitives<T>;
+
+type SerializeObj<T extends object> = {
+    [K in keyof T]: K extends string | number ? Serialize<T[K]> : never;
+};
+
+type SerializeArray<T extends Array<any>> = T extends [infer R]
+    ? [Serialize<R>]
+    : T extends [infer R0, infer R1]
+    ? [Serialize<R0>, Serialize<R1>]
+    : T extends [infer R0, infer R1, infer R2]
+    ? [Serialize<R0>, Serialize<R1>, Serialize<R2>]
+    : T extends Array<infer R>
+    ? Serialize<R>[]
+    : never;
+
+type Primitives<T> = Extract<T, number | string | null | boolean>;
+
+export type Serializable = number | string | boolean | null | object;


### PR DESCRIPTION
Plugin type is not compatible with serialization. The solution was to pull it out into `AdvancedCSpellSettings`