### PR TITLE
fix(cspell-pipe): Add operators

### DIFF
--- a/packages/cspell-pipe/src/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-pipe/src/__snapshots__/index.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`Pipe API pipe api 1`] = `
 Array [
   "helpers",
+  "interleave",
   "isAsyncIterable",
+  "opAppend",
   "opAwaitAsync",
   "opConcatMap",
   "opFilter",
@@ -19,5 +21,6 @@ Array [
   "pipeSync",
   "toArray",
   "toAsyncIterable",
+  "toDistributableIterable",
 ]
 `;

--- a/packages/cspell-pipe/src/helpers/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-pipe/src/helpers/__snapshots__/index.test.ts.snap
@@ -2,8 +2,10 @@
 
 exports[`Helpers helpers 1`] = `
 Array [
+  "interleave",
   "isAsyncIterable",
   "toArray",
   "toAsyncIterable",
+  "toDistributableIterable",
 ]
 `;

--- a/packages/cspell-pipe/src/helpers/distribute.test.ts
+++ b/packages/cspell-pipe/src/helpers/distribute.test.ts
@@ -1,0 +1,58 @@
+import { opMap, opTake } from '../operators';
+import { pipeSync } from '../pipe';
+import { toDistributableIterable } from './distribute';
+import { interleave } from './interleave';
+
+describe('distribute', () => {
+    test.each`
+        iter                     | expected
+        ${[1, 2]}                | ${[3, 4]}
+        ${[1, 2, 3]}             | ${[3, 4, 9]}
+        ${toIterable([1, 2, 3])} | ${[3, 4, 9]}
+    `('toDistributableIterable interleave', ({ iter, expected }) => {
+        const dIter = toDistributableIterable<number>(iter);
+        const a = pipeSync(
+            dIter,
+            opMap((a) => a * 3)
+        );
+        const b = pipeSync(
+            dIter,
+            opMap((a) => a * 2)
+        );
+        const r = [...interleave(a, b)];
+        expect(r).toEqual(expected);
+    });
+
+    test('It is consumed by the first usage.', () => {
+        const src = [1, 2, 3];
+        const c = toDistributableIterable(src);
+        const c1 = [...c];
+        const c2 = [...c];
+        expect(c1).toEqual(src);
+        expect(c1).not.toEqual(c2);
+        expect(c2).toHaveLength(0);
+    });
+
+    test('Serial consumers', () => {
+        const src = [1, 2, 3, 4, 5];
+        const c = toDistributableIterable(src);
+        const c1 = [...pipeSync(c, opTake(2))];
+        const c2 = [...c];
+        expect(c1).toEqual(src.slice(0, 2));
+        expect(c2).toEqual(src.slice(2));
+    });
+
+    test('toIterable', () => {
+        const src = [1, 2, 3];
+        const c = toIterable(src);
+        const c1 = [...c];
+        const c2 = [...c];
+        expect(c1).toEqual(src);
+        expect(c1).not.toEqual(c2);
+        expect(c2).toHaveLength(0);
+    });
+});
+
+function* toIterable<T>(a: Iterable<T>): Iterable<T> {
+    yield* a;
+}

--- a/packages/cspell-pipe/src/helpers/distribute.ts
+++ b/packages/cspell-pipe/src/helpers/distribute.ts
@@ -1,0 +1,36 @@
+/**
+ * Allows an iterable to be shared by multiple consumers.
+ * Each consumer takes from the iterable.
+ * @param iterable - the iterable to share
+ */
+export function toDistributableIterableSync<T>(iterable: Iterable<T>): Iterable<T> {
+    let lastValue: IteratorResult<T>;
+    let iter: Iterator<T> | undefined;
+
+    function getNext(): IteratorResult<T> {
+        if (lastValue && lastValue.done) {
+            return { ...lastValue };
+        }
+        iter = iter || iterable[Symbol.iterator]();
+        lastValue = iter.next();
+        return lastValue;
+    }
+
+    function* iterableFn() {
+        let next: IteratorResult<T>;
+        while (!(next = getNext()).done) {
+            yield next.value;
+        }
+    }
+
+    return {
+        [Symbol.iterator]: iterableFn,
+    };
+}
+
+/**
+ * Allows an iterable to be shared by multiple consumers.
+ * Each consumer takes from the iterable.
+ * @param iterable - the iterable to share
+ */
+export const toDistributableIterable = toDistributableIterableSync;

--- a/packages/cspell-pipe/src/helpers/index.ts
+++ b/packages/cspell-pipe/src/helpers/index.ts
@@ -1,3 +1,5 @@
 export { toAsyncIterable } from './toAsyncIterable';
 export { isAsyncIterable } from './util';
 export { toArray } from './toArray';
+export { toDistributableIterable } from './distribute';
+export { interleave } from './interleave';

--- a/packages/cspell-pipe/src/helpers/interleave.test.ts
+++ b/packages/cspell-pipe/src/helpers/interleave.test.ts
@@ -1,0 +1,23 @@
+import { interleave } from './interleave';
+
+describe('distribute', () => {
+    test.each`
+        a                  | b                       | expected
+        ${[1, 2, 3]}       | ${[-1, -2, -3]}         | ${[1, -1, 2, -2, 3, -3]}
+        ${[]}              | ${[-1, -2, -3]}         | ${[-1, -2, -3]}
+        ${[1, 2, 3]}       | ${[]}                   | ${[1, 2, 3]}
+        ${[1, 2, 3, 4, 5]} | ${[-1, -2, -3]}         | ${[1, -1, 2, -2, 3, -3, 4, 5]}
+        ${[1, 2, 3]}       | ${[-1, -2, -3, -4, -5]} | ${[1, -1, 2, -2, 3, -3, -4, -5]}
+    `('interleave $a $b', ({ a, b, expected }) => {
+        expect([...interleave(a, b)]).toEqual(expected);
+
+        const c = toIterable([1, 2, 3]);
+        const c1 = [...c];
+        const c2 = [...c];
+        expect(c1).not.toEqual(c2);
+    });
+});
+
+function* toIterable<T>(a: Iterable<T>): Iterable<T> {
+    yield* a;
+}

--- a/packages/cspell-pipe/src/helpers/interleave.ts
+++ b/packages/cspell-pipe/src/helpers/interleave.ts
@@ -1,0 +1,19 @@
+export function* interleave<T>(a: Iterable<T>, b: Iterable<T>): Iterable<T> {
+    const ai = a[Symbol.iterator]();
+    const bi = b[Symbol.iterator]();
+
+    for (let aNext = ai.next(); !aNext.done; aNext = ai.next()) {
+        yield aNext.value;
+        const bNext = bi.next();
+        if (bNext.done) break;
+        yield bNext.value;
+    }
+
+    for (let aNext = ai.next(); !aNext.done; aNext = ai.next()) {
+        yield aNext.value;
+    }
+
+    for (let bNext = bi.next(); !bNext.done; bNext = bi.next()) {
+        yield bNext.value;
+    }
+}

--- a/packages/cspell-pipe/src/index.ts
+++ b/packages/cspell-pipe/src/index.ts
@@ -1,8 +1,9 @@
 import * as _helpers from './helpers';
 import * as _operators from './operators';
 
-export { isAsyncIterable, toArray, toAsyncIterable } from './helpers';
+export { interleave, isAsyncIterable, toArray, toAsyncIterable, toDistributableIterable } from './helpers';
 export {
+    opAppend,
     opAwaitAsync,
     opConcatMap,
     opFilter,

--- a/packages/cspell-pipe/src/operators/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-pipe/src/operators/__snapshots__/index.test.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`Operators operators 1`] = `
 Array [
+  "opAppend",
+  "opAppendAsync",
+  "opAppendSync",
   "opAwaitAsync",
   "opConcatMap",
   "opConcatMapAsync",

--- a/packages/cspell-pipe/src/operators/append.test.ts
+++ b/packages/cspell-pipe/src/operators/append.test.ts
@@ -1,0 +1,23 @@
+import { pipeAsync, pipeSync, toArray } from '..';
+import { fibonacci } from '../test/fibonacci';
+import { opAppend, opAppendAsync } from './append';
+import { opTake } from './take';
+import { toAsyncIterable } from '../helpers';
+
+describe('append', () => {
+    test('sync', () => {
+        expect([...pipeSync(fibonacci(), opTake(5), opAppend([6, 6], [7, 7]))]).toEqual([0, 1, 1, 2, 3, 6, 6, 7, 7]);
+    });
+
+    test('async', async () => {
+        expect(await toArray(pipeAsync(fibonacci(), opTake(5), opAppend([6, 6], [7, 7])))).toEqual([
+            0, 1, 1, 2, 3, 6, 6, 7, 7,
+        ]);
+    });
+
+    test('async with async', async () => {
+        expect(
+            await toArray(pipeAsync(fibonacci(), opTake(5), opAppendAsync(toAsyncIterable([6, 6]), [7, 7])))
+        ).toEqual([0, 1, 1, 2, 3, 6, 6, 7, 7]);
+    });
+});

--- a/packages/cspell-pipe/src/operators/append.ts
+++ b/packages/cspell-pipe/src/operators/append.ts
@@ -1,0 +1,45 @@
+import { isAsyncIterable } from '../helpers';
+import { PipeFn } from '../internalTypes';
+
+/**
+ * Append values onto the end of an iterable.
+ * @param iterablesToAppend - the iterables in the order to be appended.
+ * @returns
+ */
+export function opAppendAsync<T>(
+    ...iterablesToAppend: (AsyncIterable<T> | Iterable<T>)[]
+): (iter: AsyncIterable<T> | Iterable<T>) => AsyncIterable<T> {
+    async function* fn(iter: AsyncIterable<T> | Iterable<T>) {
+        yield* iter;
+        for (const i of iterablesToAppend) {
+            yield* i;
+        }
+    }
+
+    return fn;
+}
+
+/**
+ * Append values onto the end of an iterable.
+ * @param iterablesToAppend - the iterables in the order to be appended.
+ * @returns
+ */
+export function opAppendSync<T>(...iterablesToAppend: Iterable<T>[]): (iter: Iterable<T>) => Iterable<T> {
+    function* fn(iter: Iterable<T>) {
+        yield* iter;
+        for (const i of iterablesToAppend) {
+            yield* i;
+        }
+    }
+
+    return fn;
+}
+
+export function opAppend<T>(...iterablesToAppend: Iterable<T>[]): PipeFn<T, T> {
+    function _(i: Iterable<T>): Iterable<T>;
+    function _(i: AsyncIterable<T>): AsyncIterable<T>;
+    function _(i: Iterable<T> | AsyncIterable<T>): Iterable<T> | AsyncIterable<T> {
+        return isAsyncIterable(i) ? opAppendAsync(...iterablesToAppend)(i) : opAppendSync(...iterablesToAppend)(i);
+    }
+    return _;
+}

--- a/packages/cspell-pipe/src/operators/index.test.ts
+++ b/packages/cspell-pipe/src/operators/index.test.ts
@@ -4,6 +4,9 @@ describe('Operators', () => {
     test('operators', () => {
         expect(Object.keys(operators).sort()).toMatchSnapshot();
 
+        expect(operators.opAppend).toBeInstanceOf(Function);
+        expect(operators.opAppendAsync).toBeInstanceOf(Function);
+        expect(operators.opAppendSync).toBeInstanceOf(Function);
         expect(operators.opAwaitAsync).toBeInstanceOf(Function);
         expect(operators.opConcatMap).toBeInstanceOf(Function);
         expect(operators.opConcatMapAsync).toBeInstanceOf(Function);

--- a/packages/cspell-pipe/src/operators/index.ts
+++ b/packages/cspell-pipe/src/operators/index.ts
@@ -1,3 +1,4 @@
+export { opAppend, opAppendAsync, opAppendSync } from './append';
 export { opAwaitAsync } from './await';
 export { opConcatMap, opConcatMapAsync, opConcatMapSync } from './concatMap';
 export { opFilter as opFilter, opFilterAsync, opFilterSync } from './filter';

--- a/packages/cspell-pipe/src/operators/joinStrings.ts
+++ b/packages/cspell-pipe/src/operators/joinStrings.ts
@@ -25,5 +25,5 @@ export function opJoinStringsSync(joinCharacter = ','): (iter: Iterable<Iterable
     return fn;
 }
 
-export const opJoinStrings = (joinCharacter = ',') =>
+export const opJoinStrings = (joinCharacter?: string) =>
     toPipeFn(opJoinStringsSync(joinCharacter), opJoinStringsAsync(joinCharacter));

--- a/packages/cspell-pipe/src/operators/take.test.ts
+++ b/packages/cspell-pipe/src/operators/take.test.ts
@@ -1,13 +1,45 @@
-import { pipeAsync, pipeSync, toArray } from '..';
+import { pipeAsync, pipeSync, toArray, opTap } from '..';
 import { fibonacci } from '../test/fibonacci';
 import { opTake } from './take';
 
 describe('take', () => {
-    test('sync', () => {
-        expect([...pipeSync(fibonacci(), opTake(5))]).toEqual([0, 1, 1, 2, 3]);
+    test.each`
+        iter           | count | expected
+        ${fibonacci()} | ${5}  | ${[0, 1, 1, 2, 3]}
+        ${fibonacci()} | ${0}  | ${[]}
+        ${fibonacci()} | ${-1} | ${[]}
+        ${fibonacci()} | ${1}  | ${[0]}
+    `('sync', ({ iter, count, expected }) => {
+        let callCount = 0;
+
+        expect([
+            ...pipeSync(
+                iter,
+                opTap(() => callCount++),
+                opTake(count)
+            ),
+        ]).toEqual(expected);
+        expect(callCount).toBe(Math.max(0, count));
     });
 
-    test('async', async () => {
-        expect(await toArray(pipeAsync(fibonacci(), opTake(5)))).toEqual([0, 1, 1, 2, 3]);
+    test.each`
+        iter           | count | expected
+        ${fibonacci()} | ${5}  | ${[0, 1, 1, 2, 3]}
+        ${fibonacci()} | ${0}  | ${[]}
+        ${fibonacci()} | ${-1} | ${[]}
+        ${fibonacci()} | ${1}  | ${[0]}
+    `('async', async ({ iter, count, expected }) => {
+        let callCount = 0;
+
+        expect(
+            await toArray(
+                pipeAsync(
+                    iter,
+                    opTap(() => callCount++),
+                    opTake(count)
+                )
+            )
+        ).toEqual(expected);
+        expect(callCount).toBe(Math.max(0, count));
     });
 });

--- a/packages/cspell-pipe/src/operators/take.ts
+++ b/packages/cspell-pipe/src/operators/take.ts
@@ -24,4 +24,8 @@ export function opTakeSync<T>(count: number): (iter: Iterable<T>) => Iterable<T>
     return fn;
 }
 
+/**
+ * Consume only the first `count` number from the iterable.
+ * @param count - number to take
+ */
 export const opTake = <T>(count: number) => toPipeFn(opTakeSync<T>(count), opTakeAsync<T>(count));


### PR DESCRIPTION
Operators / methods:
- append: be able to append values to the end of an iterator
- interleave: be able to interleave values.
- toDistributableIterable

Improve coverage.