### PR TITLE
ci: Reduce the cost of Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-recreate.yml
+++ b/.github/workflows/dependabot-recreate.yml
@@ -24,11 +24,20 @@ jobs:
         run: |
           echo PR_SUMMARY=$(gh pr list -S "-label:cspell5 author:app/dependabot") >> $GITHUB_ENV
 
-      - name: Get Open PRs and apply comment
+      - name: Get Open PRs and apply label
         if: ${{ env.PR_SUMMARY }}
         env:
           GH_TOKEN: ${{ secrets.TOKEN_UPDATE_DEPENDABOT }}
         run: >
           gh pr list -S "-label:cspell5 author:app/dependabot" --json number
           | jq '.[].number'
-          | xargs -n1 gh pr comment -b "@dependabot recreate"
+          | xargs -n1 gh pr edit --add-label "dependabot:recreate"
+
+      # - name: Get Open PRs and apply comment
+      #   if: ${{ env.PR_SUMMARY }}
+      #   env:
+      #     GH_TOKEN: ${{ secrets.TOKEN_UPDATE_DEPENDABOT }}
+      #   run: >
+      #     gh pr list -S "-label:cspell5 author:app/dependabot" --json number
+      #     | jq '.[].number'
+      #     | xargs -n1 gh pr comment -b "@dependabot recreate"


### PR DESCRIPTION
Instead of having Dependabot recreate all the PRs at the same time, the idea is to:

1. tag all of them with `dependabot:recreate`
2. later slowly mark them to be recreated.
