### PR TITLE
feat(cspell-eslint-plugin): Experimental Add word to dictionary

### DIFF
--- a/packages/cspell-eslint-plugin/fixtures/with-errors/creepyData.dict.txt
+++ b/packages/cspell-eslint-plugin/fixtures/with-errors/creepyData.dict.txt
@@ -1,0 +1,3 @@
+muawhahaha
+grrrrr
+uuuug

--- a/packages/cspell-eslint-plugin/src/_auto_generated_/options.schema.json
+++ b/packages/cspell-eslint-plugin/src/_auto_generated_/options.schema.json
@@ -23,6 +23,10 @@
       "description": "Spell check strings",
       "type": "boolean"
     },
+    "customWordListFile": {
+      "description": "**Experimental**: Specify a path to a custom word list file. A utf-8 text file with one word per line. This file is used to present the option to add words.",
+      "type": "string"
+    },
     "debugMode": {
       "default": false,
       "description": "Output debug logs",

--- a/packages/cspell-eslint-plugin/src/customWordList.ts
+++ b/packages/cspell-eslint-plugin/src/customWordList.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const sortFn = new Intl.Collator().compare;
+
+export function addWordToCustomWordList(customWordListPath: string, word: string) {
+    const content = readFile(customWordListPath) || '\n';
+    const lineEndingMatch = content.match(/\r?\n/);
+    const lineEnding = lineEndingMatch?.[0] || '\n';
+    const words = new Set(
+        content
+            .split(/\n/g)
+            .map((a) => a.trim())
+            .filter((a) => !!a)
+    );
+    words.add(word);
+
+    const lines = [...words];
+    lines.sort(sortFn);
+    writeFile(customWordListPath, lines.join(lineEnding) + lineEnding);
+}
+
+function readFile(file: string): string | undefined {
+    try {
+        return fs.readFileSync(file, 'utf-8');
+    } catch (e) {
+        return undefined;
+    }
+}
+
+function writeFile(file: string, content: string) {
+    makeDir(path.dirname(file));
+    fs.writeFileSync(file, content);
+}
+
+function makeDir(dir: string) {
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+    } catch (e) {
+        console.log(e);
+    }
+}

--- a/packages/cspell-eslint-plugin/src/index.test.ts
+++ b/packages/cspell-eslint-plugin/src/index.test.ts
@@ -13,8 +13,6 @@ const parsers: Record<string, string | undefined> = {
 type CachedSample = RuleTester.ValidTestCase;
 type Options = Partial<Rule.Options>;
 
-const sampleFiles = new Map<string, CachedSample>();
-
 const ruleTester = new RuleTester({
     env: {
         es6: true,
@@ -119,6 +117,12 @@ ruleTester.run('cspell', Rule.rules.spellchecker, {
             ],
             { ignoreImports: false }
         ),
+        // cspell:ignore GRRRRRR UUUUUG
+        readInvalid(
+            'with-errors/creepyData.ts',
+            ['Unknown word: "uuug"', 'Unknown word: "grrr"', 'Unknown word: "GRRRRRR"', 'Unknown word: "UUUUUG"'],
+            { ignoreImports: false, customWordListFile: resolveFix('with-errors/creepyData.dict.txt') }
+        ),
     ],
 });
 
@@ -126,11 +130,12 @@ function resolveFromMonoRepo(file: string): string {
     return path.resolve(root, file);
 }
 
-function readFix(_filename: string, options?: Options): CachedSample {
-    const s = sampleFiles.get(_filename);
-    if (s) return s;
+function resolveFix(filename: string): string {
+    return path.resolve(fixturesDir, filename);
+}
 
-    const filename = path.resolve(fixturesDir, _filename);
+function readFix(_filename: string, options?: Options): CachedSample {
+    const filename = resolveFix(_filename);
     const code = fs.readFileSync(filename, 'utf-8');
 
     const sample: CachedSample = {

--- a/packages/cspell-eslint-plugin/src/options.ts
+++ b/packages/cspell-eslint-plugin/src/options.ts
@@ -57,6 +57,11 @@ export interface Check {
      * @default true
      */
     checkComments?: boolean;
+    /**
+     * **Experimental**: Specify a path to a custom word list file. A utf-8 text file with one word per line.
+     * This file is used to present the option to add words.
+     */
+    customWordListFile?: string | undefined;
 }
 
 export const defaultCheckOptions: Required<Check> = {
@@ -64,8 +69,9 @@ export const defaultCheckOptions: Required<Check> = {
     checkIdentifiers: true,
     checkStrings: true,
     checkStringTemplates: true,
-    ignoreImports: true,
+    customWordListFile: undefined,
     ignoreImportProperties: true,
+    ignoreImports: true,
 };
 
 export const defaultOptions: Required<Options> = {

--- a/test-packages/test-cspell-eslint-plugin/.eslintrc.js
+++ b/test-packages/test-cspell-eslint-plugin/.eslintrc.js
@@ -40,6 +40,7 @@ const config = {
                         ignores: ['modules'],
                     },
                 ],
+                '@cspell/spellchecker': ['warn', { customWordListFile: 'words.txt' }],
             },
         },
         {


### PR DESCRIPTION
## Experimental Feature
Add the ability to add words to a custom dictionary.

Mostly fixes: #3233, but is flaky because it is using an unsupported technique to detect when a fix has been applied.
-  Option: `customWordListFile`
      **Experimental**: Specify a path to a custom word list file (A utf-8 text file with one word per line). This file is used to present the option to add words.
