### PR TITLE
feat: Disable default reporter if another reporter has been defined.

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -904,7 +904,7 @@
           "type": "number"
         },
         "maxNumberOfProblems": {
-          "default": 100,
+          "default": 10000,
           "description": "The maximum number of problems to report in a file.",
           "type": "number"
         },
@@ -1105,14 +1105,23 @@
       },
       "type": "array"
     },
+    "ReporterModuleName": {
+      "description": "The module or path to the the reporter to load.",
+      "type": "string"
+    },
+    "ReporterOptions": {
+      "$ref": "#/definitions/Serializable",
+      "description": "Options to send to the reporter. These are defined by the reporter."
+    },
     "ReporterSettings": {
       "anyOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/ReporterModuleName"
         },
         {
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/ReporterModuleName",
+            "title": "name"
           },
           "maxItems": 1,
           "minItems": 1,
@@ -1121,10 +1130,12 @@
         {
           "items": [
             {
-              "type": "string"
+              "$ref": "#/definitions/ReporterModuleName",
+              "title": "name"
             },
             {
-              "$ref": "#/definitions/Serializable"
+              "$ref": "#/definitions/ReporterOptions",
+              "title": "options"
             }
           ],
           "maxItems": 2,
@@ -1132,7 +1143,7 @@
           "type": "array"
         }
       ],
-      "description": "Reporter name or reporter name + reporter config."
+      "description": "Declare a reporter to use.\n\n`default` - is a special name for the default cli reporter.\n\nExamples:\n- `\"default\"` - to use the default reporter\n- `\"@cspell/cspell-json-reporter\"` - use the cspell JSON reporter.\n- `[\"@cspell/cspell-json-reporter\", { \"outFile\": \"out.json\" }]`"
     },
     "Serializable": {
       "anyOf": [
@@ -1373,7 +1384,7 @@
       "type": "number"
     },
     "maxNumberOfProblems": {
-      "default": 100,
+      "default": 10000,
       "description": "The maximum number of problems to report in a file.",
       "type": "number"
     },
@@ -1434,7 +1445,10 @@
       "type": "boolean"
     },
     "reporters": {
-      "description": "Custom reporters configuration.",
+      "default": [
+        "default"
+      ],
+      "description": "Define which reports to use. `default` - is a special name for the default cli reporter.\n\nExamples:\n- `[\"default\"]` - to use the default reporter\n- `[\"@cspell/cspell-json-reporter\"]` - use the cspell JSON reporter.\n- `[[\"@cspell/cspell-json-reporter\", { \"outFile\": \"out.json\" }]]`\n- `[ \"default\", [\"@cspell/cspell-json-reporter\", { \"outFile\": \"out.json\" }]]` - Use both the default reporter and the cspell-json-reporter.",
       "items": {
         "$ref": "#/definitions/ReporterSettings"
       },

--- a/integration-tests/repositories/cspell-reporter.json
+++ b/integration-tests/repositories/cspell-reporter.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     "version": "0.2",
-    "reporters": [["../dist/reporter/index.js"]]
+    "reporters": ["default", ["../dist/reporter/index.js"]]
 }

--- a/packages/cspell-json-reporter/src/index.test.ts
+++ b/packages/cspell-json-reporter/src/index.test.ts
@@ -47,7 +47,7 @@ describe('getReporter', () => {
     });
 });
 
-async function runReporter(reporter: CSpellReporter): Promise<void> {
+async function runReporter(reporter: Required<CSpellReporter>): Promise<void> {
     reporter.debug('foo');
     reporter.debug('bar');
 

--- a/packages/cspell-json-reporter/src/index.ts
+++ b/packages/cspell-json-reporter/src/index.ts
@@ -14,7 +14,7 @@ function mkdirp(p: string) {
 
 const noopReporter = () => undefined;
 
-export function getReporter(settings: unknown | CSpellJSONReporterSettings): CSpellReporter {
+export function getReporter(settings: unknown | CSpellJSONReporterSettings): Required<CSpellReporter> {
     validateSettings(settings);
     const reportData: Omit<CSpellJSONReporterOutput, 'result'> = {
         issues: [],

--- a/packages/cspell-lib/src/Settings/Controller/configLoader/normalizeRawSettings.ts
+++ b/packages/cspell-lib/src/Settings/Controller/configLoader/normalizeRawSettings.ts
@@ -57,6 +57,7 @@ export function normalizeReporters(settings: NormalizeReporters, pathToSettingsF
     const folder = path.dirname(pathToSettingsFile);
 
     function resolve(s: string): string {
+        if (s === 'default') return s;
         const r = resolveFile(s, folder);
         if (!r.found) {
             throw new Error(`Not found: "${s}"`);

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -904,7 +904,7 @@
           "type": "number"
         },
         "maxNumberOfProblems": {
-          "default": 100,
+          "default": 10000,
           "description": "The maximum number of problems to report in a file.",
           "type": "number"
         },
@@ -1105,14 +1105,23 @@
       },
       "type": "array"
     },
+    "ReporterModuleName": {
+      "description": "The module or path to the the reporter to load.",
+      "type": "string"
+    },
+    "ReporterOptions": {
+      "$ref": "#/definitions/Serializable",
+      "description": "Options to send to the reporter. These are defined by the reporter."
+    },
     "ReporterSettings": {
       "anyOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/ReporterModuleName"
         },
         {
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/ReporterModuleName",
+            "title": "name"
           },
           "maxItems": 1,
           "minItems": 1,
@@ -1121,10 +1130,12 @@
         {
           "items": [
             {
-              "type": "string"
+              "$ref": "#/definitions/ReporterModuleName",
+              "title": "name"
             },
             {
-              "$ref": "#/definitions/Serializable"
+              "$ref": "#/definitions/ReporterOptions",
+              "title": "options"
             }
           ],
           "maxItems": 2,
@@ -1132,7 +1143,7 @@
           "type": "array"
         }
       ],
-      "description": "Reporter name or reporter name + reporter config."
+      "description": "Declare a reporter to use.\n\n`default` - is a special name for the default cli reporter.\n\nExamples:\n- `\"default\"` - to use the default reporter\n- `\"@cspell/cspell-json-reporter\"` - use the cspell JSON reporter.\n- `[\"@cspell/cspell-json-reporter\", { \"outFile\": \"out.json\" }]`"
     },
     "Serializable": {
       "anyOf": [
@@ -1373,7 +1384,7 @@
       "type": "number"
     },
     "maxNumberOfProblems": {
-      "default": 100,
+      "default": 10000,
       "description": "The maximum number of problems to report in a file.",
       "type": "number"
     },
@@ -1434,7 +1445,10 @@
       "type": "boolean"
     },
     "reporters": {
-      "description": "Custom reporters configuration.",
+      "default": [
+        "default"
+      ],
+      "description": "Define which reports to use. `default` - is a special name for the default cli reporter.\n\nExamples:\n- `[\"default\"]` - to use the default reporter\n- `[\"@cspell/cspell-json-reporter\"]` - use the cspell JSON reporter.\n- `[[\"@cspell/cspell-json-reporter\", { \"outFile\": \"out.json\" }]]`\n- `[ \"default\", [\"@cspell/cspell-json-reporter\", { \"outFile\": \"out.json\" }]]` - Use both the default reporter and the cspell-json-reporter.",
       "items": {
         "$ref": "#/definitions/ReporterSettings"
       },

--- a/packages/cspell-types/src/CSpellReporter.ts
+++ b/packages/cspell-types/src/CSpellReporter.ts
@@ -110,14 +110,58 @@ export interface RunResult {
 export type ResultEmitter = (result: RunResult) => void | Promise<void>;
 
 export interface CSpellReporter {
-    issue: SpellingErrorEmitter;
-    info: MessageEmitter;
-    debug: DebugEmitter;
-    error: ErrorEmitter;
-    progress: ProgressEmitter;
-    result: ResultEmitter;
+    issue?: SpellingErrorEmitter;
+    info?: MessageEmitter;
+    debug?: DebugEmitter;
+    error?: ErrorEmitter;
+    progress?: ProgressEmitter;
+    result?: ResultEmitter;
 }
 
+export interface ReporterConfigurationBase {
+    /**
+     * The maximum number of problems to report in a file.
+     *
+     * @default 10000
+     */
+    maxNumberOfProblems?: number;
+
+    /**
+     * The maximum number of times the same word can be flagged as an error in a file.
+     *
+     * @default 5
+     */
+    maxDuplicateProblems?: number;
+
+    /**
+     * The minimum length of a word before checking it against a dictionary.
+     *
+     * @default 4
+     */
+    minWordLength?: number;
+}
+
+interface ReporterCommandLineOptions {
+    /**
+     * Display verbose information
+     */
+    verbose?: boolean;
+    /**
+     * Show extensive output.
+     */
+    debug?: boolean;
+    /**
+     * Only report the words, no line numbers or file names.
+     */
+    wordsOnly?: boolean;
+    /**
+     * unique errors per file only.
+     */
+    unique?: boolean;
+}
+
+export interface ReporterConfiguration extends ReporterCommandLineOptions, ReporterConfigurationBase {}
+
 export interface CSpellReporterModule {
-    getReporter: (settings: unknown) => CSpellReporter;
+    getReporter: (settings: unknown, config: ReporterConfiguration) => CSpellReporter;
 }

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -1,3 +1,4 @@
+import type { ReporterConfigurationBase } from './CSpellReporter.js';
 import type { DictionaryDefinition, DictionaryReference } from './DictionaryDefinition.js';
 import type { Features } from './features.js';
 import type { Parser, ParserName } from './Parser/index.js';
@@ -111,7 +112,16 @@ export interface FileSettings extends ExtendableSettings, CommandLineSettings {
     readonly?: boolean;
 
     /**
-     * Custom reporters configuration.
+     * Define which reports to use.
+     * `default` - is a special name for the default cli reporter.
+     *
+     * Examples:
+     * - `["default"]` - to use the default reporter
+     * - `["@cspell/cspell-json-reporter"]` - use the cspell JSON reporter.
+     * - `[["@cspell/cspell-json-reporter", { "outFile": "out.json" }]]`
+     * - `[ "default", ["@cspell/cspell-json-reporter", { "outFile": "out.json" }]]` - Use both the default reporter and the cspell-json-reporter.
+     *
+     * @default ["default"]
      */
     reporters?: ReporterSettings[];
 
@@ -226,28 +236,7 @@ export interface Settings extends ReportingConfiguration, BaseSetting, PnPSettin
     loadDefaultConfiguration?: boolean;
 }
 
-export interface ReportingConfiguration extends SuggestionsConfiguration {
-    /**
-     * The maximum number of problems to report in a file.
-     *
-     * @default 100
-     */
-    maxNumberOfProblems?: number;
-
-    /**
-     * The maximum number of times the same word can be flagged as an error in a file.
-     *
-     * @default 5
-     */
-    maxDuplicateProblems?: number;
-
-    /**
-     * The minimum length of a word before checking it against a dictionary.
-     *
-     * @default 4
-     */
-    minWordLength?: number;
-}
+export interface ReportingConfiguration extends ReporterConfigurationBase, SuggestionsConfiguration {}
 
 export interface SuggestionsConfiguration {
     /**
@@ -770,9 +759,29 @@ interface BaseSource {
 }
 
 /**
- * Reporter name or reporter name + reporter config.
+ * The module or path to the the reporter to load.
  */
-export type ReporterSettings = string | [string] | [string, Serializable];
+export type ReporterModuleName = string;
+
+/**
+ * Options to send to the reporter. These are defined by the reporter.
+ */
+export type ReporterOptions = Serializable;
+
+/**
+ * Declare a reporter to use.
+ *
+ * `default` - is a special name for the default cli reporter.
+ *
+ * Examples:
+ * - `"default"` - to use the default reporter
+ * - `"@cspell/cspell-json-reporter"` - use the cspell JSON reporter.
+ * - `["@cspell/cspell-json-reporter", { "outFile": "out.json" }]`
+ */
+export type ReporterSettings =
+    | ReporterModuleName
+    | [name: ReporterModuleName]
+    | [name: ReporterModuleName, options: ReporterOptions];
 
 /**
  * Experimental Configuration / Options

--- a/packages/cspell-types/src/index.ts
+++ b/packages/cspell-types/src/index.ts
@@ -18,6 +18,7 @@ export type {
     ProgressFileComplete,
     ProgressItem,
     ProgressTypes,
+    ReporterConfiguration,
     ResultEmitter,
     RunResult,
     SpellingErrorEmitter,

--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -19,6 +19,7 @@ import type { BaseOptions, LegacyOptions, LinterCliOptions, SuggestionOptions, T
 import { fixLegacy } from './options';
 import { simpleRepl } from './repl';
 import { fileInfoToDocument, readConfig, readFileInfo } from './util/fileHelper';
+import { finalizeReporter } from './util/reporters';
 import { readStdin } from './util/stdin';
 import { getTimeMeasurer } from './util/timer';
 import * as util from './util/util';
@@ -29,7 +30,11 @@ export type AppError = NodeJS.ErrnoException;
 
 export function lint(fileGlobs: string[], options: LinterCliOptions, reporter?: CSpellReporter): Promise<RunResult> {
     options = fixLegacy(options);
-    const cfg = new LintRequest(fileGlobs, options, reporter ?? getReporter({ ...options, fileGlobs }));
+    const cfg = new LintRequest(
+        fileGlobs,
+        options,
+        finalizeReporter(reporter) ?? getReporter({ ...options, fileGlobs })
+    );
     return runLint(cfg);
 }
 

--- a/packages/cspell/src/cli-reporter.ts
+++ b/packages/cspell/src/cli-reporter.ts
@@ -1,5 +1,4 @@
 import type {
-    CSpellReporter,
     Issue,
     MessageType,
     ProgressFileBegin,
@@ -14,6 +13,7 @@ import * as path from 'path';
 import { URI } from 'vscode-uri';
 
 import type { LinterCliOptions } from './options';
+import type { FinalizedReporter } from './util/reporters';
 
 const templateIssue = `{green $filename}:{yellow $row:$col} - $message ({red $text})`;
 const templateIssueWithSuggestions = `{green $filename}:{yellow $row:$col} - $message ({red $text}) Suggestions: {yellow [$suggestions]}`;
@@ -118,7 +118,7 @@ export interface ReporterOptions
     fileGlobs: string[];
 }
 
-export function getReporter(options: ReporterOptions): CSpellReporter {
+export function getReporter(options: ReporterOptions): FinalizedReporter {
     const issueTemplate = options.wordsOnly
         ? templateIssueWordsOnly
         : options.legacy
@@ -161,7 +161,7 @@ export function getReporter(options: ReporterOptions): CSpellReporter {
         }
         if (result.cachedFiles) {
             console.error(
-                'CSpell: Files checked: %d (%d from cache), Issues found: %d in %d files',
+                'CSpell\x3a Files checked: %d (%d from cache), Issues found: %d in %d files',
                 result.files,
                 result.cachedFiles,
                 result.issues,
@@ -171,7 +171,7 @@ export function getReporter(options: ReporterOptions): CSpellReporter {
         }
 
         console.error(
-            'CSpell: Files checked: %d, Issues found: %d in %d files',
+            'CSpell\x3a Files checked: %d, Issues found: %d in %d files',
             result.files,
             result.issues,
             result.filesWithIssues.size

--- a/packages/cspell/src/lint/LintRequest.ts
+++ b/packages/cspell/src/lint/LintRequest.ts
@@ -1,9 +1,10 @@
-import type { CSpellReporter, Issue } from '@cspell/cspell-types';
+import type { Issue } from '@cspell/cspell-types';
 import * as path from 'path';
 
 import type { LinterOptions } from '../options';
 import type { GlobSrcInfo } from '../util/glob';
 import { calcExcludeGlobInfo } from '../util/glob';
+import type { FinalizedReporter } from '../util/reporters';
 import * as util from '../util/util';
 
 const defaultContextRange = 20;
@@ -26,7 +27,7 @@ export class LintRequest {
     constructor(
         readonly fileGlobs: string[],
         readonly options: LinterOptions & Deprecated,
-        readonly reporter: CSpellReporter
+        readonly reporter: FinalizedReporter
     ) {
         this.root = path.resolve(options.root || process.cwd());
         this.configFile = options.config;

--- a/packages/cspell/src/util/reporters.test.ts
+++ b/packages/cspell/src/util/reporters.test.ts
@@ -4,6 +4,15 @@ import { MessageTypes } from '@cspell/cspell-types';
 import { InMemoryReporter } from './InMemoryReporter';
 import { loadReporters, mergeReporters } from './reporters';
 
+const defaultReporter: CSpellReporter = {
+    issue: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    progress: jest.fn(),
+    result: jest.fn(),
+};
+
 describe('mergeReporters', () => {
     it('processes a single reporter', async () => {
         const reporter = new InMemoryReporter();
@@ -23,7 +32,7 @@ describe('mergeReporters', () => {
 
     test('loadReporters', () => {
         const reporters: ReporterSettings[] = [['@cspell/cspell-json-reporter', { outFile: 'out.json' }]];
-        const loaded = loadReporters({ reporters });
+        const loaded = loadReporters({ reporters }, defaultReporter, {});
         expect(loaded).toEqual([expect.objectContaining({})]);
     });
 
@@ -34,23 +43,23 @@ describe('mergeReporters', () => {
         ${'@cspell/cspell-unknown-reporter'}   | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
     `('loadReporters fail $reporter', ({ reporter, expected }) => {
         const reporters: ReporterSettings[] = [reporter];
-        const fn = () => loadReporters({ reporters });
+        const fn = () => loadReporters({ reporters }, defaultReporter, {});
         expect(fn).toThrow(expected);
     });
 });
 
 async function runReporter(reporter: CSpellReporter): Promise<void> {
-    reporter.debug('foo');
-    reporter.debug('bar');
+    reporter.debug?.('foo');
+    reporter.debug?.('bar');
 
-    reporter.error('something went wrong', new Error('oh geez'));
+    reporter.error?.('something went wrong', new Error('oh geez'));
 
-    reporter.info('some logs', MessageTypes.Info);
-    reporter.info('some warnings', MessageTypes.Warning);
-    reporter.info('some debug logs', MessageTypes.Debug);
+    reporter.info?.('some logs', MessageTypes.Info);
+    reporter.info?.('some warnings', MessageTypes.Warning);
+    reporter.info?.('some debug logs', MessageTypes.Debug);
 
     // cSpell:disable
-    reporter.issue({
+    reporter.issue?.({
         text: 'fulll',
         offset: 13,
         line: { text: 'This text is fulll of errrorrrs.', offset: 0 },
@@ -61,7 +70,7 @@ async function runReporter(reporter: CSpellReporter): Promise<void> {
     });
     // cSpell:enable
 
-    reporter.progress({
+    reporter.progress?.({
         type: 'ProgressFileComplete',
         fileNum: 1,
         fileCount: 1,
@@ -71,7 +80,7 @@ async function runReporter(reporter: CSpellReporter): Promise<void> {
         numErrors: 2,
     });
 
-    await reporter.result({
+    await reporter.result?.({
         files: 1,
         filesWithIssues: new Set(['text.txt']),
         issues: 2,


### PR DESCRIPTION
## Minor Breakage
If a configuration contains a custom reporter, the default cli reporter will no longer be called. The fix is to add `"default"` to the list of `"reporters"`.

<details>
<summary>Fix to Breakage</summary>
Old `cspell.json`

```js
//...
"reporters": ["./my-custom-reporter.cjs"]
```

Becomes


```js
//...
"reporters": ["./my-custom-reporter.cjs", "default"]
```
</details>

## Problem
It is was not possible to disable the default cli reporter when using a custom reporter. This made custom reporters less useful in a CI/CD environment with structured logging.

## Solution
If a custom reporter is defined, disable the default reporter. Allow the `"default"` reporter to be re-enabled by explicitly including it in the `"reporters"` list.