### PR TITLE
chore: Lock `vscode-uri` to 3.0.4

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
     "simple-git": "^3.14.0",
-    "vscode-uri": "^3.0.4"
+    "vscode-uri": "3.0.4"
   },
   "devDependencies": {
     "@cspell/cspell-bundled-dicts": "workspace:^",

--- a/packages/cspell-config-lib/package.json
+++ b/packages/cspell-config-lib/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@cspell/cspell-types": "workspace:^",
     "comment-json": "^4.2.3",
-    "vscode-uri": "^3.0.4",
+    "vscode-uri": "3.0.4",
     "yaml": "^1.10.2"
   },
   "devDependencies": {

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -67,7 +67,7 @@
     "resolve-from": "^5.0.0",
     "resolve-global": "^1.0.0",
     "vscode-languageserver-textdocument": "^1.0.7",
-    "vscode-uri": "^3.0.4"
+    "vscode-uri": "3.0.4"
   },
   "engines": {
     "node": ">=14"

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -84,7 +84,7 @@
     "imurmurhash": "^0.1.4",
     "semver": "^7.3.7",
     "strip-ansi": "^6.0.1",
-    "vscode-uri": "^3.0.4"
+    "vscode-uri": "3.0.4"
   },
   "engines": {
     "node": ">=14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
       rimraf: ^3.0.2
       shelljs: ^0.8.5
       simple-git: ^3.14.0
-      vscode-uri: ^3.0.4
+      vscode-uri: 3.0.4
     dependencies:
       '@cspell/cspell-types': link:../packages/cspell-types
       '@octokit/rest': 19.0.4
@@ -138,7 +138,7 @@ importers:
       rollup-plugin-dts: ^4.2.2
       semver: ^7.3.7
       strip-ansi: ^6.0.1
-      vscode-uri: ^3.0.4
+      vscode-uri: 3.0.4
     dependencies:
       '@cspell/cspell-pipe': link:../cspell-pipe
       chalk: 4.1.2
@@ -272,7 +272,7 @@ importers:
       comment-json: ^4.2.3
       jest: ^29.0.3
       rimraf: ^3.0.2
-      vscode-uri: ^3.0.4
+      vscode-uri: 3.0.4
       yaml: ^1.10.2
     dependencies:
       '@cspell/cspell-types': link:../cspell-types
@@ -461,7 +461,7 @@ importers:
       rollup-plugin-dts: ^4.2.2
       ts-jest: ^29.0.1
       vscode-languageserver-textdocument: ^1.0.7
-      vscode-uri: ^3.0.4
+      vscode-uri: 3.0.4
     dependencies:
       '@cspell/cspell-bundled-dicts': link:../cspell-bundled-dicts
       '@cspell/cspell-pipe': link:../cspell-pipe


### PR DESCRIPTION
To be reverted by #3608