### PR TITLE
fix: Do not late bind parsers

### DIFF
--- a/packages/cspell-bundled-dicts/cspell-default.config.js
+++ b/packages/cspell-bundled-dicts/cspell-default.config.js
@@ -1,5 +1,4 @@
 "use strict";
-const index_js_1 = require("cspell-grammar/parsers/typescript/index.js");
 const settings = {
     version: '0.2',
     name: 'cspell default settings .js',
@@ -133,11 +132,6 @@ const settings = {
         '@cspell/dict-swift/cspell-ext.json',
         '@cspell/dict-typescript/cspell-ext.json',
         '@cspell/dict-vue/cspell-ext.json',
-    ],
-    plugins: [
-        {
-            parsers: [index_js_1.parser],
-        },
     ],
 };
 module.exports = settings;

--- a/packages/cspell-bundled-dicts/cspell-default.config.ts
+++ b/packages/cspell-bundled-dicts/cspell-default.config.ts
@@ -1,7 +1,4 @@
-/* eslint-disable node/no-missing-import */
-/* eslint-disable import/no-unresolved */
 import type { AdvancedCSpellSettings } from '@cspell/cspell-types';
-import { parser as parserTypeScript } from 'cspell-grammar/parsers/typescript/index.js';
 
 const settings: AdvancedCSpellSettings = {
     version: '0.2',
@@ -137,11 +134,6 @@ const settings: AdvancedCSpellSettings = {
         '@cspell/dict-swift/cspell-ext.json',
         '@cspell/dict-typescript/cspell-ext.json',
         '@cspell/dict-vue/cspell-ext.json',
-    ],
-    plugins: [
-        {
-            parsers: [parserTypeScript],
-        },
     ],
 };
 

--- a/packages/cspell-bundled-dicts/package-lock.json
+++ b/packages/cspell-bundled-dicts/package-lock.json
@@ -49,8 +49,7 @@
         "@cspell/dict-software-terms": "^2.1.9",
         "@cspell/dict-swift": "^1.0.3",
         "@cspell/dict-typescript": "^2.0.0",
-        "@cspell/dict-vue": "^2.0.2",
-        "cspell-grammar": "^6.2.1"
+        "@cspell/dict-vue": "^2.0.2"
       },
       "devDependencies": {
         "@cspell/cspell-tools": "^6.2.1",
@@ -64,6 +63,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.2.0.tgz",
       "integrity": "sha512-uHRFRYpnwlUUINNCEdyzmsLOPFfGgGBn5vZFf/37h9Un2Ox6dFH7dLKc/HX66uMosm+pGGsT4fWWC0bNzX5yfA==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -93,6 +93,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.2.0.tgz",
       "integrity": "sha512-OmIDxX9HBPfnEyg6gbxMGKF3PlM5H/vvuIiE13F5kAh0SoGLFxlhYAWfPN3vjHl2e9QuWGHS9ZzWlyjiunAqPQ==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -358,21 +359,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/cspell-grammar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.2.1.tgz",
-      "integrity": "sha512-KRbFLryGt2idhPmimq8cRpWomB+hM7/fvk8tzuDTGB7+1N6DdLgF4+NKFq9/6yMk8EFWD1U9DpX5vtRLGc6b1A==",
-      "dependencies": {
-        "@cspell/cspell-pipe": "^6.2.0",
-        "@cspell/cspell-types": "^6.2.0"
-      },
-      "bin": {
-        "cspell-grammar": "bin.js"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/cspell-io": {
@@ -647,7 +633,8 @@
     "@cspell/cspell-pipe": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.2.0.tgz",
-      "integrity": "sha512-uHRFRYpnwlUUINNCEdyzmsLOPFfGgGBn5vZFf/37h9Un2Ox6dFH7dLKc/HX66uMosm+pGGsT4fWWC0bNzX5yfA=="
+      "integrity": "sha512-uHRFRYpnwlUUINNCEdyzmsLOPFfGgGBn5vZFf/37h9Un2Ox6dFH7dLKc/HX66uMosm+pGGsT4fWWC0bNzX5yfA==",
+      "dev": true
     },
     "@cspell/cspell-tools": {
       "version": "6.2.1",
@@ -667,7 +654,8 @@
     "@cspell/cspell-types": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.2.0.tgz",
-      "integrity": "sha512-OmIDxX9HBPfnEyg6gbxMGKF3PlM5H/vvuIiE13F5kAh0SoGLFxlhYAWfPN3vjHl2e9QuWGHS9ZzWlyjiunAqPQ=="
+      "integrity": "sha512-OmIDxX9HBPfnEyg6gbxMGKF3PlM5H/vvuIiE13F5kAh0SoGLFxlhYAWfPN3vjHl2e9QuWGHS9ZzWlyjiunAqPQ==",
+      "dev": true
     },
     "@cspell/dict-ada": {
       "version": "2.0.0",
@@ -925,15 +913,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
       "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
       "dev": true
-    },
-    "cspell-grammar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.2.1.tgz",
-      "integrity": "sha512-KRbFLryGt2idhPmimq8cRpWomB+hM7/fvk8tzuDTGB7+1N6DdLgF4+NKFq9/6yMk8EFWD1U9DpX5vtRLGc6b1A==",
-      "requires": {
-        "@cspell/cspell-pipe": "^6.2.0",
-        "@cspell/cspell-types": "^6.2.0"
-      }
     },
     "cspell-io": {
       "version": "6.2.0",

--- a/packages/cspell-bundled-dicts/package.json
+++ b/packages/cspell-bundled-dicts/package.json
@@ -83,8 +83,7 @@
     "@cspell/dict-software-terms": "^2.1.9",
     "@cspell/dict-swift": "^1.0.3",
     "@cspell/dict-typescript": "^2.0.0",
-    "@cspell/dict-vue": "^2.0.2",
-    "cspell-grammar": "^6.2.1"
+    "@cspell/dict-vue": "^2.0.2"
   },
   "engines": {
     "node": ">=14"

--- a/packages/cspell-grammar/src/index.ts
+++ b/packages/cspell-grammar/src/index.ts
@@ -1,2 +1,3 @@
 export { compileGrammar, tokenizeLine, tokenizeText } from './parser';
 export type { Grammar, GrammarDef, Pattern, Repository } from './parser';
+export { parsers } from './parsers';

--- a/packages/cspell-grammar/src/parsers/index.ts
+++ b/packages/cspell-grammar/src/parsers/index.ts
@@ -1,0 +1,2 @@
+import { parser as parserTypeScript } from './typescript';
+export const parsers = [parserTypeScript];

--- a/packages/cspell-lib/package-lock.json
+++ b/packages/cspell-lib/package-lock.json
@@ -17,6 +17,7 @@
         "configstore": "^5.0.1",
         "cosmiconfig": "^7.0.1",
         "cspell-glob": "^6.2.0",
+        "cspell-grammar": "^6.2.1",
         "cspell-io": "^6.2.0",
         "cspell-trie-lib": "^6.2.1",
         "fast-equals": "^4.0.1",

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -56,6 +56,7 @@
     "configstore": "^5.0.1",
     "cosmiconfig": "^7.0.1",
     "cspell-glob": "^6.2.0",
+    "cspell-grammar": "^6.2.1",
     "cspell-io": "^6.2.0",
     "cspell-trie-lib": "^6.2.1",
     "fast-equals": "^4.0.1",

--- a/packages/cspell-lib/src/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/Settings/DefaultSettings.ts
@@ -1,4 +1,5 @@
 import type { PredefinedPatterns, RegExpPatternDefinition } from '@cspell/cspell-types';
+import { parsers } from 'cspell-grammar';
 import { createCSpellSettingsInternal, CSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef';
 import { PatternRegExp } from '../Models/PatternRegExp';
 import { resolveFile } from '../util/resolveFile';
@@ -103,6 +104,7 @@ export const _defaultSettingsBasis: Readonly<CSpellSettingsInternal> = Object.fr
         languageSettings: [],
         source: { name: 'defaultSettings' },
         reporters: [],
+        plugins: [{ parsers }],
     })
 );
 


### PR DESCRIPTION
Late binding of parsers is creating an issue with the config loader.
This will be fixed later, since late binding is the desired behavior.