### PR TITLE
fix: ignore the gitignored files in the scan to improve performance

### DIFF
--- a/cspell-ignore-words.txt
+++ b/cspell-ignore-words.txt
@@ -4,4 +4,7 @@ cacheable
 crap
 flagger
 flaggy
+globify
+Posixified
+posixify
 shit

--- a/packages/cspell-gitignore/package.json
+++ b/packages/cspell-gitignore/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "cspell-glob": "workspace:*",
-    "find-up": "^5.0.0"
+    "find-up": "^5.0.0",
+    "globify-gitignore": "^0.2.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",

--- a/packages/cspell-gitignore/package.json
+++ b/packages/cspell-gitignore/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "cspell-glob": "workspace:*",
     "find-up": "^5.0.0",
-    "globify-gitignore": "^0.2.1"
+    "globify-gitignore": "^1.0.3"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",

--- a/packages/cspell-gitignore/src/GitIgnore.ts
+++ b/packages/cspell-gitignore/src/GitIgnore.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'fs';
 import { globifyGitIgnoreFile } from 'globify-gitignore';
 import * as path from 'path';
 import { contains } from '.';
@@ -54,6 +55,10 @@ export class GitIgnore {
     }
 
     async getGlobs(root: string) {
+        if (!existsSync(path.join(root, '.gitignore'))) {
+            return [[], []];
+        }
+
         const globEntries = await globifyGitIgnoreFile(root, false);
         const ignored: string[] = [];
         const included: string[] = [];

--- a/packages/cspell-gitignore/src/GitIgnore.ts
+++ b/packages/cspell-gitignore/src/GitIgnore.ts
@@ -1,4 +1,4 @@
-import { globifyGitIgnoreFile, posixifyPathNormalized } from 'globify-gitignore';
+import { globifyGitIgnoreFile } from 'globify-gitignore';
 import * as path from 'path';
 import { contains } from '.';
 import { GitIgnoreHierarchy, IsIgnoredExResult, loadGitIgnore } from './GitIgnoreFile';
@@ -54,19 +54,14 @@ export class GitIgnore {
     }
 
     async getGlobs(root: string) {
-        const rootPosixified = posixifyPathNormalized(root);
-        const globs = await globifyGitIgnoreFile(rootPosixified);
-
-        // globify-gitignore is compatible with fast-glob, but to make it work with glob,
-        // the patterns need to be separated and normalized.
-        const rootPosixifiedSlashed = `${rootPosixified}/`;
-        const ignored = [];
-        const included = [];
-        for (const g of globs) {
-            if (g.startsWith('!')) {
-                ignored.push(g.slice(1).replace(rootPosixifiedSlashed, ''));
+        const globEntries = await globifyGitIgnoreFile(root, false);
+        const ignored: string[] = [];
+        const included: string[] = [];
+        for (const globEntry of globEntries) {
+            if (!globEntry.included) {
+                ignored.push(globEntry.glob);
             } else {
-                included.push(g.replace(rootPosixifiedSlashed, ''));
+                included.push(globEntry.glob);
             }
         }
         return [ignored, included];

--- a/packages/cspell/src/lint/lint.ts
+++ b/packages/cspell/src/lint/lint.ts
@@ -380,6 +380,24 @@ async function determineFilesToCheck(
             globOptions.dot = enableGlobDot;
         }
 
+        if (gitIgnore) {
+            // Add the gitignore file in the root to the globs to improve performance.
+            const [gitIgnoredGlobs, gitIncludedGlobs] = await gitIgnore.getGlobs(root);
+
+            allGlobs.push(...gitIncludedGlobs);
+            fileGlobs.push(...gitIncludedGlobs);
+
+            let globOptionsIgnore: string[] = [];
+            if (Array.isArray(globOptions.ignore)) {
+                globOptionsIgnore = globOptions.ignore;
+            } else if (typeof globOptions.ignore === 'string') {
+                globOptionsIgnore = [globOptions.ignore];
+            }
+
+            globOptionsIgnore.push(...gitIgnoredGlobs);
+            globOptions.ignore = globOptionsIgnore;
+        }
+
         const filterFiles = opFilter(filterFilesFn(globMatcher));
         const foundFiles = await (hasFileLists
             ? useFileLists(fileLists, allGlobs, root, enableGlobDot)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,11 +384,13 @@ importers:
       '@vitest/coverage-istanbul': ^0.26.3
       cspell-glob: workspace:*
       find-up: ^5.0.0
+      globify-gitignore: ^0.2.1
       vite: ^4.0.4
       vitest: ^0.26.3
     dependencies:
       cspell-glob: link:../cspell-glob
       find-up: 5.0.0
+      globify-gitignore: 0.2.1
     devDependencies:
       '@types/node': 18.11.18
       '@vitest/coverage-c8': 0.26.3
@@ -7362,7 +7364,6 @@ packages:
 
   /dedent/0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
-    dev: true
 
   /deep-eql/4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
@@ -9059,6 +9060,13 @@ packages:
       - supports-color
     dev: true
 
+  /globify-gitignore/0.2.1:
+    resolution: {integrity: sha512-n0aqsgpq9gKkLYBKG7U0oeMOGXykm/RnGTt8qgWK57GBxif1VxclBF2YzXnx4yGc6/QIUI44OV+/R+RY+685SQ==}
+    dependencies:
+      dedent: 0.7.0
+      is-valid-path: 0.1.1
+    dev: false
+
   /globrex/0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
     dev: true
@@ -9760,6 +9768,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /is-extglob/1.0.0:
+    resolution: {integrity: sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-extglob/2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -9772,6 +9785,13 @@ packages:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /is-glob/2.0.1:
+    resolution: {integrity: sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 1.0.0
+    dev: false
 
   /is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -9799,6 +9819,13 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
     dev: true
+
+  /is-invalid-path/0.1.0:
+    resolution: {integrity: sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-glob: 2.0.1
+    dev: false
 
   /is-lambda/1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
@@ -9955,6 +9982,13 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
     dev: true
+
+  /is-valid-path/0.1.1:
+    resolution: {integrity: sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-invalid-path: 0.1.0
+    dev: false
 
   /is-weakref/1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,13 +384,13 @@ importers:
       '@vitest/coverage-istanbul': ^0.26.3
       cspell-glob: workspace:*
       find-up: ^5.0.0
-      globify-gitignore: ^0.2.1
+      globify-gitignore: ^1.0.3
       vite: ^4.0.4
       vitest: ^0.26.3
     dependencies:
       cspell-glob: link:../cspell-glob
       find-up: 5.0.0
-      globify-gitignore: 0.2.1
+      globify-gitignore: 1.0.3
     devDependencies:
       '@types/node': 18.11.18
       '@vitest/coverage-c8': 0.26.3
@@ -5840,6 +5840,12 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  /array-uniq/1.0.3:
+    resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+    optional: true
+
   /array.prototype.flat/1.3.1:
     resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
     engines: {node: '>= 0.4'}
@@ -6435,6 +6441,12 @@ packages:
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
+
+  /chainsaw/0.0.9:
+    resolution: {integrity: sha512-nG8PYH+/4xB+8zkV4G844EtfvZ5tTiLFoX3dZ4nhF4t3OCKIb9UvaFyNmeZO2zOSmRWzBoTD+napN6hiL+EgcA==}
+    dependencies:
+      traverse: 0.3.9
+    dev: false
 
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -9060,11 +9072,15 @@ packages:
       - supports-color
     dev: true
 
-  /globify-gitignore/0.2.1:
-    resolution: {integrity: sha512-n0aqsgpq9gKkLYBKG7U0oeMOGXykm/RnGTt8qgWK57GBxif1VxclBF2YzXnx4yGc6/QIUI44OV+/R+RY+685SQ==}
+  /globify-gitignore/1.0.3:
+    resolution: {integrity: sha512-yfwxPrXeIf6EvirmOZ8LOPxETorIbusANNnHdpXtmDwMW10NSEv4j2kgjWUR9OTRHtdchc07AFmgXLc29Wv89w==}
     dependencies:
       dedent: 0.7.0
       is-valid-path: 0.1.1
+      remove: 0.1.5
+    optionalDependencies:
+      make-unique: 1.0.4
+      sort-es: 1.6.4
     dev: false
 
   /globrex/0.1.2:
@@ -9200,6 +9216,12 @@ packages:
       is-stream: 2.0.1
       type-fest: 0.8.1
     dev: true
+
+  /hashish/0.0.4:
+    resolution: {integrity: sha512-xyD4XgslstNAs72ENaoFvgMwtv8xhiDtC2AtzCG+8yF7W/Knxxm9BX+e2s25mm+HxMKh0rBmXVOEGF3zNImXvA==}
+    dependencies:
+      traverse: 0.6.7
+    dev: false
 
   /hast-to-hyperscript/9.0.1:
     resolution: {integrity: sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==}
@@ -11061,6 +11083,15 @@ packages:
       - bluebird
       - supports-color
     dev: true
+
+  /make-unique/1.0.4:
+    resolution: {integrity: sha512-fhy5iusM7DNzilx1gW1YvAm1d6VjZ1TRoD52+U4ZrfMwIMzHObPGEcvssZwvUgO9R2ef8XOakx6lGMVgS68QcQ==}
+    engines: {node: '>=0.10.0'}
+    requiresBuild: true
+    dependencies:
+      array-uniq: 1.0.3
+    dev: false
+    optional: true
 
   /makeerror/1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -13719,6 +13750,12 @@ packages:
       - supports-color
     dev: true
 
+  /remove/0.1.5:
+    resolution: {integrity: sha512-AJMA9oWvJzdTjwIGwSQZsjGQiRx73YTmiOWmfCp1fpLa/D4n7jKcpoA+CZiVLJqKcEKUuh1Suq80c5wF+L/qVQ==}
+    dependencies:
+      seq: 0.3.5
+    dev: false
+
   /renderkid/3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
     dependencies:
@@ -14024,6 +14061,13 @@ packages:
       - supports-color
     dev: false
 
+  /seq/0.3.5:
+    resolution: {integrity: sha512-sisY2Ln1fj43KBkRtXkesnRHYNdswIkIibvNe/0UKm2GZxjMbqmccpiatoKr/k2qX5VKiLU8xm+tz/74LAho4g==}
+    dependencies:
+      chainsaw: 0.0.9
+      hashish: 0.0.4
+    dev: false
+
   /serialize-javascript/6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
     dependencies:
@@ -14221,6 +14265,12 @@ packages:
     resolution: {integrity: sha512-IeWvo8NkNiY2vVYdPa27MCQiR0MN0M80johAYFVxWWXQ44KU84WNxjslwBHmc/7ZL2ccwkM7/e6S5aiKZXm7jA==}
     engines: {node: '>= 6.3.0'}
     dev: false
+
+  /sort-es/1.6.4:
+    resolution: {integrity: sha512-/aujEfKqeR9ghQScotgmE+/54becfWtez5HdZnENAtR/oWQpFD6+HXv1jo/rO97UVuSb/GgOLEW9x0uGUm6mpQ==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /sort-keys/2.0.0:
     resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
@@ -14782,6 +14832,14 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  /traverse/0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
+    dev: false
+
+  /traverse/0.6.7:
+    resolution: {integrity: sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==}
+    dev: false
 
   /treeverse/3.0.0:
     resolution: {integrity: sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==}


### PR DESCRIPTION
Fixes #3047

This uses [ `globify-gitignore` ](https://github.com/aminya/globify-gitignore/) to get the glob patterns of the gitignore file at the root and appends those to the ignore pattern of the `glob` package. This significantly improves the performance of `cspell` as those directories are excluded in the scan. 

I see speeds up of 3x to 10x depending on the size of the project!

- [x] (Edit: fixed in v1.0.3) Because `cspell` uses `glob` instead of `fast-glob`, I had to make some changes in the output of `globify-gitignore`. I will modify the API of `globify-gitignore` a bit so that we don't have to do these changes here:
https://github.com/aminya/globify-gitignore/pull/1
