### PR TITLE
doc: Drop Active Support for CSpell 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Tidelift will coordinate the fix and disclosure.
 
 ## Versions
 
-|        | version | Node | Support                | End-Of-Life |
-| :----- | :------ | :--- | :--------------------- | :---------- |
-| cspell | 6.x     | 14.x | In Active Development  | TBD         |
-| cspell | 5.x     | 12.x | Security and bug fixes | 2023-05-01  |
-| cspell | 4.x     | 10.x | Paid support only[^1]  | 2022-05-01  |
+|        | version | Node | Support               | End-Of-Life |
+| :----- | :------ | :--- | :-------------------- | :---------- |
+| cspell | 6.x     | 14.x | In Active Development | TBD         |
+| cspell | 5.x     | 12.x | Paid support only[^1] | 2022-10-01  |
+| cspell | 4.x     | 10.x | Paid support only[^1] | 2022-05-01  |
 
 [^1]: [Support - Street Side Software](https://streetsidesoftware.com/support/#maintenance-agreements)


### PR DESCRIPTION
It has become too hard to automatically update the tools used by CSpell 5.x to build and test.

Due to this, all support for CSpell 5 has moved to paid support only.