### PR TITLE
fix: Adjust the Typos definition to match Terms

### DIFF
--- a/packages/cspell-dictionary/src/SpellingDictionary/Terms/index.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Terms/index.ts
@@ -1,0 +1,10 @@
+export {
+    TermsDef,
+    TermsDefKey,
+    TermsDefValue,
+    TermValueIgnoreWord,
+    TermValueOk,
+    TermValueTypo,
+    TermValueTypoNoSuggestions,
+    TermValueTypoWithSuggestions,
+} from './terms';

--- a/packages/cspell-dictionary/src/SpellingDictionary/Terms/terms.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Terms/terms.ts
@@ -1,0 +1,13 @@
+export type TermValueTypoNoSuggestions = false;
+type TermValueTypoSingleSuggestion = string;
+type TermValueTypoMultipleSuggestions = string[];
+export type TermValueTypoWithSuggestions = TermValueTypoSingleSuggestion | TermValueTypoMultipleSuggestions;
+export type TermValueTypo = TermValueTypoWithSuggestions | TermValueTypoNoSuggestions;
+
+export type TermValueIgnoreWord = null;
+export type TermValueOk = true;
+
+export type TermsDefValue = TermValueTypo | TermValueIgnoreWord | TermValueOk;
+export type TermsDefKey = string;
+
+export type TermsDef = Record<TermsDefKey, TermsDefValue>;

--- a/packages/cspell-dictionary/src/SpellingDictionary/Typos/typos.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Typos/typos.ts
@@ -1,4 +1,4 @@
-import { TermsDefKey, TermValueTypo, TermValueTypoNoSuggestions, TermValueTypoWithSuggestions } from '../Terms';
+import type { TermsDefKey, TermValueTypo, TermValueTypoNoSuggestions, TermValueTypoWithSuggestions } from '../Terms';
 
 export type TypoValueNoSuggestions = TermValueTypoNoSuggestions;
 export type TypoValueWithSuggestions = TermValueTypoWithSuggestions;

--- a/packages/cspell-dictionary/src/SpellingDictionary/Typos/typos.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Typos/typos.ts
@@ -1,9 +1,10 @@
-type NoSuggestion = null | undefined;
-type SingleSuggestion = string;
-type MultipleSuggestions = string[];
+import { TermsDefKey, TermValueTypo, TermValueTypoNoSuggestions, TermValueTypoWithSuggestions } from '../Terms';
 
-export type TyposDefValue = MultipleSuggestions | SingleSuggestion | NoSuggestion;
-export type TyposDefKey = string;
+export type TypoValueNoSuggestions = TermValueTypoNoSuggestions;
+export type TypoValueWithSuggestions = TermValueTypoWithSuggestions;
+
+export type TyposDefValue = TermValueTypo;
+export type TyposDefKey = TermsDefKey;
 
 /**
  * Typos Definition
@@ -12,9 +13,9 @@ export type TyposDefKey = string;
  */
 export type TyposDef = Record<TyposDefKey, TyposDefValue>;
 
-type TypoNoSuggestions = string;
+type TypoWithNoSuggestions = string;
 type TypoWithSuggestionsArray = [forbidWord: string, ...suggestions: string[]];
 type TypoWithSuggestionsObj = TyposDef;
 type TypoWithSuggestions = TypoWithSuggestionsArray | TypoWithSuggestionsObj;
 
-export type TypoEntry = TypoNoSuggestions | TypoWithSuggestions;
+export type TypoEntry = TypoWithNoSuggestions | TypoWithSuggestions;

--- a/packages/cspell-dictionary/src/SpellingDictionary/Typos/typosParser.test.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Typos/typosParser.test.ts
@@ -5,14 +5,14 @@ describe('TypoParser', () => {
         content                | expected
         ${''}                  | ${{}}
         ${'apple ->orange'}    | ${{ apple: 'orange' }}
-        ${'apple ->'}          | ${{ apple: null }}
-        ${'apple : , '}        | ${{ apple: null }}
+        ${'apple ->'}          | ${{ apple: false }}
+        ${'apple : , '}        | ${{ apple: false }}
         ${'a: b, c'}           | ${{ a: ['b', 'c'] }}
-        ${'a: b; c; d:e'}      | ${{ a: 'b', c: null, d: 'e' }}
+        ${'a: b; c; d:e'}      | ${{ a: 'b', c: false, d: 'e' }}
         ${'a->b , c'}          | ${{ a: ['b', 'c'] }}
         ${'a->b , c'}          | ${{ a: ['b', 'c'] }}
-        ${'a->b , c\nb'}       | ${{ a: ['b', 'c'], b: null }}
-        ${'a->b , c\nb\na->b'} | ${{ a: 'b', b: null }}
+        ${'a->b , c\nb'}       | ${{ a: ['b', 'c'], b: false }}
+        ${'a->b , c\nb\na->b'} | ${{ a: 'b', b: false }}
     `('parseTyposFile $content', ({ content, expected }) => {
         const result = parseTyposFile(content);
         expect(result).toEqual(expected);
@@ -23,8 +23,8 @@ describe('TypoParser', () => {
         ${[]}                | ${{}}
         ${['']}              | ${{}}
         ${[['', 'b']]}       | ${{}}
-        ${['a']}             | ${{ a: null }}
-        ${[['a']]}           | ${{ a: null }}
+        ${['a']}             | ${{ a: false }}
+        ${[['a']]}           | ${{ a: false }}
         ${[['a', 'b']]}      | ${{ a: 'b' }}
         ${[['a', 'b', 'c']]} | ${{ a: ['b', 'c'] }}
     `('createTyposDefFromEntries $entries', ({ entries, expected }) => {
@@ -37,8 +37,8 @@ describe('TypoParser', () => {
         ${[]}                | ${{}}
         ${['']}              | ${{}}
         ${[['', 'b']]}       | ${{}}
-        ${['a']}             | ${{ a: null }}
-        ${[['a']]}           | ${{ a: null }}
+        ${['a']}             | ${{ a: false }}
+        ${[['a']]}           | ${{ a: false }}
         ${[['a', 'b']]}      | ${{ a: 'b' }}
         ${[['a', 'b', 'c']]} | ${{ a: ['b', 'c'] }}
         ${{ a: ['b'] }}      | ${{ a: 'b' }}

--- a/packages/cspell-dictionary/src/SpellingDictionary/Typos/typosParser.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Typos/typosParser.ts
@@ -35,7 +35,7 @@ function trimAndFilter(lines: readonly string[]): string[] {
 
 function cleanSugs(rawSugs: readonly string[]): TyposDefValue {
     const sugs = trimAndFilter(rawSugs);
-    return sugs.length === 1 ? sugs[0] : sugs.length ? sugs : null;
+    return sugs.length === 1 ? sugs[0] : sugs.length ? sugs : false;
 }
 
 function splitSuggestionsValue(value: string): TyposDefValue {
@@ -59,8 +59,8 @@ export function sanitizeIntoTypoDef(dirtyDef: TyposDef | Record<string, unknown>
             def[key] = sugs;
             continue;
         }
-        assert(value === null || value === undefined, 'Unexpected suggestion type.');
-        def[key] = null;
+        assert(value === false, 'Unexpected suggestion type.');
+        def[key] = false;
     }
 
     return def;

--- a/packages/cspell-dictionary/src/SpellingDictionary/Typos/util.test.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Typos/util.test.ts
@@ -4,8 +4,8 @@ describe('typos/util', () => {
     test.each`
         def                     | entry              | expected
         ${{}}                   | ${''}              | ${{}}
-        ${{ a: 'b' }}           | ${'a'}             | ${{ a: null }}
-        ${{}}                   | ${['a']}           | ${{ a: null }}
+        ${{ a: 'b' }}           | ${'a'}             | ${{ a: false }}
+        ${{}}                   | ${['a']}           | ${{ a: false }}
         ${{}}                   | ${['a', 'b']}      | ${{ a: 'b' }}
         ${{}}                   | ${['a', 'b', 'c']} | ${{ a: ['b', 'c'] }}
         ${{ a: 'aa', b: 'bb' }} | ${{ a: 'aaa' }}    | ${{ a: 'aaa', b: 'bb' }}
@@ -17,7 +17,7 @@ describe('typos/util', () => {
         entries                | expected
         ${[]}                  | ${{}}
         ${undefined}           | ${{}}
-        ${[['a', null]]}       | ${{ a: null }}
+        ${[['a', null]]}       | ${{ a: false }}
         ${[['a', 'b']]}        | ${{ a: 'b' }}
         ${[['a', ['b']]]}      | ${{ a: ['b'] }}
         ${[['a', ['b', 'c']]]} | ${{ a: ['b', 'c'] }}

--- a/packages/cspell-dictionary/src/SpellingDictionary/Typos/util.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/Typos/util.ts
@@ -1,5 +1,5 @@
 import { opConcatMap, opFilter, pipe } from '@cspell/cspell-pipe/sync';
-import { TypoEntry, TyposDef, TyposDefKey, TyposDefValue } from './typos';
+import { TypoEntry, TyposDef, TyposDefKey, TyposDefValue, TypoValueWithSuggestions } from './typos';
 
 /**
  * Append an entry to a TyposDef.
@@ -10,14 +10,14 @@ import { TypoEntry, TyposDef, TyposDefKey, TyposDefValue } from './typos';
 export function appendToDef(def: TyposDef, entry: TypoEntry | undefined): TyposDef {
     if (!entry) return def;
     if (typeof entry === 'string') {
-        def[entry] = null;
+        def[entry] = false;
         return def;
     }
     if (Array.isArray(entry)) {
         const [key, ...sugs] = entry.map((s) => s.trim());
         if (!key) return def;
         const s = sugs.map((s) => s.trim()).filter((s) => !!s);
-        def[key] = !s.length ? null : s.length === 1 ? s[0] : s;
+        def[key] = !s.length ? false : s.length === 1 ? s[0] : s;
         return def;
     }
 
@@ -31,7 +31,7 @@ export function createTyposDef(entries?: Iterable<[TyposDefKey, TyposDefValue]>)
     if (!entries) return def;
 
     for (const [key, value] of entries) {
-        def[key] = value;
+        def[key] = isDefined(value) ? value : false;
     }
 
     return def;
@@ -45,7 +45,7 @@ export function createTyposDef(entries?: Iterable<[TyposDefKey, TyposDefValue]>)
 export function extractAllSuggestions(typosDef: TyposDef): Set<string> {
     const allSugs = pipe(
         Object.values(typosDef),
-        opFilter(isDefined),
+        opFilter(hasSuggestions),
         opConcatMap((v) => (Array.isArray(v) ? v : [v]))
     );
     return new Set(allSugs);
@@ -68,4 +68,16 @@ export function extractIgnoreValues(typosDef: TyposDef, ignorePrefix: string): S
 
 function isDefined<T>(v: T | undefined | null): v is T {
     return v !== undefined && v !== null;
+}
+
+function isString(v: unknown): v is string {
+    return typeof v === 'string';
+}
+
+function isArray<T>(v: T[] | unknown): v is T[] {
+    return Array.isArray(v);
+}
+
+function hasSuggestions(v: TyposDefValue): v is TypoValueWithSuggestions {
+    return isString(v) || isArray(v);
 }


### PR DESCRIPTION
In the proposed Terms definition, flagged words have a value of `false` instead of `null`. `null` is reserved to ignore words. `true` is reserved to mean the word is ok.