### PR TITLE
feat: Support Ignoring characters before checking

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -17,6 +17,7 @@ estree
 exonum
 gimu
 globstar
+Harakat
 jamstack
 lcov
 licia

--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -434,6 +434,10 @@
           "$ref": "#/definitions/HunspellInformation",
           "description": "Used by dictionary authors"
         },
+        "ignore": {
+          "$ref": "#/definitions/CharacterSet",
+          "description": "An optional set of characters that can possibly be removed from a word before checking it.\n\nThis is useful in languages like Arabic where Harakat accents are optional.\n\nNote: All matching characters are removed or none. Partial removal is not supported."
+        },
         "locale": {
           "description": "The locale of the dictionary. Example: `nl,nl-be`",
           "type": "string"

--- a/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryCollection.test.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/SpellingDictionaryCollection.test.ts
@@ -32,6 +32,7 @@ describe('Verify using multiple dictionaries', () => {
     const wordsC = ['ant', 'snail', 'beetle', 'worm', 'stink bug', 'centipede', 'millipede', 'flea', 'fly'];
     const wordsD = ['red*', 'green*', 'blue*', 'pink*', 'black*', '*berry', '+-fruit', '*bug', 'pinkie'];
     const wordsF = ['!pink*', '+berry', '+bug', '!stinkbug'];
+    const wordsG = ['café', 'accent'];
 
     const wordsLegacy = ['error', 'code', 'system', 'ctrl'];
 
@@ -181,24 +182,35 @@ describe('Verify using multiple dictionaries', () => {
     });
 
     test.each`
-        word            | expected
-        ${'redberry'}   | ${true}
-        ${'pink'}       | ${false}
-        ${'bug'}        | ${true}
-        ${'blackberry'} | ${true}
-        ${'pinkbug'}    | ${true}
+        word              | expected
+        ${'redberry'}     | ${true}
+        ${'pink'}         | ${false}
+        ${'bug'}          | ${true}
+        ${'blackberry'}   | ${true}
+        ${'pinkbug'}      | ${true}
+        ${'cafe'}         | ${false}
+        ${'café'}         | ${true}
+        ${'cafe\u0301'}   | ${true}
+        ${'accent'}       | ${true}
+        ${'áccent'}       | ${true /* ignore the accent. cspell:disable-line */}
+        ${'a\u0301ccent'} | ${true /* ignore the accent. cspell:disable-line */}
+        ${'applé'}        | ${true /* ignore the accent. cspell:disable-line */}
     `('checks has word: "$word"', ({ word, expected }) => {
         const dicts = [
-            createSpellingDictionary(wordsA, 'wordsA', 'test', undefined),
+            createSpellingDictionary(wordsA, 'wordsA', 'test', { dictionaryInformation: { ignore: '\u0300-\u0362' } }),
             createSpellingDictionary(wordsB, 'wordsB', 'test', undefined),
             createSpellingDictionary(wordsC, 'wordsC', 'test', undefined),
             createSpellingDictionary(wordsD, 'wordsD', 'test', undefined),
             createSpellingDictionary(wordsF, 'wordsF', 'test', undefined),
+            createSpellingDictionary(wordsG, 'wordsA', 'test', {
+                dictionaryInformation: { ignore: '\u0300-\u0362' },
+                caseSensitive: true,
+            }),
             createForbiddenWordsDictionary(['Avocado'], 'flag_words', 'test', undefined),
         ];
 
         const dictCollection = createCollection(dicts, 'test');
-        expect(dictCollection.has(word)).toEqual(expected);
+        expect(dictCollection.has(word, { ignoreCase: false })).toEqual(expected);
     });
 
     test.each`

--- a/packages/cspell-lib/src/SpellingDictionary/charset.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/charset.ts
@@ -4,7 +4,7 @@ export function charsetToRegExp(charset: CharacterSet | undefined): RegExp | und
     if (!charset) return undefined;
 
     try {
-        const reg = `[${charset.replace(/[\][]/g, '\\$&')}]`;
+        const reg = `[${charset.replace(/[\][\\]/g, '\\$&')}]`;
         return new RegExp(reg, 'g');
     } catch (e) {
         return undefined;

--- a/packages/cspell-lib/src/SpellingDictionary/charset.ts
+++ b/packages/cspell-lib/src/SpellingDictionary/charset.ts
@@ -1,0 +1,12 @@
+import { CharacterSet } from '@cspell/cspell-types';
+
+export function charsetToRegExp(charset: CharacterSet | undefined): RegExp | undefined {
+    if (!charset) return undefined;
+
+    try {
+        const reg = `[${charset.replace(/[\][]/g, '\\$&')}]`;
+        return new RegExp(reg, 'g');
+    } catch (e) {
+        return undefined;
+    }
+}

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -434,6 +434,10 @@
           "$ref": "#/definitions/HunspellInformation",
           "description": "Used by dictionary authors"
         },
+        "ignore": {
+          "$ref": "#/definitions/CharacterSet",
+          "description": "An optional set of characters that can possibly be removed from a word before checking it.\n\nThis is useful in languages like Arabic where Harakat accents are optional.\n\nNote: All matching characters are removed or none. Partial removal is not supported."
+        },
         "locale": {
           "description": "The locale of the dictionary. Example: `nl,nl-be`",
           "type": "string"

--- a/packages/cspell-types/src/DictionaryInformation.ts
+++ b/packages/cspell-types/src/DictionaryInformation.ts
@@ -47,6 +47,16 @@ export interface DictionaryInformation {
      * If the word matches the pattern, then the penalty is applied.
      */
     adjustments?: PatternAdjustment[];
+
+    /**
+     * An optional set of characters that can possibly be removed from a word before
+     * checking it.
+     *
+     * This is useful in languages like Arabic where Harakat accents are optional.
+     *
+     * Note: All matching characters are removed or none. Partial removal is not supported.
+     */
+    ignore?: CharacterSet;
 }
 
 // cspell:ignore aeistlunkodmrvpgjhäõbüoöfcwzxðqþ aàâä eéèêë iîïy


### PR DESCRIPTION
Added the ability to specify characters to be ignored (removed) from a word before checking the word in the dictionary.

Related to Aribic Harakat vowel accents.
https://github.com/streetsidesoftware/cspell-dicts/issues/1314