### PR TITLE
refactor: move spell checking into worker

### DIFF
--- a/packages/cspell-eslint-plugin/package.json
+++ b/packages/cspell-eslint-plugin/package.json
@@ -36,7 +36,7 @@
     "build": "pnpm run build-schema && pnpm run build-rollup",
     "build-rollup": "rollup --config rollup.config.ts --configPlugin typescript",
     "build-schema": "ts-json-schema-generator --no-top-ref --expose none --path src/options.ts --type Options  -o  ./src/_auto_generated_/options.schema.json",
-    "watch": "pnpm run build-rollup -- --watch",
+    "watch": "pnpm run build-rollup --watch",
     "clean": "shx rm -rf dist coverage .tsbuildinfo",
     "clean-build": "pnpm run clean && pnpm run build",
     "coverage": "echo coverage",
@@ -72,6 +72,7 @@
     "ts-json-schema-generator": "^1.2.0"
   },
   "dependencies": {
-    "cspell-lib": "workspace:*"
+    "cspell-lib": "workspace:*",
+    "estree-walker": "^2.0.2"
   }
 }

--- a/packages/cspell-eslint-plugin/src/cspell-eslint-plugin.ts
+++ b/packages/cspell-eslint-plugin/src/cspell-eslint-plugin.ts
@@ -1,17 +1,13 @@
 // cspell:ignore TSESTree
-import type { TSESTree } from '@typescript-eslint/types';
-import assert from 'assert';
-import type { CSpellSettings, TextDocument, ValidationIssue } from 'cspell-lib';
-import { createTextDocument, DocumentValidator, refreshDictionaryCache } from 'cspell-lib';
+import { refreshDictionaryCache } from 'cspell-lib';
 import type { Rule } from 'eslint';
-import type { Comment, Identifier, ImportSpecifier, Literal, Node, TemplateElement } from 'estree';
 import * as path from 'path';
-import { format } from 'util';
 
 import optionsSchema from './_auto_generated_/options.schema.json';
 import { addWordToCustomWordList } from './customWordList';
-import type { CustomWordListFile, Options } from './options';
+import type { CustomWordListFile } from './options';
 import { normalizeOptions } from './options';
+import { type Issue, spellCheck, walkTree } from './worker';
 
 const schema = optionsSchema as unknown as Rule.RuleMetaData['schema'];
 
@@ -40,159 +36,37 @@ const meta: Rule.RuleMetaData = {
     schema: [schema],
 };
 
-type ASTNode = (Node | Comment) & Partial<Rule.NodeParentExtension>;
-
-const defaultSettings: CSpellSettings = {
-    patterns: [
-        // @todo: be able to use cooked / transformed strings.
-        // {
-        //     // Do not block unicode escape sequences.
-        //     name: 'js-unicode-escape',
-        //     pattern: /$^/g,
-        // },
-    ],
-};
-
 let isDebugMode = false;
 function log(...args: Parameters<typeof console.log>) {
     if (!isDebugMode) return;
     console.log(...args);
 }
 
+const debugTree = false;
+
+function dumpTree(context: Rule.RuleContext) {
+    if (!debugTree) return;
+
+    walkTree(context.getSourceCode().ast, function (node, _parent, key) {
+        const withValue: { type: string; value?: unknown } = node;
+        console.log('key: %o, node: %o', key, { type: node.type, value: withValue.value });
+    });
+}
+
 function create(context: Rule.RuleContext): Rule.RuleListener {
-    const options = normalizeOptions(context.options[0]);
-    const toIgnore = new Set<string>();
-    const importedIdentifiers = new Set<string>();
+    const options = normalizeOptions(context.options[0], context.getCwd());
     isDebugMode = options.debugMode || false;
     isDebugMode && logContext(context);
-    const validator = getDocValidator(context);
-    validator.prepareSync();
 
-    function checkLiteral(node: Literal & Rule.NodeParentExtension) {
-        if (!options.checkStrings) return;
-        if (typeof node.value === 'string') {
-            debugNode(node, node.value);
-            if (options.ignoreImports && isImportOrRequired(node)) return;
-            if (options.ignoreImportProperties && isImportedProperty(node)) return;
-            checkNodeText(node, node.value);
-        }
-    }
+    dumpTree(context);
 
-    function checkJSXText(node: Literal & Rule.NodeParentExtension) {
-        if (!options.checkJSXText) return;
-        if (typeof node.value === 'string') {
-            debugNode(node, node.value);
-            checkNodeText(node, node.value);
-        }
-    }
-
-    function checkTemplateElement(node: TemplateElement & Rule.NodeParentExtension) {
-        if (!options.checkStringTemplates) return;
-        debugNode(node, node.value);
-        checkNodeText(node, node.value.cooked || node.value.raw);
-    }
-
-    function checkIdentifier(node: Identifier & Rule.NodeParentExtension) {
-        debugNode(node, node.name);
-        if (options.ignoreImports) {
-            if (isRawImportIdentifier(node)) {
-                toIgnore.add(node.name);
-                return;
-            }
-            if (isImportIdentifier(node)) {
-                importedIdentifiers.add(node.name);
-                if (isLocalImportIdentifierUnique(node)) {
-                    checkNodeText(node, node.name);
-                }
-                return;
-            } else if (options.ignoreImportProperties && isImportedProperty(node)) {
-                return;
-            }
-        }
-        if (!options.checkIdentifiers) return;
-        if (toIgnore.has(node.name) && !isObjectProperty(node)) return;
-        if (skipCheckForRawImportIdentifiers(node)) return;
-        checkNodeText(node, node.name);
-    }
-
-    function checkComment(node: Comment) {
-        if (!options.checkComments) return;
-        debugNode(node, node.value);
-        checkNodeText(node, node.value);
-    }
-
-    function checkNodeText(node: ASTNode, text: string) {
-        if (!node.range) return;
-
-        const adj = node.type === 'Literal' ? 1 : 0;
-        const range = [node.range[0] + adj, node.range[1] - adj] as const;
-
-        const scope: string[] = calcScope(node);
-        const result = validator.checkText(range, text, scope);
-        result.forEach((issue) => reportIssue(issue));
-    }
-
-    function calcScope(_node: ASTNode): string[] {
-        // inheritance(node);
-        return [];
-    }
-
-    function isImportIdentifier(node: ASTNode): boolean {
-        const parent = node.parent;
-        if (node.type !== 'Identifier' || !parent) return false;
-        return (
-            (parent.type === 'ImportSpecifier' ||
-                parent.type === 'ImportNamespaceSpecifier' ||
-                parent.type === 'ImportDefaultSpecifier') &&
-            parent.local === node
-        );
-    }
-
-    function isRawImportIdentifier(node: ASTNode): boolean {
-        const parent = node.parent;
-        if (node.type !== 'Identifier' || !parent) return false;
-        return (
-            (parent.type === 'ImportSpecifier' && parent.imported === node) ||
-            (parent.type === 'ExportSpecifier' && parent.local === node)
-        );
-    }
-
-    function isLocalImportIdentifierUnique(node: ASTNode): boolean {
-        const parent = getImportParent(node);
-        if (!parent) return true;
-        const { imported, local } = parent;
-        if (imported.name !== local.name) return true;
-        return imported.range?.[0] !== local.range?.[0] && imported.range?.[1] !== local.range?.[1];
-    }
-
-    function getImportParent(node: ASTNode): ImportSpecifier | undefined {
-        const parent = node.parent;
-        return parent?.type === 'ImportSpecifier' ? parent : undefined;
-    }
-
-    function skipCheckForRawImportIdentifiers(node: ASTNode): boolean {
-        if (options.ignoreImports) return false;
-        const parent = getImportParent(node);
-        return !!parent && parent.imported === node && !isLocalImportIdentifierUnique(node);
-    }
-
-    function isImportedProperty(node: ASTNode): boolean {
-        const obj = findOriginObject(node);
-        return !!obj && obj.type === 'Identifier' && importedIdentifiers.has(obj.name);
-    }
-
-    function isObjectProperty(node: ASTNode): boolean {
-        return node.parent?.type === 'MemberExpression';
-    }
-
-    function reportIssue(issue: ValidationIssue) {
-        const messageId: MessageIds = issue.isFlagged ? 'wordForbidden' : 'wordUnknown';
+    function reportIssue(issue: Issue) {
+        const messageId: MessageIds = issue.severity === 'Forbidden' ? 'wordForbidden' : 'wordUnknown';
+        const { word, start, end } = issue;
         const data = {
-            word: issue.text,
+            word,
         };
         const code = context.getSourceCode();
-        const start = issue.offset;
-        const end = issue.offset + (issue.length || issue.text.length);
         const startPos = code.getLocFromIndex(start);
         const endPos = code.getLocFromIndex(end);
         const loc = { start: startPos, end: endPos };
@@ -231,7 +105,6 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
                     return new WrapFix({ range: [start, end], text: word }, () => {
                         refreshDictionaryCache(0);
                         addWordToCustomWordList(dictFile, word);
-                        validator.updateDocumentText(context.getSourceCode().getText());
                     });
                 },
             };
@@ -239,7 +112,7 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
 
         log('Suggestions: %o', issue.suggestions);
         const suggestions: Rule.ReportDescriptorOptions['suggest'] = issue.suggestions?.map(createSug);
-        const addWordFix = createAddWordToDictionaryFix(issue.text);
+        const addWordFix = createAddWordToDictionaryFix(issue.word);
 
         const suggest =
             suggestions || addWordFix ? (suggestions || []).concat(addWordFix ? [addWordFix] : []) : undefined;
@@ -253,127 +126,13 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
         context.report(des);
     }
 
-    context
-        .getSourceCode()
-        .getAllComments()
-        .forEach(function (commentNode) {
-            checkComment(commentNode);
-        });
-
-    return {
-        Literal: checkLiteral,
-        TemplateElement: checkTemplateElement,
-        Identifier: checkIdentifier,
-        JSXText: checkJSXText,
-    };
-
-    function mapNode(node: ASTNode | TSESTree.Node, index: number, nodes: ASTNode[]): string {
-        const child = nodes[index + 1];
-        if (node.type === 'ImportSpecifier') {
-            const extra = node.imported === child ? '.imported' : node.local === child ? '.local' : '';
-            return node.type + extra;
-        }
-        if (node.type === 'ImportDeclaration') {
-            const extra = node.source === child ? '.source' : '';
-            return node.type + extra;
-        }
-        if (node.type === 'ExportSpecifier') {
-            const extra = node.exported === child ? '.exported' : node.local === child ? '.local' : '';
-            return node.type + extra;
-        }
-        if (node.type === 'ExportNamedDeclaration') {
-            const extra = node.source === child ? '.source' : '';
-            return node.type + extra;
-        }
-        if (node.type === 'Property') {
-            const extra = node.key === child ? 'key' : node.value === child ? 'value' : '';
-            return [node.type, node.kind, extra].join('.');
-        }
-        if (node.type === 'MemberExpression') {
-            const extra = node.property === child ? 'property' : node.object === child ? 'object' : '';
-            return node.type + '.' + extra;
-        }
-        if (node.type === 'ArrowFunctionExpression') {
-            const extra = node.body === child ? 'body' : 'param';
-            return node.type + '.' + extra;
-        }
-        if (node.type === 'FunctionDeclaration') {
-            const extra = node.id === child ? 'id' : node.body === child ? 'body' : 'params';
-            return node.type + '.' + extra;
-        }
-        if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
-            const extra = node.id === child ? 'id' : node.body === child ? 'body' : 'superClass';
-            return node.type + '.' + extra;
-        }
-        if (node.type === 'CallExpression') {
-            const extra = node.callee === child ? 'callee' : 'arguments';
-            return node.type + '.' + extra;
-        }
-        if (node.type === 'Literal') {
-            return tagLiteral(node);
-        }
-        if (node.type === 'Block') {
-            return node.value[0] === '*' ? 'Comment.docBlock' : 'Comment.block';
-        }
-        if (node.type === 'Line') {
-            return 'Comment.line';
-        }
-        return node.type;
+    function checkProgram() {
+        const sc = context.getSourceCode();
+        const issues = spellCheck(context.getFilename(), sc.text, sc.ast, options);
+        issues.forEach((issue) => reportIssue(issue));
     }
 
-    function inheritance(node: ASTNode) {
-        const a = [...context.getAncestors(), node];
-        return a.map(mapNode);
-    }
-
-    function inheritanceSummary(node: ASTNode) {
-        return inheritance(node).join(' ');
-    }
-
-    /**
-     * find the origin of a member expression
-     */
-    function findOriginObject(node: ASTNode): ASTNode | undefined {
-        const parent = node.parent;
-        if (parent?.type !== 'MemberExpression' || parent.property !== node) return undefined;
-        let obj = parent.object;
-        while (obj.type === 'MemberExpression') {
-            obj = obj.object;
-        }
-        return obj;
-    }
-
-    function isFunctionCall(node: ASTNode | undefined, name: string): boolean {
-        return node?.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === name;
-    }
-
-    function isRequireCall(node: ASTNode | undefined) {
-        return isFunctionCall(node, 'require');
-    }
-
-    function isImportOrRequired(node: ASTNode) {
-        return isRequireCall(node.parent) || (node.parent?.type === 'ImportDeclaration' && node.parent.source === node);
-    }
-
-    function debugNode(node: ASTNode, value: unknown) {
-        if (!isDebugMode) return;
-        const val = format('%o', value);
-        log(`${inheritanceSummary(node)}: ${val}`);
-    }
-}
-
-function tagLiteral(node: ASTNode | TSESTree.Node): string {
-    assert(node.type === 'Literal');
-    const kind = typeof node.value;
-    const extra =
-        kind === 'string'
-            ? node.raw?.[0] === '"'
-                ? 'string.double'
-                : 'string.single'
-            : node.value === null
-            ? 'null'
-            : kind;
-    return node.type + '.' + extra;
+    return { Program: checkProgram };
 }
 
 export const rules: PluginRules = {
@@ -410,60 +169,6 @@ export const configs = {
         },
     },
 };
-
-interface CachedDoc {
-    filename: string;
-    doc: TextDocument;
-}
-
-const cache: { lastDoc: CachedDoc | undefined } = { lastDoc: undefined };
-
-const docValCache = new WeakMap<TextDocument, DocumentValidator>();
-
-function getDocValidator(context: Rule.RuleContext): DocumentValidator {
-    const text = context.getSourceCode().getText();
-    const doc = getTextDocument(context.getFilename(), text);
-    const cachedValidator = docValCache.get(doc);
-    if (cachedValidator) {
-        refreshDictionaryCache(0);
-        cachedValidator.updateDocumentText(text);
-        return cachedValidator;
-    }
-
-    const options = normalizeOptions(context.options[0]);
-    const settings = calcInitialSettings(options, context.getCwd());
-    isDebugMode = options.debugMode || false;
-    isDebugMode && logContext(context);
-    const validator = new DocumentValidator(doc, options, settings);
-    docValCache.set(doc, validator);
-    return validator;
-}
-
-function calcInitialSettings(options: Options, cwd: string): CSpellSettings {
-    const { customWordListFile } = options;
-    if (!customWordListFile) return defaultSettings;
-
-    const filePath = isCustomWordListFile(customWordListFile) ? customWordListFile.path : customWordListFile;
-    const dictFile = path.resolve(cwd, filePath);
-
-    const settings: CSpellSettings = {
-        ...defaultSettings,
-        dictionaryDefinitions: [{ name: 'eslint-plugin-custom-words', path: dictFile }],
-        dictionaries: ['eslint-plugin-custom-words'],
-    };
-
-    return settings;
-}
-
-function getTextDocument(filename: string, content: string): TextDocument {
-    if (cache.lastDoc?.filename === filename) {
-        return cache.lastDoc.doc;
-    }
-
-    const doc = createTextDocument({ uri: filename, content });
-    cache.lastDoc = { filename, doc };
-    return doc;
-}
 
 /**
  * This wrapper is used to add a

--- a/packages/cspell-eslint-plugin/src/options.ts
+++ b/packages/cspell-eslint-plugin/src/options.ts
@@ -18,6 +18,8 @@ export interface Options extends Check {
     debugMode?: boolean;
 }
 
+export type RequiredOptions = Required<Options>;
+
 export interface Check {
     /**
      * Ignore import and require names
@@ -103,14 +105,16 @@ export const defaultCheckOptions: Required<Check> = {
     ignoreImports: true,
 };
 
-export const defaultOptions: Required<Options> = {
+export const defaultOptions: RequiredOptions = {
     ...defaultCheckOptions,
     numSuggestions: 8,
     generateSuggestions: true,
     debugMode: false,
 };
 
-export function normalizeOptions(opts: Options | undefined): Required<Options> {
-    const options: Required<Options> = Object.assign({}, defaultOptions, opts || {});
+export type WorkerOptions = RequiredOptions & { cwd: string };
+
+export function normalizeOptions(opts: Options | undefined, cwd: string): WorkerOptions {
+    const options: WorkerOptions = Object.assign({}, defaultOptions, opts || {}, { cwd });
     return options;
 }

--- a/packages/cspell-eslint-plugin/src/worker.ts
+++ b/packages/cspell-eslint-plugin/src/worker.ts
@@ -1,0 +1,390 @@
+// cspell:ignore TSESTree
+import type { TSESTree } from '@typescript-eslint/types';
+import assert from 'assert';
+import type { CSpellSettings, TextDocument, ValidationIssue } from 'cspell-lib';
+import { createTextDocument, DocumentValidator, refreshDictionaryCache } from 'cspell-lib';
+import type { Comment, Identifier, ImportSpecifier, Literal, Node, TemplateElement } from 'estree';
+import { walk } from 'estree-walker';
+import * as path from 'path';
+import { format } from 'util';
+
+import type { CustomWordListFile, WorkerOptions } from './options';
+
+interface JSXText extends Omit<Literal, 'type'> {
+    type: 'JSXText';
+}
+
+export interface Issue {
+    start: number;
+    end: number;
+    word: string;
+    severity: 'Forbidden' | 'Unknown' | 'Hint';
+    suggestions: string[] | undefined;
+}
+
+type ASTNode = (Node | Comment | JSXText) & { parent?: Node };
+
+const defaultSettings: CSpellSettings = {
+    patterns: [
+        // @todo: be able to use cooked / transformed strings.
+        // {
+        //     // Do not block unicode escape sequences.
+        //     name: 'js-unicode-escape',
+        //     pattern: /$^/g,
+        // },
+    ],
+};
+
+let isDebugMode = false;
+function log(...args: Parameters<typeof console.log>) {
+    if (!isDebugMode) return;
+    console.log(...args);
+}
+
+export function spellCheck(filename: string, text: string, root: Node, options: WorkerOptions): Issue[] {
+    const toIgnore = new Set<string>();
+    const importedIdentifiers = new Set<string>();
+    isDebugMode = options.debugMode || false;
+    const validator = getDocValidator(filename, text, options);
+    validator.prepareSync();
+    const issues: Issue[] = [];
+
+    function checkLiteral(node: Literal | ASTNode) {
+        if (node.type !== 'Literal') return;
+        if (!options.checkStrings) return;
+        if (typeof node.value === 'string') {
+            debugNode(node, node.value);
+            if (options.ignoreImports && isImportOrRequired(node)) return;
+            if (options.ignoreImportProperties && isImportedProperty(node)) return;
+            checkNodeText(node, node.value);
+        }
+    }
+
+    function checkJSXText(node: JSXText | ASTNode) {
+        if (node.type !== 'JSXText') return;
+        if (!options.checkJSXText) return;
+        if (typeof node.value === 'string') {
+            debugNode(node, node.value);
+            checkNodeText(node, node.value);
+        }
+    }
+
+    function checkTemplateElement(node: TemplateElement | ASTNode) {
+        if (node.type !== 'TemplateElement') return;
+        if (!options.checkStringTemplates) return;
+        debugNode(node, node.value);
+        checkNodeText(node, node.value.cooked || node.value.raw);
+    }
+
+    function checkIdentifier(node: Identifier | ASTNode) {
+        if (node.type !== 'Identifier') return;
+        debugNode(node, node.name);
+        if (options.ignoreImports) {
+            if (isRawImportIdentifier(node)) {
+                toIgnore.add(node.name);
+                return;
+            }
+            if (isImportIdentifier(node)) {
+                importedIdentifiers.add(node.name);
+                if (isLocalImportIdentifierUnique(node)) {
+                    checkNodeText(node, node.name);
+                }
+                return;
+            } else if (options.ignoreImportProperties && isImportedProperty(node)) {
+                return;
+            }
+        }
+        if (!options.checkIdentifiers) return;
+        if (toIgnore.has(node.name) && !isObjectProperty(node)) return;
+        if (skipCheckForRawImportIdentifiers(node)) return;
+        checkNodeText(node, node.name);
+    }
+
+    function checkComment(node: Comment | ASTNode) {
+        if (node.type !== 'Line' && node.type !== 'Block') return;
+        if (!options.checkComments) return;
+        debugNode(node, node.value);
+        checkNodeText(node, node.value);
+    }
+
+    function checkNodeText(node: ASTNode, text: string) {
+        if (!node.range) return;
+
+        const adj = node.type === 'Literal' ? 1 : 0;
+        const range = [node.range[0] + adj, node.range[1] - adj] as const;
+
+        const scope: string[] = calcScope(node);
+        const result = validator.checkText(range, text, scope);
+        result.forEach((issue) => reportIssue(issue));
+    }
+
+    function calcScope(_node: ASTNode): string[] {
+        // inheritance(node);
+        return [];
+    }
+
+    function isImportIdentifier(node: ASTNode): boolean {
+        const parent = node.parent;
+        if (node.type !== 'Identifier' || !parent) return false;
+        return (
+            (parent.type === 'ImportSpecifier' ||
+                parent.type === 'ImportNamespaceSpecifier' ||
+                parent.type === 'ImportDefaultSpecifier') &&
+            parent.local === node
+        );
+    }
+
+    function isRawImportIdentifier(node: ASTNode): boolean {
+        const parent = node.parent;
+        if (node.type !== 'Identifier' || !parent) return false;
+        return (
+            (parent.type === 'ImportSpecifier' && parent.imported === node) ||
+            (parent.type === 'ExportSpecifier' && parent.local === node)
+        );
+    }
+
+    function isLocalImportIdentifierUnique(node: ASTNode): boolean {
+        const parent = getImportParent(node);
+        if (!parent) return true;
+        const { imported, local } = parent;
+        if (imported.name !== local.name) return true;
+        return imported.range?.[0] !== local.range?.[0] && imported.range?.[1] !== local.range?.[1];
+    }
+
+    function getImportParent(node: ASTNode): ImportSpecifier | undefined {
+        const parent = node.parent;
+        return parent?.type === 'ImportSpecifier' ? parent : undefined;
+    }
+
+    function skipCheckForRawImportIdentifiers(node: ASTNode): boolean {
+        if (options.ignoreImports) return false;
+        const parent = getImportParent(node);
+        return !!parent && parent.imported === node && !isLocalImportIdentifierUnique(node);
+    }
+
+    function isImportedProperty(node: ASTNode): boolean {
+        const obj = findOriginObject(node);
+        return !!obj && obj.type === 'Identifier' && importedIdentifiers.has(obj.name);
+    }
+
+    function isObjectProperty(node: ASTNode): boolean {
+        return node.parent?.type === 'MemberExpression';
+    }
+
+    function reportIssue(issue: ValidationIssue): void {
+        const word = issue.text;
+        const start = issue.offset;
+        const end = issue.offset + (issue.length || issue.text.length);
+        const suggestions = issue.suggestions;
+        const severity = issue.isFlagged ? 'Forbidden' : 'Unknown';
+        issues.push({ word, start, end, suggestions, severity });
+    }
+
+    type NodeTypes = Node['type'] | Comment['type'] | 'JSXText';
+
+    type Handlers = {
+        [K in NodeTypes]?: (n: ASTNode) => void;
+    };
+
+    const processors: Handlers = {
+        Line: checkComment,
+        Block: checkComment,
+        Literal: checkLiteral,
+        TemplateElement: checkTemplateElement,
+        Identifier: checkIdentifier,
+        JSXText: checkJSXText,
+    };
+
+    function checkNode(node: ASTNode) {
+        processors[node.type]?.(node);
+    }
+
+    function mapNode(node: ASTNode | TSESTree.Node, index: number, nodes: ASTNode[]): string {
+        const child = nodes[index + 1];
+        if (node.type === 'ImportSpecifier') {
+            const extra = node.imported === child ? '.imported' : node.local === child ? '.local' : '';
+            return node.type + extra;
+        }
+        if (node.type === 'ImportDeclaration') {
+            const extra = node.source === child ? '.source' : '';
+            return node.type + extra;
+        }
+        if (node.type === 'ExportSpecifier') {
+            const extra = node.exported === child ? '.exported' : node.local === child ? '.local' : '';
+            return node.type + extra;
+        }
+        if (node.type === 'ExportNamedDeclaration') {
+            const extra = node.source === child ? '.source' : '';
+            return node.type + extra;
+        }
+        if (node.type === 'Property') {
+            const extra = node.key === child ? 'key' : node.value === child ? 'value' : '';
+            return [node.type, node.kind, extra].join('.');
+        }
+        if (node.type === 'MemberExpression') {
+            const extra = node.property === child ? 'property' : node.object === child ? 'object' : '';
+            return node.type + '.' + extra;
+        }
+        if (node.type === 'ArrowFunctionExpression') {
+            const extra = node.body === child ? 'body' : 'param';
+            return node.type + '.' + extra;
+        }
+        if (node.type === 'FunctionDeclaration') {
+            const extra = node.id === child ? 'id' : node.body === child ? 'body' : 'params';
+            return node.type + '.' + extra;
+        }
+        if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+            const extra = node.id === child ? 'id' : node.body === child ? 'body' : 'superClass';
+            return node.type + '.' + extra;
+        }
+        if (node.type === 'CallExpression') {
+            const extra = node.callee === child ? 'callee' : 'arguments';
+            return node.type + '.' + extra;
+        }
+        if (node.type === 'Literal') {
+            return tagLiteral(node);
+        }
+        if (node.type === 'Block') {
+            return node.value[0] === '*' ? 'Comment.docBlock' : 'Comment.block';
+        }
+        if (node.type === 'Line') {
+            return 'Comment.line';
+        }
+        return node.type;
+    }
+
+    function inheritance(node: ASTNode) {
+        const a = [...parents(node), node];
+        return a.map(mapNode);
+    }
+
+    function* parents(node: ASTNode | undefined): Iterable<ASTNode> {
+        while (node && node.parent) {
+            yield node.parent;
+            node = node.parent;
+        }
+    }
+
+    function inheritanceSummary(node: ASTNode) {
+        return inheritance(node).join(' ');
+    }
+
+    /**
+     * find the origin of a member expression
+     */
+    function findOriginObject(node: ASTNode): ASTNode | undefined {
+        const parent = node.parent;
+        if (parent?.type !== 'MemberExpression' || parent.property !== node) return undefined;
+        let obj = parent.object;
+        while (obj.type === 'MemberExpression') {
+            obj = obj.object;
+        }
+        return obj;
+    }
+
+    function isFunctionCall(node: ASTNode | undefined, name: string): boolean {
+        return node?.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === name;
+    }
+
+    function isRequireCall(node: ASTNode | undefined) {
+        return isFunctionCall(node, 'require');
+    }
+
+    function isImportOrRequired(node: ASTNode) {
+        return isRequireCall(node.parent) || (node.parent?.type === 'ImportDeclaration' && node.parent.source === node);
+    }
+
+    function debugNode(node: ASTNode, value: unknown) {
+        if (!isDebugMode) return;
+        const val = format('%o', value);
+        log(`${inheritanceSummary(node)}: ${val}`);
+    }
+
+    walkTree(root, checkNode);
+
+    return issues;
+}
+
+function tagLiteral(node: ASTNode | TSESTree.Node): string {
+    assert(node.type === 'Literal');
+    const kind = typeof node.value;
+    const extra =
+        kind === 'string'
+            ? node.raw?.[0] === '"'
+                ? 'string.double'
+                : 'string.single'
+            : node.value === null
+            ? 'null'
+            : kind;
+    return node.type + '.' + extra;
+}
+
+interface CachedDoc {
+    filename: string;
+    doc: TextDocument;
+}
+
+const cache: { lastDoc: CachedDoc | undefined } = { lastDoc: undefined };
+
+const docValCache = new WeakMap<TextDocument, DocumentValidator>();
+
+function getDocValidator(filename: string, text: string, options: WorkerOptions): DocumentValidator {
+    const doc = getTextDocument(filename, text);
+    const cachedValidator = docValCache.get(doc);
+    if (cachedValidator) {
+        refreshDictionaryCache(0);
+        cachedValidator.updateDocumentText(text);
+        return cachedValidator;
+    }
+
+    const settings = calcInitialSettings(options);
+    isDebugMode = options.debugMode || false;
+    const validator = new DocumentValidator(doc, options, settings);
+    docValCache.set(doc, validator);
+    return validator;
+}
+
+function calcInitialSettings(options: WorkerOptions): CSpellSettings {
+    const { customWordListFile, cwd } = options;
+    if (!customWordListFile) return defaultSettings;
+
+    const filePath = isCustomWordListFile(customWordListFile) ? customWordListFile.path : customWordListFile;
+    const dictFile = path.resolve(cwd, filePath);
+
+    const settings: CSpellSettings = {
+        ...defaultSettings,
+        dictionaryDefinitions: [{ name: 'eslint-plugin-custom-words', path: dictFile }],
+        dictionaries: ['eslint-plugin-custom-words'],
+    };
+
+    return settings;
+}
+
+function getTextDocument(filename: string, content: string): TextDocument {
+    if (cache.lastDoc?.filename === filename) {
+        return cache.lastDoc.doc;
+    }
+
+    const doc = createTextDocument({ uri: filename, content });
+    cache.lastDoc = { filename, doc };
+    return doc;
+}
+
+function isCustomWordListFile(value: string | CustomWordListFile | undefined): value is CustomWordListFile {
+    return !!value && typeof value === 'object';
+}
+
+export function walkTree(node: ASTNode, enter: (node: ASTNode, parent: ASTNode | undefined, key: string) => void) {
+    const visited = new Set<object>();
+
+    walk(node, {
+        enter: function (node, parent, key) {
+            if (visited.has(node) || key === 'tokens') {
+                this.skip();
+                return;
+            }
+            visited.add(node);
+            enter(node as ASTNode, parent as ASTNode, key);
+        },
+    });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,12 +365,14 @@ importers:
       cspell-lib: workspace:*
       eslint: ^8.33.0
       eslint-plugin-react: ^7.32.2
+      estree-walker: ^2.0.2
       mocha: ^10.2.0
       rollup: ^3.12.0
       rollup-plugin-dts: ^5.1.1
       ts-json-schema-generator: ^1.2.0
     dependencies:
       cspell-lib: link:../cspell-lib
+      estree-walker: 2.0.2
     devDependencies:
       '@rollup/plugin-commonjs': 24.0.1_rollup@3.12.0
       '@rollup/plugin-json': 6.0.0_rollup@3.12.0
@@ -700,6 +702,7 @@ importers:
   test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin:
     specifiers:
       '@cspell/eslint-plugin': workspace:*
+      '@types/react': ^18.0.27
       '@typescript-eslint/eslint-plugin': ^5.49.0
       '@typescript-eslint/parser': ^5.49.0
       eslint: ^8.33.0
@@ -710,9 +713,13 @@ importers:
       eslint-plugin-prettier: ^4.2.1
       eslint-plugin-promise: ^6.1.1
       prettier: ^2.8.3
+      react: ^17.0.2
       typescript: ^4.9.4
+    dependencies:
+      react: 17.0.2
     devDependencies:
       '@cspell/eslint-plugin': link:../../../packages/cspell-eslint-plugin
+      '@types/react': 18.0.27
       '@typescript-eslint/eslint-plugin': 5.49.0_rsaczafy73x3xqauzesvzbsgzy
       '@typescript-eslint/parser': 5.49.0_zkdaqh7it7uc4cvz2haft7rc6u
       eslint: 8.33.0
@@ -8569,7 +8576,6 @@ packages:
 
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-    dev: true
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -15354,7 +15360,7 @@ packages:
       '@babel/core': 7.20.12
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1
+      jest: 29.4.1_@types+node@18.11.18
       jest-util: 29.4.1
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin/.eslintrc.js
+++ b/test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin/.eslintrc.js
@@ -22,10 +22,17 @@ const config = {
     },
     overrides: [
         {
-            files: '**/*.ts',
+            files: ['**/*.ts', '**/*.tsx'],
             extends: ['plugin:@typescript-eslint/recommended', 'plugin:import/typescript'],
             parser: '@typescript-eslint/parser',
             plugins: ['@typescript-eslint'],
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true,
+                },
+                ecmaVersion: 2020,
+                sourceType: 'module',
+            },
             rules: {
                 '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
                 'node/no-missing-import': [

--- a/test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin/fixtures/component.tsx
+++ b/test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin/fixtures/component.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+/**
+ * This is acomment.
+ */
+
+const Logo = 'https://example.com/logo.svg';
+export default class FirstComponent extends React.Component<object> {
+    render() {
+        return (
+            <div>
+                <h3>A Simplle React Component Example with Typescript</h3>
+                <div>
+                    <img height="250" src={Logo} />
+                </div>
+                <p>This component shows the logo.</p>
+                <p>For more infoo, pleese visit https://example.com </p>
+            </div>
+        );
+    }
+}

--- a/test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin/package.json
+++ b/test-packages/cspell-eslint-plugin/test-cspell-eslint-plugin/package.json
@@ -4,8 +4,8 @@
   "description": "Pure testing package for @cspell/eslint-plugin-cspell.",
   "private": true,
   "scripts": {
-    "eslint": "eslint -c .eslintrc.js .",
-    "test": "pnpm run eslint"
+    "test:eslint": "eslint -c .eslintrc.js .",
+    "test": "pnpm test:eslint"
   },
   "engines": {
     "node": ">=14"
@@ -16,6 +16,7 @@
   "keywords": [],
   "devDependencies": {
     "@cspell/eslint-plugin": "workspace:*",
+    "@types/react": "^18.0.27",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
     "eslint": "^8.33.0",
@@ -27,5 +28,8 @@
     "eslint-plugin-promise": "^6.1.1",
     "prettier": "^2.8.3",
     "typescript": "^4.9.4"
+  },
+  "dependencies": {
+    "react": "^17.0.2"
   }
 }


### PR DESCRIPTION
## cspell-eslint-plugin

Move the logic out of `cspell-eslint-plugin.ts` and into its own file.

The plan is to make an async version, but it needs to be in its own file and cannot call into eslint context.