### PR TITLE
feat: Support Verbose Regexp Patterns

### DIFF
--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -274,6 +274,8 @@ declare function isSpellingDictionaryLoadError(e: Error): e is SpellingDictionar
 
 declare function createSpellingDictionary(wordList: readonly string[] | IterableLike<string>, name: string, source: string, options: SpellingDictionaryOptions | undefined): SpellingDictionary;
 
+declare function stringToRegExp(pattern: string | RegExp, defaultFlags?: string, forceFlags?: string): RegExp | undefined;
+
 declare function splitCamelCaseWordWithOffset(wo: TextOffset): Array<TextOffset>;
 /**
  * Split camelCase words into an array of strings.
@@ -313,7 +315,6 @@ declare function camelToSnake(word: string): string;
 declare function matchCase(example: string, word: string): string;
 declare function textOffset(text: string, offset?: number): TextOffset;
 declare function extractText(textOffset: TextOffset, startPos: number, endPos: number): string;
-declare function stringToRegExp(pattern: string | RegExp, defaultFlags?: string, forceFlags?: string): RegExp | undefined;
 declare function calculateTextDocumentOffsets<T extends TextOffset>(uri: string, doc: string, wordOffsets: T[]): (TextDocumentOffset & T)[];
 declare function removeAccents(text: string): string;
 declare const __testing__: {
@@ -345,10 +346,10 @@ declare const text_d_camelToSnake: typeof camelToSnake;
 declare const text_d_matchCase: typeof matchCase;
 declare const text_d_textOffset: typeof textOffset;
 declare const text_d_extractText: typeof extractText;
-declare const text_d_stringToRegExp: typeof stringToRegExp;
 declare const text_d_calculateTextDocumentOffsets: typeof calculateTextDocumentOffsets;
 declare const text_d_removeAccents: typeof removeAccents;
 declare const text_d___testing__: typeof __testing__;
+declare const text_d_stringToRegExp: typeof stringToRegExp;
 declare namespace text_d {
   export {
     text_d_splitCamelCaseWordWithOffset as splitCamelCaseWordWithOffset,
@@ -375,10 +376,10 @@ declare namespace text_d {
     text_d_matchCase as matchCase,
     text_d_textOffset as textOffset,
     text_d_extractText as extractText,
-    text_d_stringToRegExp as stringToRegExp,
     text_d_calculateTextDocumentOffsets as calculateTextDocumentOffsets,
     text_d_removeAccents as removeAccents,
     text_d___testing__ as __testing__,
+    text_d_stringToRegExp as stringToRegExp,
   };
 }
 

--- a/packages/cspell-lib/src/Settings/patterns.test.ts
+++ b/packages/cspell-lib/src/Settings/patterns.test.ts
@@ -29,11 +29,14 @@ describe('patterns', () => {
     const p = selectPatterns;
 
     test.each`
-        regExpList                | patternDefinitions         | expected
-        ${[]}                     | ${[]}                      | ${[]}
-        ${['string', 'hello']}    | ${p('string', 'comments')} | ${[/".*?"/gim, /hello/gim]}
-        ${['string', 'comments']} | ${patterns}                | ${[/".*?"/gim, /#.*/g, /(?:\/\*[\s\S]*?\*\/)/g]}
-        ${['a', 'b']}             | ${patterns}                | ${[/c/gim]}
+        regExpList                | patternDefinitions                         | expected
+        ${[]}                     | ${[]}                                      | ${[]}
+        ${['string', 'hello']}    | ${p('string', 'comments')}                 | ${[/".*?"/gim, /hello/gim]}
+        ${['string', 'comments']} | ${patterns}                                | ${[/".*?"/gim, /#.*/g, /(?:\/\*[\s\S]*?\*\/)/g]}
+        ${['a', 'b']}             | ${patterns}                                | ${[/c/gim]}
+        ${[' /\\b.*==/g\n']}      | ${patterns}                                | ${[/\b.*==/g]}
+        ${['pat']}                | ${[{ name: 'pat', pattern: ' /pat.*/g' }]} | ${[/pat.*/g]}
+        ${['pat\n']}              | ${[{ name: 'pat', pattern: ' /pat.*/g' }]} | ${[/pat/gim]}
     `('resolvePatterns $regExpList', ({ regExpList, patternDefinitions, expected }) => {
         expect(resolvePatterns(regExpList, patternDefinitions)).toEqual(expected);
     });

--- a/packages/cspell-lib/src/Settings/patterns.ts
+++ b/packages/cspell-lib/src/Settings/patterns.ts
@@ -1,5 +1,5 @@
 import type { Pattern, RegExpPatternDefinition } from '@cspell/cspell-types';
-import { stringToRegExp } from '../util/text';
+import { stringToRegExp } from '../util/textRegex';
 import { isDefined } from '../util/util';
 
 export function resolvePatterns(

--- a/packages/cspell-lib/src/util/text.ts
+++ b/packages/cspell-lib/src/util/text.ts
@@ -9,7 +9,6 @@ import {
     regExFirstUpper,
     regExIgnoreCharacters,
     regExLines,
-    regExMatchRegExParts,
     regExSplitWords,
     regExSplitWords2,
     regExUpperSOrIng,
@@ -17,6 +16,8 @@ import {
     regExWordsAndDigits,
 } from './textRegex';
 import { scanMap } from './util';
+
+export { stringToRegExp } from './textRegex';
 
 // CSpell:ignore ings ning gimuy tsmerge
 
@@ -178,24 +179,6 @@ interface OffsetMap {
 }
 function offsetMap(offset: number) {
     return <T extends OffsetMap>(xo: T) => ({ ...xo, offset: xo.offset + offset } as T);
-}
-
-export function stringToRegExp(pattern: string | RegExp, defaultFlags = 'gimu', forceFlags = 'g'): RegExp | undefined {
-    if (pattern instanceof RegExp) {
-        return pattern;
-    }
-    try {
-        const [, pat, flag] = [...(pattern.match(regExMatchRegExParts) || ['', pattern, defaultFlags]), forceFlags];
-        // Make sure the flags are unique.
-        const flags = [...new Set(forceFlags + flag)].join('').replace(/[^gimuy]/g, '');
-        if (pat) {
-            const regex = new RegExp(pat, flags);
-            return regex;
-        }
-    } catch (e) {
-        /* empty */
-    }
-    return undefined;
 }
 
 export function calculateTextDocumentOffsets<T extends TextOffset>(

--- a/packages/cspell-lib/src/util/textRegex.test.ts
+++ b/packages/cspell-lib/src/util/textRegex.test.ts
@@ -4,9 +4,11 @@ import {
     regExAllUpper,
     regExDanglingQuote,
     regExFirstUpper,
+    regExMatchRegExParts,
     regExSplitWords,
     regExSplitWords2,
     regExTrailingEndings,
+    stringToRegExp,
 } from './textRegex';
 
 describe('Validate textRegex', () => {
@@ -124,6 +126,37 @@ describe('Validate textRegex', () => {
     `('regExSplitWords2 on "$text"', ({ text, expected }: { text: string; expected: string[] }) => {
         const m = [...text.matchAll(regExSplitWords2)].map((m) => Array.from(m));
         expect(m).toEqual(expected);
+    });
+
+    test.each`
+        value           | expected
+        ${''}           | ${null}
+        ${'/pat/gm'}    | ${['/pat/gm', 'pat', 'gm']}
+        ${' /pat/gm\n'} | ${[' /pat/gm\n', 'pat', 'gm']}
+    `('regExMatchRegExParts "$value"', ({ value, expected }) => {
+        const r = value.match(regExMatchRegExParts);
+        expect(r ? [...r] : r).toEqual(expected);
+    });
+
+    const examplePattern = `/
+    ^                           # start of url
+    https?:\\/\\/([^?#\n]*?)    # path
+    (\\?[^#\n]*?)?              # query
+    (\\#.*?)?                   # hash
+    $                           # end of string
+    /gmx`;
+
+    test.each`
+        pattern                            | expected
+        ${''}                              | ${undefined}
+        ${'/pat/gm'}                       | ${/pat/gm}
+        ${' /pat/gm\n'}                    | ${/pat/gm}
+        ${' /\npat # the pattern\n/gmx\n'} | ${/pat/gm}
+        ${' /\npat # the pattern\n/gm\n'}  | ${/\npat # the pattern\n/gm}
+        ${examplePattern}                  | ${/^https?:\/\/([^?#\n]*?)(\?[^#\n]*?)?(#.*?)?$/gm}
+    `('stringToRegExp "$pattern"', ({ pattern, expected }) => {
+        const r = stringToRegExp(pattern);
+        expect(r).toEqual(expected);
     });
 });
 

--- a/packages/cspell-lib/src/util/textRegex.ts
+++ b/packages/cspell-lib/src/util/textRegex.ts
@@ -1,4 +1,4 @@
-// cspell:ignore ings ning gimuy anrvtbf
+// cspell:ignore ings ning gimuy anrvtbf gimuxy
 
 export const regExLines = /.*(\r?\n|$)/g;
 export const regExUpperSOrIng = /([\p{Lu}\p{M}]+\\?['’]?(?:s|ing|ies|es|ings|ed|ning))(?!\p{Ll})/gu;
@@ -11,10 +11,129 @@ export const regExFirstUpper = /^\p{Lu}\p{M}?\p{Ll}+$/u;
 export const regExAllUpper = /^(?:\p{Lu}\p{M}?)+$/u;
 export const regExAllLower = /^(?:\p{Ll}\p{M}?)+$/u;
 export const regExPossibleWordBreaks = /[-_’']/g;
-export const regExMatchRegExParts = /^\/(.*)\/([gimuy]*)$/;
+export const regExMatchRegExParts = /^\s*\/([\s\S]*?)\/([gimuxy]*)\s*$/;
 export const regExAccents = /\p{M}/gu;
 export const regExEscapeCharacters = /(?<=\\)[anrvtbf]/gi;
 /** Matches against leading `'` or `{single letter}'` */
 export const regExDanglingQuote = /(?<=(?:^|(?!\p{M})\P{L})(?:\p{L}\p{M}?)?)[']/gu;
 /** Match tailing endings after CAPS words */
 export const regExTrailingEndings = /(?<=(?:\p{Lu}\p{M}?){2})['’]?(?:s|d|ings?|ies|e[ds]?|ning|th|nth)(?!\p{Ll})/gu;
+
+export function stringToRegExp(pattern: string | RegExp, defaultFlags = 'gimu', forceFlags = 'g'): RegExp | undefined {
+    if (pattern instanceof RegExp) {
+        return pattern;
+    }
+    try {
+        const [, pat, flag] = [
+            ...(pattern.match(regExMatchRegExParts) || ['', pattern.trim(), defaultFlags]),
+            forceFlags,
+        ];
+        if (pat) {
+            const regPattern = flag.includes('x') ? removeVerboseFromRegExp(pat) : pat;
+            // Make sure the flags are unique.
+            const flags = [...new Set(forceFlags + flag)].join('').replace(/[^gimuy]/g, '');
+            const regex = new RegExp(regPattern, flags);
+            return regex;
+        }
+    } catch (e) {
+        /* empty */
+    }
+    return undefined;
+}
+
+interface ReduceResults {
+    /** current offset into the pattern */
+    idx: number;
+    /** the cleaned RegExp */
+    result: string;
+}
+
+type Reducer = (acc: ReduceResults) => ReduceResults | undefined;
+
+const SPACES: Record<string, true | undefined> = {
+    ' ': true,
+    '\n': true,
+    '\r': true,
+    '\t': true,
+};
+
+/**
+ * Remove all whitespace and comments from a regexp string. The format follows Pythons Verbose.
+ * Note: this is a best attempt. Special cases for comments: `#` and spaces should be proceeded with a `\`
+ *
+ * All space must be proceeded by a `\` or in a character class `[]`
+ *
+ * @param pattern - the pattern to clean
+ */
+function removeVerboseFromRegExp(pattern: string): string {
+    function escape(acc: ReduceResults) {
+        const char = pattern[acc.idx];
+        if (char !== '\\') return undefined;
+        const next = pattern[++acc.idx];
+        acc.idx++;
+        if (next === '#') {
+            acc.result += '#';
+            return acc;
+        }
+        if (!(next in SPACES)) {
+            acc.result += '\\' + next;
+            return acc;
+        }
+        acc.result += next;
+        if (next === '\r' && pattern[acc.idx] === '\n') {
+            acc.result += '\n';
+            acc.idx++;
+        }
+        return acc;
+    }
+
+    function braces(acc: ReduceResults) {
+        const char = pattern[acc.idx];
+        if (char !== '[') return undefined;
+        acc.result += char;
+        acc.idx++;
+        let escCount = 0;
+        while (acc.idx < pattern.length) {
+            const char = pattern[acc.idx];
+            acc.result += char;
+            acc.idx++;
+            if (char === ']' && !(escCount & 1)) break;
+            escCount = char === '\\' ? escCount + 1 : 0;
+        }
+        return acc;
+    }
+
+    function spaces(acc: ReduceResults) {
+        const char = pattern[acc.idx];
+        if (!(char in SPACES)) return undefined;
+        acc.idx++;
+        return acc;
+    }
+
+    function comments(acc: ReduceResults) {
+        const char = pattern[acc.idx];
+        if (char !== '#') return undefined;
+        while (acc.idx < pattern.length && pattern[acc.idx] !== '\n') {
+            acc.idx++;
+        }
+        return acc;
+    }
+
+    function copy(acc: ReduceResults) {
+        const char = pattern[acc.idx++];
+        acc.result += char;
+        return acc;
+    }
+
+    const reducers: Reducer[] = [escape, braces, spaces, comments, copy];
+
+    const result: ReduceResults = { idx: 0, result: '' };
+
+    while (result.idx < pattern.length) {
+        for (const r of reducers) {
+            if (r(result)) break;
+        }
+    }
+
+    return result.result;
+}

--- a/packages/cspell/samples/config/yaml-regexp/README.md
+++ b/packages/cspell/samples/config/yaml-regexp/README.md
@@ -1,0 +1,7 @@
+# Yaml example with RegExp Ignore
+
+```text
+This bit of text should be ignorrred.
+```
+
+But this is checkedd.

--- a/packages/cspell/samples/config/yaml-regexp/cspell.config.yaml
+++ b/packages/cspell/samples/config/yaml-regexp/cspell.config.yaml
@@ -1,0 +1,10 @@
+patterns:
+  - name: code_block
+    pattern: |
+      /
+          ^(\s*`{3,}).*     # match the ```
+          [\s\S]*?          # the block of code
+          ^\1               # end of the block
+      /gmx
+ignoreRegExpList:
+  - code_block

--- a/packages/cspell/src/lint/lint.test.ts
+++ b/packages/cspell/src/lint/lint.test.ts
@@ -11,6 +11,7 @@ const failFastSamples = path.resolve(samples, 'fail-fast');
 const hiddenSamples = path.resolve(samples, 'hidden-test');
 const filesToCheck = path.resolve(root, 'fixtures/features/file-list/files-to-check.txt');
 const filesToCheckWithMissing = path.resolve(root, 'fixtures/features/file-list/files-to-check-missing.txt');
+const configSamples = path.resolve(samples, 'config');
 
 const oc = expect.objectContaining;
 const j = path.join;
@@ -25,7 +26,7 @@ describe('Linter Validation Tests', () => {
         expect(rWithFiles.files).toBe(1);
     });
 
-    // cspell:ignore Tufte
+    // cspell:ignore Tufte checkedd
     test.each`
         files               | options                                                                                                | expectedRunResult              | expectedReport
         ${[]}               | ${{ root: latexSamples }}                                                                              | ${oc({ errors: 0, files: 4 })} | ${oc({ errorCount: 0, errors: [], issues: [oc({ text: 'Tufte' })] })}
@@ -51,6 +52,7 @@ describe('Linter Validation Tests', () => {
         ${['**']}           | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheckWithMissing] }}                      | ${oc({ errors: 0, files: 3 })} | ${oc({ errorCount: 0, errors: [], issues: [] })}
         ${['**']}           | ${{ root, config: j(root, 'cspell.json'), fileLists: [filesToCheckWithMissing], mustFindFiles: true }} | ${oc({ errors: 1, files: 3 })} | ${oc({ errorCount: 1, errors: [expect.anything()], issues: [] })}
         ${["'**'"]}         | ${{ root, config: j(root, 'cspell.json'), mustFindFiles: true }}                                       | ${oc({ errors: 0, files: 0 })} | ${oc({ errorCount: 1, errors: [expect.any(CheckFailed)], issues: [] })}
+        ${['**']}           | ${{ root: j(configSamples, 'yaml-regexp') }}                                                           | ${oc({ errors: 0, files: 2 })} | ${oc({ errorCount: 0, errors: [], issues: [oc({ text: 'checkedd' })] })}
     `('runLint $files $options', async ({ files, options, expectedRunResult, expectedReport }) => {
         const reporter = new InMemoryReporter();
         const runResult = await runLint(new LintRequest(files, options, reporter));


### PR DESCRIPTION
## Minor Breakage
This change might break some regexp patterns that have leading or trailing spaces and are NOT inside slashes, `/.../`.

```json
"ignoreRegExp": ["end of line\n"]
```

convert to:

```json
"ignoreRegExp": ["/end of line\n/g"]
```


## Verbose Regexp Pattern Support

Defining RegExp Patterns in `.json` or `.yaml` CSpell config files has been difficult.

This feature makes it easier to define patterns in a `.yaml` file.

CSpell now supports the `x` - verbose flag.

```regexp
/
    ^(\s*`{3,}).*     # match the ```
    [\s\S]*?          # the block of code
    ^\1               # end of the block
/gmx
```

Example of Ignoring code block in `markdown`.

**`cspell.config.yaml`**

```yaml
patterns:
  - name: markdown_code_block
    pattern: |
      /
          ^(\s*`{3,}).*     # match the ```
          [\s\S]*?          # the block of code
          ^\1               # end of the block
      /gmx
languageSettings:
  - languageId: markdown
    ignoreRegExpList:
      - markdown_code_block
```

Leading and trailing spaces are automatically trimmed from patterns, make it possible to avoid escaping in YAML by using `>`.

```yaml
ignoreRegExpList:
  - >
    /auth_token: .*/g
```
