### PR TITLE
fix: Capitalised image extensions not being ignored

### DIFF
--- a/packages/cspell-lib/src/LanguageIds.ts
+++ b/packages/cspell-lib/src/LanguageIds.ts
@@ -192,7 +192,25 @@ export const languageExtensionDefinitions: LanguageDefinitions = [
     //
     // Special file types used to prevent spell checking.
     //
-    { id: 'image', extensions: ['.jpg', '.JPG', '.png', '.PNG', '.jpeg', '.JPEG', '.tiff', '.TIFF','.bmp', '.BMP', '.gif', '.GIF', '.ico', '.ICO'] },
+    {
+        id: 'image',
+        extensions: [
+            '.jpg',
+            '.JPG',
+            '.png',
+            '.PNG',
+            '.jpeg',
+            '.JPEG',
+            '.tiff',
+            '.TIFF',
+            '.bmp',
+            '.BMP',
+            '.gif',
+            '.GIF',
+            '.ico',
+            '.ICO',
+        ],
+    },
     // cspell:ignore woff
     {
         id: 'binary',

--- a/packages/cspell-lib/src/LanguageIds.ts
+++ b/packages/cspell-lib/src/LanguageIds.ts
@@ -192,7 +192,7 @@ export const languageExtensionDefinitions: LanguageDefinitions = [
     //
     // Special file types used to prevent spell checking.
     //
-    { id: 'image', extensions: ['.jpg', '.png', '.jpeg', '.tiff', '.bmp', '.gif', '.ico'] },
+    { id: 'image', extensions: ['.jpg', '.JPG', '.png', '.PNG', '.jpeg', '.JPEG', '.tiff', '.TIFF','.bmp', '.BMP', '.gif', '.GIF', '.ico', '.ICO'] },
     // cspell:ignore woff
     {
         id: 'binary',


### PR DESCRIPTION
Added capitalised version of image extensions werent ignored, this PR fixes that, see below.

```js
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12335:65 - Unknown word (JRNB)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12341:537 - Unknown word (momh)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12341:570 - Unknown word (cۚwu)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12341:964 - Unknown word (ЍRWC)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12342:161 - Unknown word (BވKx)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12342:167 - Unknown word (qߐoo)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12349:232 - Unknown word (i͗ky)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12350:215 - Unknown word (Ȟmyy)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12350:605 - Unknown word (i'Wˤ)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12357:32 - Unknown word (YܞDd)
c:\Users\kiera\OneDrive\Projects\Discord Bots\hullcss-discord-bot\src\images\gorbcelebration.PNG:12363:409 - Unknown word (IEND)
```


This is probably also the case for the other extensions, however Im yet to test this