### PR TITLE
Add example for remote dictionaries

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -91,7 +91,7 @@ Or you can specify a path to a config file with the `--config <path>` argument o
   "dictionaries": ["spanish", "ruby", "corp-terms", "fonts"],
   // Define each dictionary:
   //  - Relative paths are relative to the config file.
-  //  - URLs will be retrieved via HTTP GET one word per line.
+  //  - URLs will be retrieved via HTTP GET
   "dictionaryDefinitions": [
       { "name": "spanish", "path": "./spanish-words.txt"},
       { "name": "ruby", "path": "./ruby.txt"},

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -85,7 +85,7 @@ Or you can specify a path to a config file with the `--config <path>` argument o
 
   ```javascript
   "language": "en",
-  // Dictionaries "spanish", "ruby", and "corp-term" will always be checked.
+  // Dictionaries "spanish", "ruby", and "corp-terms" will always be checked.
   // Including "spanish" in the list of dictionaries means both Spanish and English
   // words will be considered correct.
   "dictionaries": ["spanish", "ruby", "corp-terms", "fonts"],
@@ -96,7 +96,7 @@ Or you can specify a path to a config file with the `--config <path>` argument o
       { "name": "spanish", "path": "./spanish-words.txt"},
       { "name": "ruby", "path": "./ruby.txt"},
       {
-        "name": "company-terms",
+        "name": "corp-terms",
         "path": "https://shared-company-repository/cspell-terms.txt"
       },
   ],

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -89,11 +89,16 @@ Or you can specify a path to a config file with the `--config <path>` argument o
   // Including "spanish" in the list of dictionaries means both Spanish and English
   // words will be considered correct.
   "dictionaries": ["spanish", "ruby", "corp-terms", "fonts"],
-  // Define each dictionary.  Relative paths are relative to the config file.
+  // Define each dictionary:
+  //  - Relative paths are relative to the config file.
+  //  - URLs will be retrieved via HTTP GET one word per line.
   "dictionaryDefinitions": [
       { "name": "spanish", "path": "./spanish-words.txt"},
       { "name": "ruby", "path": "./ruby.txt"},
-      { "name": "company-terms", "path": "./corp-terms.txt"}
+      {
+        "name": "company-terms",
+        "path": "https://shared-company-repository/cspell-terms.txt"
+      },
   ],
   ```
 


### PR DESCRIPTION
This PR adds a config example in the documentation which demonstrates how to use dictionaries defined in remote files.

Along the lines it also fixes an issue in the example: The "name" of the dictionary was inconsistent. The three variants `corp-term`, `corp-terms` and `company-terms` were used. This, in my understanding would not have worked either way.

See also #4035