### PR TITLE
fix(cspell-trie-lib): move `@cspell/cspell-types`

### DIFF
--- a/packages/cspell-trie-lib/package.json
+++ b/packages/cspell-trie-lib/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell#readme",
   "dependencies": {
     "@cspell/cspell-pipe": "workspace:^",
+    "@cspell/cspell-types": "workspace:^",
     "fs-extra": "^10.1.0",
     "gensequence": "^3.1.1"
   },
@@ -45,7 +46,6 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@cspell/cspell-types": "workspace:^",
     "@cspell/dict-en_us": "^2.3.1",
     "@cspell/dict-es-es": "^2.2.0",
     "@types/fs-extra": "^9.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,10 +596,10 @@ importers:
       rimraf: ^3.0.2
     dependencies:
       '@cspell/cspell-pipe': link:../cspell-pipe
+      '@cspell/cspell-types': link:../cspell-types
       fs-extra: 10.1.0
       gensequence: 3.1.1
     devDependencies:
-      '@cspell/cspell-types': link:../cspell-types
       '@cspell/dict-en_us': 2.3.1
       '@cspell/dict-es-es': 2.2.0
       '@types/fs-extra': 9.0.13


### PR DESCRIPTION
It was a devDependency, but parts of `cspell-trie-lib` import from it.  This brings it in line with how other packages in the repo (e.g. `@cspell/cspell-json-reporter`, `cspell-grammar`) depend on `@cspell/cspell-types`.