### PR TITLE
feat: cspell-tools - support build command

### DIFF
--- a/packages/cspell-tools/cspell-tools.config.schema.json
+++ b/packages/cspell-tools/cspell-tools.config.schema.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "DictionaryFormats": {
+      "enum": [
+        "plaintext",
+        "trie",
+        "trie3",
+        "trie4"
+      ],
+      "type": "string"
+    },
+    "DictionarySource": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FilePath"
+        },
+        {
+          "$ref": "#/definitions/FileSource"
+        },
+        {
+          "$ref": "#/definitions/FileListSource"
+        }
+      ]
+    },
+    "FileListSource": {
+      "additionalProperties": false,
+      "properties": {
+        "keepRawCase": {
+          "default": false,
+          "description": "Do not generate lower case / accent free versions of words.",
+          "type": "boolean"
+        },
+        "listFile": {
+          "$ref": "#/definitions/FilePath"
+        },
+        "maxDepth": {
+          "description": "Maximum number of nested Hunspell Rules to apply. This is needed for recursive dictionaries like Hebrew.",
+          "type": "number"
+        },
+        "split": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "const": "legacy",
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Split lines into words."
+        }
+      },
+      "required": [
+        "listFile"
+      ],
+      "type": "object"
+    },
+    "FilePath": {
+      "description": "Note: All relative paths are relative to the config file location.",
+      "type": "string"
+    },
+    "FileSource": {
+      "additionalProperties": false,
+      "properties": {
+        "filename": {
+          "$ref": "#/definitions/FilePath"
+        },
+        "keepRawCase": {
+          "default": false,
+          "description": "Do not generate lower case / accent free versions of words.",
+          "type": "boolean"
+        },
+        "maxDepth": {
+          "description": "Maximum number of nested Hunspell Rules to apply. This is needed for recursive dictionaries like Hebrew.",
+          "type": "number"
+        },
+        "split": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "const": "legacy",
+              "type": "string"
+            }
+          ],
+          "default": false,
+          "description": "Split lines into words."
+        }
+      },
+      "required": [
+        "filename"
+      ],
+      "type": "object"
+    },
+    "Target": {
+      "additionalProperties": false,
+      "properties": {
+        "compress": {
+          "default": ": false",
+          "description": "gzip the file?",
+          "type": "boolean"
+        },
+        "excludeWordsFrom": {
+          "description": "Words from the sources that are found in `excludeWordsFrom` files will not be added to the dictionary.",
+          "items": {
+            "$ref": "#/definitions/FilePath"
+          },
+          "type": "array"
+        },
+        "filename": {
+          "$ref": "#/definitions/FilePath",
+          "description": "The target filename"
+        },
+        "format": {
+          "$ref": "#/definitions/DictionaryFormats",
+          "description": "Format of the dictionary."
+        },
+        "sort": {
+          "default": ": true",
+          "description": "Sort the words in the resulting dictionary. Does not apply to `trie` based formats.",
+          "type": "boolean"
+        },
+        "sources": {
+          "description": "File sources used to build the dictionary.",
+          "items": {
+            "$ref": "#/definitions/DictionarySource"
+          },
+          "type": "array"
+        },
+        "trieBase": {
+          "description": "Advanced: Set the trie base number. A value between 10 and 36 Set numeric base to use. 10 is the easiest to read. 16 is common hex format. 36 is the most compact.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "filename",
+        "compress",
+        "format",
+        "sources"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "experimental": {
+      "description": "Experimental flags",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "keepRawCase": {
+      "default": false,
+      "description": "Do not generate lower case / accent free versions of words.",
+      "type": "boolean"
+    },
+    "maxDepth": {
+      "description": "Maximum number of nested Hunspell Rules to apply. This is needed for recursive dictionaries like Hebrew.",
+      "type": "number"
+    },
+    "split": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "const": "legacy",
+          "type": "string"
+        }
+      ],
+      "default": false,
+      "description": "Split lines into words."
+    },
+    "targets": {
+      "description": "Optional Target Dictionaries to create.",
+      "items": {
+        "$ref": "#/definitions/Target"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/packages/cspell-tools/package.json
+++ b/packages/cspell-tools/package.json
@@ -10,8 +10,10 @@
     "cspell-tools-cli": "bin.js"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "pnpm run build-schema && pnpm run compile",
     "build-dev": "tsc -p tsconfig.dev.json",
+    "build-schema": "ts-json-schema-generator --no-top-ref --path src/config/index.ts --type RunConfig --validation-keywords deprecated  -o  ./cspell-tools.config.schema.json",
+    "compile": "tsc -p .",
     "watch": "tsc -p . -w",
     "clean-build": "pnpm run clean && pnpm run build",
     "clean": "rimraf dist temp coverage .tsbuildinfo",
@@ -67,7 +69,8 @@
     "jest": "^29.1.2",
     "lorem-ipsum": "^2.0.8",
     "rimraf": "^3.0.2",
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.8.5",
+    "ts-json-schema-generator": "^1.1.2"
   },
   "main": "bin.js"
 }

--- a/packages/cspell-tools/src/app.test.ts
+++ b/packages/cspell-tools/src/app.test.ts
@@ -115,7 +115,8 @@ describe('Validate the application', () => {
     test('app compile merge legacy', async () => {
         const commander = getCommander();
         const targetDir = relPathTemp;
-        const target = 'merge.txt';
+        const name = 'merge';
+        const target = name + '.txt';
         const pathSamples = path.join(projectRoot, '..', 'Samples', 'dicts');
         const cities = path.join(pathSamples, 'cities.txt');
         const exampleHunspell = path.join(pathSamples, 'hunspell', 'example.dic');
@@ -124,7 +125,7 @@ describe('Validate the application', () => {
             '-n',
             '--use-legacy-splitter',
             '-M',
-            target,
+            name,
             cities,
             exampleHunspell,
             '-o',
@@ -138,11 +139,12 @@ describe('Validate the application', () => {
     test('app compile merge', async () => {
         const commander = getCommander();
         const targetDir = relPathTemp;
-        const target = 'merge.txt';
+        const name = 'merge';
+        const target = name + '.txt';
         const pathSamples = path.join(projectRoot, '..', 'Samples', 'dicts');
         const cities = path.join(pathSamples, 'cities.txt');
         const exampleHunspell = path.join(pathSamples, 'hunspell', 'example.dic');
-        const args = argv('compile', '-n', '--split', '-M', target, cities, exampleHunspell, '-o', targetDir);
+        const args = argv('compile', '-n', '--split', '-M', name, cities, exampleHunspell, '-o', targetDir);
         await expect(app.run(commander, args)).resolves.toBeUndefined();
         const words = await fs.readFile(path.join(targetDir, target), 'utf8');
         expect(words).toMatchSnapshot();
@@ -151,11 +153,12 @@ describe('Validate the application', () => {
     test('app compile merge with defaults', async () => {
         const commander = getCommander();
         const targetDir = relPathTemp;
-        const target = 'merge.txt';
+        const name = 'merge';
+        const target = name + '.txt';
         const pathSamples = path.join(projectRoot, '..', 'Samples', 'dicts');
         const cities = path.join(pathSamples, 'cities.txt');
         const exampleHunspell = path.join(pathSamples, 'hunspell', 'example.dic');
-        const args = argv('compile', '-n', '-M', target, cities, exampleHunspell, '-o', targetDir);
+        const args = argv('compile', '-n', '-M', name, cities, exampleHunspell, '-o', targetDir);
         await expect(app.run(commander, args)).resolves.toBeUndefined();
         const words = await fs.readFile(path.join(targetDir, target), 'utf8');
         expect(words).toMatchSnapshot();
@@ -164,11 +167,12 @@ describe('Validate the application', () => {
     test('app compile merge with defaults --keep-raw-case', async () => {
         const commander = getCommander();
         const targetDir = relPathTemp;
-        const target = 'merge.txt';
+        const name = 'merge';
+        const target = name + '.txt';
         const pathSamples = path.join(projectRoot, '..', 'Samples', 'dicts');
         const cities = path.join(pathSamples, 'cities.txt');
         const exampleHunspell = path.join(pathSamples, 'hunspell', 'example.dic');
-        const args = argv('compile', '--keep-raw-case', '-n', '-M', target, cities, exampleHunspell, '-o', targetDir);
+        const args = argv('compile', '--keep-raw-case', '-n', '-M', name, cities, exampleHunspell, '-o', targetDir);
         await expect(app.run(commander, args)).resolves.toBeUndefined();
         const words = await fs.readFile(path.join(targetDir, target), 'utf8');
         expect(words).toMatchSnapshot();

--- a/packages/cspell-tools/src/app.ts
+++ b/packages/cspell-tools/src/app.ts
@@ -5,8 +5,9 @@ import * as path from 'path';
 import type { CompileAppOptions, CompileTrieAppOptions } from './AppOptions';
 import * as compiler from './compiler';
 import { logWithTimestamp } from './compiler/logWithTimestamp';
-import { processCompileAction } from './compiler/processCompileAction';
+import { processCompileAction } from './compile';
 import { FeatureFlags } from './FeatureFlags';
+import { build } from './build';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const npmPackage = require(path.join(__dirname, '..', 'package.json'));
@@ -63,8 +64,11 @@ export async function run(program: program.Command, argv: string[], flags?: Feat
         return processCompileAction(src, { ...options, trie: true }, flags);
     });
 
+    program
+        .command('build [targets]')
+        .description('Build the targets defined in the run configuration.')
+        .option('-c, --config <path to run configuration>', 'Specify the run configuration file.')
+        .action(build);
+
     await program.parseAsync(argv);
-    // if (!argv.slice(2).length) {
-    //     program.help();
-    // }
 }

--- a/packages/cspell-tools/src/build.ts
+++ b/packages/cspell-tools/src/build.ts
@@ -1,0 +1,8 @@
+export interface BuildOptions {
+    /** Optional path to config file */
+    config?: string;
+}
+
+export async function build(targets: string[] | undefined, options: BuildOptions) {
+    console.log('build targets: %o, options: %o', targets, options);
+}

--- a/packages/cspell-tools/src/compile.ts
+++ b/packages/cspell-tools/src/compile.ts
@@ -1,9 +1,9 @@
 import { opConcatMap, pipe } from '@cspell/cspell-pipe/sync';
-import { CompileCommonAppOptions } from '../AppOptions';
-import { FeatureFlags, getSystemFeatureFlags, parseFlags } from '../FeatureFlags';
-import { compile } from './compile';
-import { createCompileRequest } from './createCompileRequest';
-import { globP } from './globP';
+import { CompileCommonAppOptions } from './AppOptions';
+import { FeatureFlags, getSystemFeatureFlags, parseFlags } from './FeatureFlags';
+import { compile } from './compiler/compile';
+import { createCompileRequest } from './compiler/createCompileRequest';
+import { globP } from './compiler/globP';
 
 getSystemFeatureFlags().register('compound', 'Enable compound dictionary sources.');
 

--- a/packages/cspell-tools/src/compiler/__snapshots__/createCompileRequest.test.ts.snap
+++ b/packages/cspell-tools/src/compiler/__snapshots__/createCompileRequest.test.ts.snap
@@ -13,11 +13,12 @@ exports[`createCompileRequest createCompileRequest 2`] = `
   "targets": [
     {
       "compress": false,
-      "filename": "words.txt",
       "format": "plaintext",
+      "name": "words",
       "sources": [
         "src/words.txt",
       ],
+      "targetDirectory": ".",
     },
   ],
 }
@@ -29,19 +30,21 @@ exports[`createCompileRequest createCompileRequest 3`] = `
   "targets": [
     {
       "compress": false,
-      "filename": "out/words.txt",
       "format": "plaintext",
+      "name": "words",
       "sources": [
         "src/words.txt",
       ],
+      "targetDirectory": "out",
     },
     {
       "compress": false,
-      "filename": "out/cities.txt",
       "format": "plaintext",
+      "name": "cities",
       "sources": [
         "src/cities.txt",
       ],
+      "targetDirectory": "out",
     },
   ],
 }
@@ -53,12 +56,13 @@ exports[`createCompileRequest createCompileRequest 4`] = `
   "targets": [
     {
       "compress": false,
-      "filename": "out/combo.txt",
       "format": "plaintext",
+      "name": "combo",
       "sources": [
         "src/words.txt",
         "src/cities.txt",
       ],
+      "targetDirectory": "out",
     },
   ],
 }

--- a/packages/cspell-tools/src/compiler/compile.test.ts
+++ b/packages/cspell-tools/src/compiler/compile.test.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { spyOnConsole } from '../test/console';
 import { createTestHelper } from '../test/TestHelper';
 import { compile } from './compile';
-import { CompileRequest, Target } from './config';
+import { CompileRequest, Target } from '../config';
 import { readTextFile } from './readTextFile';
 
 const testHelper = createTestHelper(__filename);

--- a/packages/cspell-tools/src/compiler/compile.test.ts
+++ b/packages/cspell-tools/src/compiler/compile.test.ts
@@ -30,7 +30,8 @@ describe('compile', () => {
         ${'plaintext'} | ${true}
     `('compile', async ({ format, compress }) => {
         const target: Target = {
-            filename: 'myDictionary',
+            name: 'myDictionary',
+            targetDirectory: '.',
             format,
             sources: [sample('cities.txt')],
             compress,

--- a/packages/cspell-tools/src/compiler/compile.ts
+++ b/packages/cspell-tools/src/compiler/compile.ts
@@ -3,17 +3,8 @@ import { opAwaitAsync, opMapAsync } from '@cspell/cspell-pipe/operators';
 import { opConcatMap, opMap, pipe } from '@cspell/cspell-pipe/sync';
 import * as path from 'path';
 import { getSystemFeatureFlags } from '../FeatureFlags';
-import {
-    CompileRequest,
-    CompileTargetOptions,
-    DictionarySource,
-    FilePath,
-    FileSource,
-    isFileListSource,
-    isFilePath,
-    isFileSource,
-    Target,
-} from './config';
+import { CompileRequest, CompileTargetOptions, DictionarySource, FilePath, FileSource, Target } from '../config';
+import { isFileListSource, isFilePath, isFileSource } from './configUtils';
 import { streamWordsFromFile } from './iterateWordsFromFile';
 import { logWithTimestamp } from './logWithTimestamp';
 import { ReaderOptions } from './Reader';

--- a/packages/cspell-tools/src/compiler/compile.ts
+++ b/packages/cspell-tools/src/compiler/compile.ts
@@ -23,7 +23,7 @@ export async function compile(request: CompileRequest): Promise<void> {
 }
 
 export async function compileTarget(target: Target, options: CompileTargetOptions): Promise<void> {
-    logWithTimestamp(`Start compile: ${target.filename}`);
+    logWithTimestamp(`Start compile: ${target.name}`);
 
     const { format, sources, trieBase, sort = true } = target;
     const { keepRawCase = false, maxDepth, split = false } = options;
@@ -31,7 +31,7 @@ export async function compileTarget(target: Target, options: CompileTargetOption
     const splitWords = legacy ? false : split;
 
     const useTrie = format.startsWith('trie');
-    const filename = resolveTarget(target.filename, useTrie, target.compress);
+    const filename = resolveTarget(target.name, target.targetDirectory, useTrie, target.compress);
     const experimental = new Set(options.experimental);
     const useAnnotation = (useTrie && format >= 'trie3') || experimental.has('compound');
     const skipNormalization = useAnnotation;
@@ -69,7 +69,7 @@ export async function compileTarget(target: Target, options: CompileTargetOption
 
     await processFiles(action, filesToProcess, filename);
 
-    logWithTimestamp(`Done compile: ${target.filename}`);
+    logWithTimestamp(`Done compile: ${target.name}`);
 }
 
 async function processFiles(action: ActionFn, filesToProcess: FileToProcess[], mergeTarget: string) {
@@ -98,10 +98,10 @@ interface FileToProcess {
 
 type ActionFn = (words: Iterable<string>, dst: string) => Promise<void>;
 
-function resolveTarget(filename: string, useTrie: boolean, useGzCompress: boolean | boolean): string {
+function resolveTarget(name: string, directory: string, useTrie: boolean, useGzCompress: boolean | boolean): string {
     const ext = ((useTrie && '.trie') || '.txt') + ((useGzCompress && '.gz') || '');
-    filename = filename.replace(/((\.txt|\.dic|\.aff|\.trie)(\.gz)?)?$/, '') + ext;
-    return path.resolve(filename);
+    const filename = name + ext;
+    return path.resolve(directory, filename);
 }
 
 function readSourceList(sources: DictionarySource[]): AsyncIterable<FileSource> {

--- a/packages/cspell-tools/src/compiler/configUtils.test.ts
+++ b/packages/cspell-tools/src/compiler/configUtils.test.ts
@@ -1,4 +1,4 @@
-import { isFileListSource, isFilePath, isFileSource } from './config';
+import { isFileListSource, isFilePath, isFileSource } from './configUtils';
 
 describe('config', () => {
     test.each`

--- a/packages/cspell-tools/src/compiler/configUtils.ts
+++ b/packages/cspell-tools/src/compiler/configUtils.ts
@@ -1,0 +1,15 @@
+import { DictionarySource, FilePath, FileSource, FileListSource } from '../config';
+
+export function isFilePath(source: DictionarySource): source is FilePath {
+    return typeof source === 'string';
+}
+
+export function isFileSource(source: DictionarySource): source is FileSource {
+    if (!source || isFilePath(source)) return false;
+    return (<FileSource>source).filename !== undefined;
+}
+
+export function isFileListSource(source: DictionarySource): source is FileListSource {
+    if (!source || isFilePath(source)) return false;
+    return (<FileListSource>source).listFile !== undefined;
+}

--- a/packages/cspell-tools/src/compiler/createCompileRequest.ts
+++ b/packages/cspell-tools/src/compiler/createCompileRequest.ts
@@ -25,14 +25,11 @@ function calcTargets(sources: string[], options: CompileCommonAppOptions): Targe
     const { merge, output = '.' } = options;
 
     const format = calcFormat(options);
-    const useTrie = format.startsWith('trie');
-    const fileExt = useTrie ? '.trie' : '.txt';
 
     if (merge) {
-        const targetFilename = toTargetFilename(merge, fileExt);
-        const filename = path.join(output, targetFilename);
         const target: Target = {
-            filename,
+            name: merge,
+            targetDirectory: output,
             compress: options.compress,
             format,
             sources,
@@ -43,10 +40,10 @@ function calcTargets(sources: string[], options: CompileCommonAppOptions): Targe
     }
 
     const targets: Target[] = sources.map((source) => {
-        const targetFilename = toTargetFilename(path.basename(source), fileExt);
-        const filename = path.join(output, targetFilename);
+        const name = toTargetName(path.basename(source));
         const target: Target = {
-            filename,
+            name,
+            targetDirectory: output,
             compress: options.compress,
             format,
             sources: [source],
@@ -62,8 +59,8 @@ function calcFormat(options: CompileCommonAppOptions): DictionaryFormats {
     return (options.trie4 && 'trie4') || (options.trie3 && 'trie3') || (options.trie && 'trie') || 'plaintext';
 }
 
-function toTargetFilename(name: string, ext: string) {
-    return name.replace(/((\.txt|\.dic|\.aff|\.trie)(\.gz)?)?$/, '') + ext;
+function toTargetName(sourceFile: string) {
+    return path.basename(sourceFile).replace(/((\.txt|\.dic|\.aff|\.trie)(\.gz)?)?$/, '');
 }
 
 function parseNumber(s: string | undefined): number | undefined {

--- a/packages/cspell-tools/src/compiler/createCompileRequest.ts
+++ b/packages/cspell-tools/src/compiler/createCompileRequest.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { CompileCommonAppOptions } from '../AppOptions';
-import { CompileRequest, DictionaryFormats, Target } from './config';
+import { CompileRequest, DictionaryFormats, Target } from '../config';
 
 export function createCompileRequest(sources: string[], options: CompileCommonAppOptions): CompileRequest {
     const { max_depth, maxDepth, experimental, split, keepRawCase, useLegacySplitter } = options;

--- a/packages/cspell-tools/src/compiler/index.ts
+++ b/packages/cspell-tools/src/compiler/index.ts
@@ -1,4 +1,4 @@
 export { compileWordList, compileTrie } from './wordListCompiler';
 export { type Logger, setLogger } from './logger';
 export { compile, compileTarget } from './compile';
-export type { CompileRequest, CompileTargetOptions, RunConfig } from './config';
+export type { CompileRequest, CompileTargetOptions, RunConfig } from '../config';

--- a/packages/cspell-tools/src/config/config.ts
+++ b/packages/cspell-tools/src/config/config.ts
@@ -38,14 +38,14 @@ export interface CompileTargetOptions {
 
 export interface Target {
     /**
-     * Optional Name of the target.
+     * Name of target, used as the basis of target file name.
      */
-    name?: string;
+    name: string;
 
     /**
-     * The target filename
+     * The target directory
      */
-    filename: FilePath;
+    targetDirectory: FilePath;
     /**
      * gzip the file?
      * @default: false

--- a/packages/cspell-tools/src/config/config.ts
+++ b/packages/cspell-tools/src/config/config.ts
@@ -38,6 +38,11 @@ export interface CompileTargetOptions {
 
 export interface Target {
     /**
+     * Optional Name of the target.
+     */
+    name?: string;
+
+    /**
      * The target filename
      */
     filename: FilePath;
@@ -109,18 +114,4 @@ export interface SourceConfig {
      * @default false
      */
     keepRawCase?: boolean | undefined;
-}
-
-export function isFilePath(source: DictionarySource): source is FilePath {
-    return typeof source === 'string';
-}
-
-export function isFileSource(source: DictionarySource): source is FileSource {
-    if (!source || isFilePath(source)) return false;
-    return (<FileSource>source).filename !== undefined;
-}
-
-export function isFileListSource(source: DictionarySource): source is FileListSource {
-    if (!source || isFilePath(source)) return false;
-    return (<FileListSource>source).listFile !== undefined;
 }

--- a/packages/cspell-tools/src/config/index.ts
+++ b/packages/cspell-tools/src/config/index.ts
@@ -1,0 +1,12 @@
+export {
+    CompileRequest,
+    CompileTargetOptions,
+    DictionaryFormats,
+    DictionarySource,
+    FileListSource,
+    FilePath,
+    FileSource,
+    RunConfig,
+    SourceConfig,
+    Target,
+} from './config';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -569,6 +569,7 @@ importers:
       lorem-ipsum: ^2.0.8
       rimraf: ^3.0.2
       shelljs: ^0.8.5
+      ts-json-schema-generator: ^1.1.2
     dependencies:
       '@cspell/cspell-pipe': link:../cspell-pipe
       commander: 9.4.1
@@ -589,6 +590,7 @@ importers:
       lorem-ipsum: 2.0.8
       rimraf: 3.0.2
       shelljs: 0.8.5
+      ts-json-schema-generator: 1.1.2
 
   packages/cspell-trie:
     specifiers:


### PR DESCRIPTION
Add a run-configuration based build command.

A move towards "config" as code when using cspell-tools.