### PR TITLE
feat: Ignore markdown links

### DIFF
--- a/packages/cspell-bundled-dicts/cspell-default.config.js
+++ b/packages/cspell-bundled-dicts/cspell-default.config.js
@@ -22,13 +22,18 @@ const settings = {
         },
         {
             name: 'MARKDOWN-link-reference',
-            description: 'Markdown reference link: `[This is a link][reference]`',
+            description: 'Markdown reference link: `[This is a link][reference]`, matches `[reference]`',
             pattern: /(?<=\])\[[-\w.`'"*&;#@ ]+\]/g,
         },
         {
             name: 'MARKDOWN-link-footer',
-            description: 'Markdown referenced link: `[reference]: https://www.google.com`',
+            description: 'Markdown referenced link: `[reference]: https://www.google.com`, matches `[reference]`',
             pattern: /\[[-\w.`'"*&;#@ ]+\]:/g,
+        },
+        {
+            name: 'MARKDOWN-link',
+            description: 'Markdown link: `[link text](link)`, matches `link`',
+            pattern: /(?<=\]\()[^)\s]+/g,
         },
     ],
     languageSettings: [
@@ -86,7 +91,7 @@ const settings = {
         },
         {
             languageId: 'markdown',
-            ignoreRegExpList: ['MARKDOWN-link-reference', 'MARKDOWN-link-footer'],
+            ignoreRegExpList: ['MARKDOWN-link-reference', 'MARKDOWN-link-footer', 'MARKDOWN-link'],
         },
     ],
     import: [

--- a/packages/cspell-bundled-dicts/cspell-default.config.ts
+++ b/packages/cspell-bundled-dicts/cspell-default.config.ts
@@ -23,13 +23,18 @@ const settings: AdvancedCSpellSettings = {
         },
         {
             name: 'MARKDOWN-link-reference',
-            description: 'Markdown reference link: `[This is a link][reference]`',
+            description: 'Markdown reference link: `[This is a link][reference]`, matches `[reference]`',
             pattern: /(?<=\])\[[-\w.`'"*&;#@ ]+\]/g,
         },
         {
             name: 'MARKDOWN-link-footer',
-            description: 'Markdown referenced link: `[reference]: https://www.google.com`',
+            description: 'Markdown referenced link: `[reference]: https://www.google.com`, matches `[reference]`',
             pattern: /\[[-\w.`'"*&;#@ ]+\]:/g,
+        },
+        {
+            name: 'MARKDOWN-link',
+            description: 'Markdown link: `[link text](link)`, matches `link`',
+            pattern: /(?<=\]\()[^)\s]+/g,
         },
     ],
 
@@ -88,7 +93,7 @@ const settings: AdvancedCSpellSettings = {
         },
         {
             languageId: 'markdown',
-            ignoreRegExpList: ['MARKDOWN-link-reference', 'MARKDOWN-link-footer'],
+            ignoreRegExpList: ['MARKDOWN-link-reference', 'MARKDOWN-link-footer', 'MARKDOWN-link'],
         },
     ],
     import: [

--- a/packages/cspell-bundled-dicts/package.json
+++ b/packages/cspell-bundled-dicts/package.json
@@ -24,7 +24,7 @@
     "clean": "echo clean",
     "clean-build": "pnpm run clean && pnpm run build",
     "watch": "pnpm run build -- --watch",
-    "test": "node ../../bin.js \"*.{txt,md,ts}\""
+    "test": "node ../../bin.js \"**/*.{txt,md,ts}\""
   },
   "repository": {
     "type": "git",

--- a/packages/cspell-bundled-dicts/test-samples/markdown.md
+++ b/packages/cspell-bundled-dicts/test-samples/markdown.md
@@ -11,6 +11,8 @@ Ignore link references: [This is a link][*`fileerror`*]
 
 Ignore html: &rarr; &dash; &larr;
 
+Another link to ignore: [See Below](#seebelow).
+
 Some text with [a link][1] and
 another [link][2].
 


### PR DESCRIPTION
fix: #3588

Note:

This change will ignore anything in the `()` of a markdown link.