### PR TITLE
fix: trie-lib - fix issue with reference radix.

### DIFF
--- a/packages/cspell-trie-lib/src/lib/io/importExportV4.test.ts
+++ b/packages/cspell-trie-lib/src/lib/io/importExportV4.test.ts
@@ -4,8 +4,8 @@ import * as Trie from '..';
 import { resolveSample as resolveSamplePath } from '../../test/samples';
 import { consolidate } from '../consolidate';
 import { TrieNode } from '../TrieNode';
-import { importTrie, serializeTrie, __testing__ } from './importExportV4';
 import * as v3 from './importExportV3';
+import { importTrie, serializeTrie, __testing__ } from './importExportV4';
 
 const sampleFile = resolveSamplePath('sampleV4.trie');
 
@@ -52,7 +52,16 @@ describe('Import/Export', () => {
 
     test('tests serialize / deserialize trie', () => {
         const trie = Trie.buildTrie(sampleWords).root;
-        const data = serializeTrie(trie, 10);
+        const data = serializeTrie(trie, 16);
+        const root = importTrie(data);
+        const words = [...Trie.iteratorTrieWords(root)];
+        expect(words).toEqual([...sampleWords].sort());
+    });
+
+    test('serialize / deserialize trie DAWG', () => {
+        const trie = Trie.buildTrie(sampleWords).root;
+        const trieDawg = consolidate(trie);
+        const data = serializeTrie(trieDawg, 16);
         const root = importTrie(data);
         const words = [...Trie.iteratorTrieWords(root)];
         expect(words).toEqual([...sampleWords].sort());

--- a/packages/cspell-trie-lib/src/lib/io/importExportV4.ts
+++ b/packages/cspell-trie-lib/src/lib/io/importExportV4.ts
@@ -463,7 +463,10 @@ function parseStream(radix: number, iter: Iterable<string>): TrieRoot {
         function parser(acc: ReduceResults, s: string): ReduceResults {
             json = json + s;
             if (s === REF_INDEX_END) {
-                refIndex = JSON.parse(json) as number[];
+                refIndex = json
+                    .replace(/[\s[\]]/g, '')
+                    .split(',')
+                    .map((n) => parseInt(n, radix));
                 return { ...acc, parser: undefined };
             }
             return acc;


### PR DESCRIPTION
Fixes and issue with non-base 10 radixes.

The parser assumed that the reference index was in base 10.