### PR TITLE
fix: Add Development Feature Flags

### DIFF
--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -383,6 +383,34 @@ declare namespace text_d {
   };
 }
 
+interface FeatureFlag {
+    name: string;
+    description: string;
+}
+declare type FlagTypes = string | boolean;
+/**
+ * Feature Flags are used to turn on/off features.
+ * These are primarily used before a feature has been fully released.
+ */
+declare class FeatureFlags {
+    private flags;
+    private flagValues;
+    constructor(flags?: FeatureFlag[]);
+    register(flag: FeatureFlag): this;
+    register(name: string, description: string): this;
+    getFlag(flag: string): FlagTypes | undefined;
+    setFlag(flag: string, value?: FlagTypes): this;
+    getFlagInfo(flag: string): FeatureFlag | undefined;
+    getFlags(): FeatureFlag[];
+    getFlagValues(): Map<string, FlagTypes>;
+    reset(): this;
+}
+declare class UnknownFeatureFlagError extends Error {
+    readonly flag: string;
+    constructor(flag: string);
+}
+declare function getSystemFeatureFlags(): FeatureFlags;
+
 declare type LanguageId = string;
 declare function getLanguagesForExt(ext: string): string[];
 declare function getLanguagesForBasename(basename: string): string[];
@@ -935,4 +963,4 @@ declare function resolveFile(filename: string, relativeTo: string): ResolveFileR
 declare function clearCachedFiles(): Promise<void>;
 declare function getDictionary(settings: CSpellUserSettings): Promise<SpellingDictionaryCollection>;
 
-export { CheckTextInfo, ConfigurationDependencies, CreateTextDocumentParams, DetermineFinalDocumentSettingsResult, Document, DocumentValidator, DocumentValidatorOptions, ENV_CSPELL_GLOB_ROOT, ExcludeFilesGlobMap, ExclusionFunction, exclusionHelper_d as ExclusionHelper, ImportError, ImportFileRefWithError, IncludeExcludeFlag, IncludeExcludeOptions, index_link_d as Link, Logger, SpellCheckFileOptions, SpellCheckFileResult, SpellingDictionary, SpellingDictionaryCollection, SpellingDictionaryLoadError, SuggestOptions, SuggestedWord, SuggestionError, SuggestionOptions, SuggestionsForWordResult, text_d as Text, TextDocument, TextDocumentLine, TextInfoItem, TraceOptions, TraceResult, ValidationIssue, calcOverrideSettings, checkFilenameMatchesGlob, checkText, checkTextDocument, clearCachedFiles, clearCachedSettingsFiles, combineTextAndLanguageSettings, combineTextAndLanguageSettings as constructSettingsForText, createSpellingDictionary, createTextDocument, currentSettingsFileVersion, defaultConfigFilenames, defaultFileName, defaultFileName as defaultSettingsFilename, determineFinalDocumentSettings, extractDependencies, extractImportErrors, fileToDocument, fileToTextDocument, finalizeSettings, getCachedFileSize, getDefaultBundledSettings, getDefaultSettings, getDictionary, getGlobalSettings, getLanguagesForBasename as getLanguageIdsForBaseFilename, getLanguagesForExt, getLogger, getSources, isBinaryFile, isSpellingDictionaryLoadError, loadConfig, loadPnP, loadPnPSync, mergeInDocSettings, mergeSettings, readRawSettings, readSettings, readSettingsFiles, refreshDictionaryCache, resolveFile, searchForConfig, sectionCSpell, setLogger, spellCheckDocument, spellCheckFile, suggestionsForWord, suggestionsForWords, traceWords, traceWordsAsync, updateTextDocument, validateText };
+export { CheckTextInfo, ConfigurationDependencies, CreateTextDocumentParams, DetermineFinalDocumentSettingsResult, Document, DocumentValidator, DocumentValidatorOptions, ENV_CSPELL_GLOB_ROOT, ExcludeFilesGlobMap, ExclusionFunction, exclusionHelper_d as ExclusionHelper, FeatureFlags, ImportError, ImportFileRefWithError, IncludeExcludeFlag, IncludeExcludeOptions, index_link_d as Link, Logger, SpellCheckFileOptions, SpellCheckFileResult, SpellingDictionary, SpellingDictionaryCollection, SpellingDictionaryLoadError, SuggestOptions, SuggestedWord, SuggestionError, SuggestionOptions, SuggestionsForWordResult, text_d as Text, TextDocument, TextDocumentLine, TextInfoItem, TraceOptions, TraceResult, UnknownFeatureFlagError, ValidationIssue, calcOverrideSettings, checkFilenameMatchesGlob, checkText, checkTextDocument, clearCachedFiles, clearCachedSettingsFiles, combineTextAndLanguageSettings, combineTextAndLanguageSettings as constructSettingsForText, createSpellingDictionary, createTextDocument, currentSettingsFileVersion, defaultConfigFilenames, defaultFileName, defaultFileName as defaultSettingsFilename, determineFinalDocumentSettings, extractDependencies, extractImportErrors, fileToDocument, fileToTextDocument, finalizeSettings, getCachedFileSize, getDefaultBundledSettings, getDefaultSettings, getDictionary, getGlobalSettings, getLanguagesForBasename as getLanguageIdsForBaseFilename, getLanguagesForExt, getLogger, getSources, getSystemFeatureFlags, isBinaryFile, isSpellingDictionaryLoadError, loadConfig, loadPnP, loadPnPSync, mergeInDocSettings, mergeSettings, readRawSettings, readSettings, readSettingsFiles, refreshDictionaryCache, resolveFile, searchForConfig, sectionCSpell, setLogger, spellCheckDocument, spellCheckFile, suggestionsForWord, suggestionsForWords, traceWords, traceWordsAsync, updateTextDocument, validateText };

--- a/packages/cspell-lib/src/FeatureFlags/FeatureFalgs.test.ts
+++ b/packages/cspell-lib/src/FeatureFlags/FeatureFalgs.test.ts
@@ -1,0 +1,53 @@
+import { FeatureFlags, FeatureFlag, getSystemFeatureFlags } from './FeatureFlags';
+
+describe('FeatureFlags', () => {
+    const flags: FeatureFlag[] = [
+        { name: 'test', description: 'Enable Testing' },
+        { name: 'perf', description: 'Enable Performance Reporting' },
+    ];
+
+    test('reset', () => {
+        const ff = new FeatureFlags(flags);
+        ff.setFlag('test');
+        expect(ff.getFlag('test')).toBe(true);
+        expect(ff.getFlags()).toEqual(flags);
+        ff.reset();
+        expect(ff.getFlag('test')).toBe(undefined);
+    });
+
+    test('register', () => {
+        const flagWeb = { name: 'web', description: 'Use Web Dictionaries' };
+        const ff = new FeatureFlags(flags);
+        expect(ff.getFlags()).toEqual(flags);
+        ff.register('json', 'Use JSON reporting').register(flagWeb);
+        expect(ff.getFlags()).not.toEqual(flags);
+        expect(ff.getFlagInfo('json')).toEqual({ name: 'json', description: 'Use JSON reporting' });
+        expect(ff.getFlagInfo(flagWeb.name)).toBe(flagWeb);
+    });
+
+    test.each`
+        flag      | value        | expected
+        ${'test'} | ${false}     | ${false}
+        ${'test'} | ${undefined} | ${true}
+    `('get/set $flag/$value', ({ flag, value, expected }) => {
+        const ff = new FeatureFlags(flags);
+        ff.setFlag(flag, value);
+        expect(ff.getFlag(flag)).toBe(expected);
+        expect(ff.getFlagValues()).toEqual(new Map([[flag, expected]]));
+    });
+
+    test.each`
+        flag       | value
+        ${'test1'} | ${false}
+        ${'test2'} | ${undefined}
+    `('UnknownFeatureFlagError $flag/$value', ({ flag, value }) => {
+        const ff = new FeatureFlags(flags);
+        expect(() => ff.setFlag(flag, value)).toThrow(`Unknown feature flag: ${flag}`);
+    });
+
+    test('getSystemFeatureFlags', () => {
+        const ff = getSystemFeatureFlags();
+        expect(ff).toBeInstanceOf(FeatureFlags);
+        expect(getSystemFeatureFlags()).toBe(ff);
+    });
+});

--- a/packages/cspell-lib/src/FeatureFlags/FeatureFlags.ts
+++ b/packages/cspell-lib/src/FeatureFlags/FeatureFlags.ts
@@ -1,0 +1,71 @@
+export interface FeatureFlag {
+    name: string;
+    description: string;
+}
+
+let systemFeatureFlags: FeatureFlags | undefined;
+
+type FlagTypes = string | boolean;
+
+/**
+ * Feature Flags are used to turn on/off features.
+ * These are primarily used before a feature has been fully released.
+ */
+export class FeatureFlags {
+    private flags: Map<string, FeatureFlag>;
+    private flagValues = new Map<string, FlagTypes>();
+
+    constructor(flags: FeatureFlag[] = []) {
+        this.flags = new Map(flags.map((f) => [f.name, f]));
+    }
+
+    register(flag: FeatureFlag): this;
+    register(name: string, description: string): this;
+    register(flagOrName: string | FeatureFlag, description?: string): this {
+        if (typeof flagOrName === 'string') {
+            return this.register({ name: flagOrName, description: description || '' });
+        }
+        this.flags.set(flagOrName.name, flagOrName);
+        return this;
+    }
+
+    getFlag(flag: string): FlagTypes | undefined {
+        return this.flagValues.get(flag);
+    }
+
+    setFlag(flag: string, value: FlagTypes = true): this {
+        if (!this.flags.has(flag)) {
+            throw new UnknownFeatureFlagError(flag);
+        }
+
+        this.flagValues.set(flag, value);
+        return this;
+    }
+
+    getFlagInfo(flag: string): FeatureFlag | undefined {
+        return this.flags.get(flag);
+    }
+
+    getFlags(): FeatureFlag[] {
+        return [...this.flags.values()];
+    }
+
+    getFlagValues(): Map<string, FlagTypes> {
+        return new Map(this.flagValues);
+    }
+
+    reset(): this {
+        this.flagValues.clear();
+        return this;
+    }
+}
+
+export class UnknownFeatureFlagError extends Error {
+    constructor(readonly flag: string) {
+        super(`Unknown feature flag: ${flag}`);
+    }
+}
+
+export function getSystemFeatureFlags(): FeatureFlags {
+    return systemFeatureFlags || (systemFeatureFlags = new FeatureFlags());
+}

--- a/packages/cspell-lib/src/FeatureFlags/index.ts
+++ b/packages/cspell-lib/src/FeatureFlags/index.ts
@@ -1,0 +1,1 @@
+export { getSystemFeatureFlags, FeatureFlags, UnknownFeatureFlagError } from './FeatureFlags';

--- a/packages/cspell-lib/src/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-lib/src/__snapshots__/index.test.ts.snap
@@ -66,6 +66,7 @@ exports[`Validate the cspell API Verify API exports 1`] = `
     "generateExclusionFunctionForFiles": [Function],
     "generateExclusionFunctionForUri": [Function],
   },
+  "FeatureFlags": [Function],
   "ImportError": [Function],
   "IncludeExcludeFlag": {
     "EXCLUDE": "E",
@@ -123,6 +124,7 @@ exports[`Validate the cspell API Verify API exports 1`] = `
     "textOffset": [Function],
     "ucFirst": [Function],
   },
+  "UnknownFeatureFlagError": [Function],
   "asyncIterableToArray": [Function],
   "calcOverrideSettings": [Function],
   "checkFilenameMatchesGlob": [Function],
@@ -172,6 +174,7 @@ exports[`Validate the cspell API Verify API exports 1`] = `
   "getLanguagesForExt": [Function],
   "getLogger": [Function],
   "getSources": [Function],
+  "getSystemFeatureFlags": [Function],
   "isBinaryFile": [Function],
   "isSpellingDictionaryLoadError": [Function],
   "loadConfig": [Function],

--- a/packages/cspell-lib/src/index.ts
+++ b/packages/cspell-lib/src/index.ts
@@ -16,7 +16,8 @@ export {
     writeToFileIterableP,
 } from 'cspell-io';
 export { ExcludeFilesGlobMap, ExclusionFunction } from './exclusionHelper';
-export { getLanguagesForExt, getLanguagesForBasename as getLanguageIdsForBaseFilename } from './LanguageIds';
+export { FeatureFlags, getSystemFeatureFlags, UnknownFeatureFlagError } from './FeatureFlags';
+export { getLanguagesForBasename as getLanguageIdsForBaseFilename, getLanguagesForExt } from './LanguageIds';
 export { createTextDocument, updateTextDocument } from './Models/TextDocument';
 export type { CreateTextDocumentParams, TextDocument, TextDocumentLine } from './Models/TextDocument';
 export * from './Settings';

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -59,9 +59,9 @@ exports[`Validate cli app --help Expect Error: outputHelp 1`] = `
   "  check [options] <files...>            Spell check file(s) and display the",
   "                                        result. The full file is displayed in",
   "                                        color.",
+  "  suggestions|sug [options] [words...]  Spelling Suggestions for words.",
   "  link                                  Link dictionaries and other settings to",
   "                                        the cspell global config.",
-  "  suggestions|sug [options] [words...]  Spelling Suggestions for words.",
   "  help [command]                        display help for command",
   "",
 ]

--- a/packages/cspell/src/app.ts
+++ b/packages/cspell/src/app.ts
@@ -1,5 +1,4 @@
-import type { Command } from 'commander';
-import { program } from 'commander';
+import { Command, Option as CommanderOption, program } from 'commander';
 import { satisfies as semverSatisfies } from 'semver';
 import { commandCheck } from './commandCheck';
 import { commandLink } from './commandLink';
@@ -27,11 +26,15 @@ export async function run(command?: Command, argv?: string[]): Promise<void> {
         );
     }
 
-    commandLint(prog);
-    commandTrace(prog);
-    commandCheck(prog);
+    const optionFlags = new CommanderOption('-f,--flag <flag:value>', 'Declare an execution flag value')
+        .hideHelp()
+        .argParser((value: string, prev: undefined | string[]) => prev?.concat(value) || [value]);
+
+    commandLint(prog).addOption(optionFlags);
+    commandTrace(prog).addOption(optionFlags);
+    commandCheck(prog).addOption(optionFlags);
+    commandSuggestion(prog).addOption(optionFlags);
     commandLink(prog);
-    commandSuggestion(prog);
 
     /*
         program
@@ -48,6 +51,7 @@ export async function run(command?: Command, argv?: string[]): Promise<void> {
                 console.log('Init');
             });
     */
+
     prog.exitOverride();
     await prog.parseAsync(args);
 }

--- a/packages/cspell/src/commandCheck.ts
+++ b/packages/cspell/src/commandCheck.ts
@@ -4,6 +4,7 @@ import { checkText } from './application';
 import { BaseOptions } from './options';
 import { CheckFailed } from './util/errors';
 import chalk = require('chalk');
+import { parseFeatureFlags } from './featureFlags';
 
 export function commandCheck(prog: Command): Command {
     type CheckCommandOptions = BaseOptions;
@@ -29,6 +30,7 @@ export function commandCheck(prog: Command): Command {
             new CommanderOption('--no-default-configuration', 'Do not load the default configuration and dictionaries.')
         )
         .action(async (files: string[], options: CheckCommandOptions) => {
+            parseFeatureFlags(options.flag);
             let issueCount = 0;
             for (const filename of files) {
                 console.log(chalk.yellowBright(`Check file: ${filename}`));

--- a/packages/cspell/src/commandLint.ts
+++ b/packages/cspell/src/commandLint.ts
@@ -1,5 +1,6 @@
 import { Command, Option as CommanderOption } from 'commander';
 import * as App from './application';
+import { parseFeatureFlags } from './featureFlags';
 import { LinterCliOptions } from './options';
 import { DEFAULT_CACHE_LOCATION } from './util/cache';
 import { CheckFailed } from './util/errors';
@@ -112,6 +113,7 @@ export function commandLint(prog: Command): Command {
         .addHelpText('after', usage)
         .arguments('[globs...]')
         .action((fileGlobs: string[], options: LinterCliOptions) => {
+            parseFeatureFlags(options.flag);
             const { mustFindFiles, fileList } = options;
             return App.lint(fileGlobs, options).then((result) => {
                 if (!fileGlobs.length && !result.files && !result.errors && !fileList) {

--- a/packages/cspell/src/commandSuggestion.ts
+++ b/packages/cspell/src/commandSuggestion.ts
@@ -1,6 +1,7 @@
 import { Command, Option as CommanderOption } from 'commander';
 import * as App from './application';
 import { emitSuggestionResult } from './emitters/suggestionsEmitter';
+import { parseFeatureFlags } from './featureFlags';
 import { SuggestionOptions } from './options';
 import { CheckFailed } from './util/errors';
 
@@ -74,6 +75,7 @@ export function commandSuggestion(prog: Command): Command {
         .option('--color', 'Force color')
         .arguments('[words...]')
         .action(async (words: string[], options: SuggestionCommandOptions) => {
+            parseFeatureFlags(options.flag);
             options.useStdin = options.stdin;
             options.dictionaries = mergeArrays(options.dictionaries, options.dictionary);
 

--- a/packages/cspell/src/commandTrace.ts
+++ b/packages/cspell/src/commandTrace.ts
@@ -3,6 +3,7 @@ import * as App from './application';
 import { TraceOptions } from './options';
 import { emitTraceResults } from './emitters/traceEmitter';
 import { CheckFailed } from './util/errors';
+import { parseFeatureFlags } from './featureFlags';
 
 // interface InitOptions extends Options {}
 
@@ -42,6 +43,7 @@ export function commandTrace(prog: Command): Command {
         )
         .arguments('[words...]')
         .action(async (words: string[], options: TraceCommandOptions) => {
+            parseFeatureFlags(options.flag);
             let numFound = 0;
             for await (const results of App.trace(words, options)) {
                 emitTraceResults(results, { cwd: process.cwd() });

--- a/packages/cspell/src/featureFlags/featureFlags.test.ts
+++ b/packages/cspell/src/featureFlags/featureFlags.test.ts
@@ -1,0 +1,20 @@
+import { getFeatureFlags, parseFeatureFlags } from './featureFlags';
+
+describe('featureFlags', () => {
+    test('Unknown flag', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation();
+        parseFeatureFlags(['unknown-flag']);
+        expect(warn).toHaveBeenCalledWith('Unknown flag: "unknown-flag"');
+    });
+
+    test.each`
+        flag      | value           | expected
+        ${'test'} | ${'test'}       | ${true}
+        ${'test'} | ${'test:value'} | ${'value'}
+    `('set flags $value', ({ flag, value, expected }) => {
+        const ff = getFeatureFlags();
+        ff.register(flag, flag);
+        parseFeatureFlags([value]);
+        expect(ff.getFlag(flag)).toBe(expected);
+    });
+});

--- a/packages/cspell/src/featureFlags/featureFlags.ts
+++ b/packages/cspell/src/featureFlags/featureFlags.ts
@@ -1,0 +1,24 @@
+import { FeatureFlags, getSystemFeatureFlags } from 'cspell-lib';
+
+export function getFeatureFlags(): FeatureFlags {
+    return getSystemFeatureFlags();
+}
+
+export function parseFeatureFlags(flags: string[] | undefined): FeatureFlags {
+    const ff = getFeatureFlags();
+
+    if (!flags) return ff;
+
+    const flagsKvP = flags.map((f) => f.split(':', 2));
+
+    for (const flag of flagsKvP) {
+        const [name, value] = flag;
+        try {
+            ff.setFlag(name, value);
+        } catch (e) {
+            console.warn(`Unknown flag: "${name}"`);
+        }
+    }
+
+    return ff;
+}

--- a/packages/cspell/src/featureFlags/index.ts
+++ b/packages/cspell/src/featureFlags/index.ts
@@ -1,0 +1,1 @@
+export { getFeatureFlags, parseFeatureFlags } from './featureFlags';

--- a/packages/cspell/src/options.ts
+++ b/packages/cspell/src/options.ts
@@ -145,6 +145,13 @@ export interface BaseOptions {
      * Check In-Document CSpell directives for correctness.
      */
     validateDirectives?: boolean;
+
+    /**
+     * Execution flags.
+     * Used primarily for releasing experimental features.
+     * Flags are of the form key:value
+     */
+    flag?: string[];
 }
 
 export interface LinterCliOptions extends LinterOptions {


### PR DESCRIPTION
Feature flags are used to hide new Features and Behaviors until they are ready for release.