### PR TITLE
feat: JSON Reporter, support output to `stdout`

### DIFF
--- a/packages/cspell-json-reporter/README.md
+++ b/packages/cspell-json-reporter/README.md
@@ -37,7 +37,52 @@ or `cspell.json`
 - `info` - CSpell execution logs if `settings.verbose` is enabled
 - `debug` - CSpell debug logs if `settings.debug` is enabled
 
-See [CSpellJSONReporterOutput](https://github.com/streetsidesoftware/cspell/blob/main/packages/cspell-json-reporter/src/CSpellJSONReporterOutput.ts) for more info.
+<details>
+<summary>JSON Output Definition</summary>
+
+<!--- @@inject: src/CSpellJSONReporterOutput.ts --->
+
+```ts
+import type {
+  ErrorLike,
+  Issue,
+  MessageType,
+  ProgressFileComplete,
+  ProgressItem,
+  RunResult,
+} from '@cspell/cspell-types';
+
+export type CSpellJSONReporterOutput = {
+  /**
+   * Found spelling issues
+   */
+  issues: Array<Issue>;
+  /**
+   * CSpell execution logs
+   */
+  info: Array<{ message: string; msgType: MessageType }>;
+  /**
+   * CSpell debug logs
+   */
+  debug: Array<{ message: string }>;
+  /**
+   * CSpell error logs
+   */
+  error: Array<{ message: string; error: ErrorLike }>;
+  /**
+   * CSpell file progress logs
+   */
+  progress: Array<ProgressItem | ProgressFileComplete>;
+  /**
+   * Execution result
+   */
+  result: RunResult;
+};
+```
+
+<!--- @@inject-end: src/CSpellJSONReporterOutput.ts --->
+
+</details>
 
 ## Settings
 
@@ -48,4 +93,38 @@ Possible settings:
 - `debug` (default: false) - enable saving of debug logs
 - `progress` (default: false) - enable saving of file progress logs
 
-See [CSpellJSONReporterSettings](https://github.com/streetsidesoftware/cspell/blob/main/packages/cspell-json-reporter/src/CSpellJSONReporterSettings.ts) for more info.
+<details>
+<summary>Reporter Settings</summary>
+
+<!--- @@inject: src/CSpellJSONReporterSettings.ts --->
+
+```ts
+/**
+ * CSpell-json-reporter settings type definition
+ */
+export type CSpellJSONReporterSettings = {
+  /**
+   * Output JSON file path
+   */
+  outFile: string;
+  /**
+   * Add more information about the files being checked and the configuration
+   * @default false
+   */
+  verbose?: boolean;
+  /**
+   * Add information useful for debugging cspell.json files
+   * @default false
+   */
+  debug?: boolean;
+  /**
+   * Add progress messages
+   * @default false
+   */
+  progress?: boolean;
+};
+```
+
+<!--- @@inject-end: src/CSpellJSONReporterSettings.ts --->
+
+</details>

--- a/packages/cspell-json-reporter/src/CSpellJSONReporterOutput.ts
+++ b/packages/cspell-json-reporter/src/CSpellJSONReporterOutput.ts
@@ -15,19 +15,19 @@ export type CSpellJSONReporterOutput = {
     /**
      * CSpell execution logs
      */
-    info: Array<{ message: string; msgType: MessageType }>;
+    info?: Array<{ message: string; msgType: MessageType }>;
     /**
      * CSpell debug logs
      */
-    debug: Array<{ message: string }>;
+    debug?: Array<{ message: string }>;
     /**
      * CSpell error logs
      */
-    error: Array<{ message: string; error: ErrorLike }>;
+    error?: Array<{ message: string; error: ErrorLike }>;
     /**
      * CSpell file progress logs
      */
-    progress: Array<ProgressItem | ProgressFileComplete>;
+    progress?: Array<ProgressItem | ProgressFileComplete>;
     /**
      * Execution result
      */

--- a/packages/cspell-json-reporter/src/CSpellJSONReporterSettings.ts
+++ b/packages/cspell-json-reporter/src/CSpellJSONReporterSettings.ts
@@ -3,9 +3,17 @@
  */
 export type CSpellJSONReporterSettings = {
     /**
-     * Output JSON file path
+     * Path to the output file.
+     *
+     * Relative paths are relative to the current working directory.
+     *
+     * Special values:
+     * - `stdout` - write the JSON to `stdout`.
+     * - `stderr` - write the JSON to `stderr`.
+     *
+     * @default stdout
      */
-    outFile: string;
+    outFile?: string;
     /**
      * Add more information about the files being checked and the configuration
      * @default false

--- a/packages/cspell-json-reporter/src/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-json-reporter/src/__snapshots__/index.test.ts.snap
@@ -115,4 +115,192 @@ exports[`getReporter saves json to file 1`] = `
 }"
 `;
 
+exports[`getReporter saves json to stdout/stderr {"outFile": "stderr"} 1`] = `
+"{
+    "issues": [
+        {
+            "text": "fulll",
+            "offset": 13,
+            "line": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            },
+            "row": 1,
+            "col": 14,
+            "uri": "text.txt",
+            "context": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            }
+        }
+    ],
+    "info": [
+        {
+            "message": "some warnings",
+            "msgType": "Warning"
+        }
+    ],
+    "debug": [],
+    "error": [
+        {
+            "message": "something went wrong",
+            "error": {}
+        }
+    ],
+    "progress": [],
+    "result": {
+        "files": 1,
+        "filesWithIssues": [
+            "text.txt"
+        ],
+        "issues": 2,
+        "errors": 1,
+        "cachedFiles": 0
+    }
+}"
+`;
+
+exports[`getReporter saves json to stdout/stderr {"outFile": "stderr"} 2`] = `""`;
+
+exports[`getReporter saves json to stdout/stderr {"outFile": "stdout"} 1`] = `""`;
+
+exports[`getReporter saves json to stdout/stderr {"outFile": "stdout"} 2`] = `
+"{
+    "issues": [
+        {
+            "text": "fulll",
+            "offset": 13,
+            "line": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            },
+            "row": 1,
+            "col": 14,
+            "uri": "text.txt",
+            "context": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            }
+        }
+    ],
+    "info": [
+        {
+            "message": "some warnings",
+            "msgType": "Warning"
+        }
+    ],
+    "debug": [],
+    "error": [
+        {
+            "message": "something went wrong",
+            "error": {}
+        }
+    ],
+    "progress": [],
+    "result": {
+        "files": 1,
+        "filesWithIssues": [
+            "text.txt"
+        ],
+        "issues": 2,
+        "errors": 1,
+        "cachedFiles": 0
+    }
+}"
+`;
+
+exports[`getReporter saves json to stdout/stderr {"outFile": undefined} 1`] = `""`;
+
+exports[`getReporter saves json to stdout/stderr {"outFile": undefined} 2`] = `
+"{
+    "issues": [
+        {
+            "text": "fulll",
+            "offset": 13,
+            "line": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            },
+            "row": 1,
+            "col": 14,
+            "uri": "text.txt",
+            "context": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            }
+        }
+    ],
+    "info": [
+        {
+            "message": "some warnings",
+            "msgType": "Warning"
+        }
+    ],
+    "debug": [],
+    "error": [
+        {
+            "message": "something went wrong",
+            "error": {}
+        }
+    ],
+    "progress": [],
+    "result": {
+        "files": 1,
+        "filesWithIssues": [
+            "text.txt"
+        ],
+        "issues": 2,
+        "errors": 1,
+        "cachedFiles": 0
+    }
+}"
+`;
+
+exports[`getReporter saves json to stdout/stderr undefined 1`] = `""`;
+
+exports[`getReporter saves json to stdout/stderr undefined 2`] = `
+"{
+    "issues": [
+        {
+            "text": "fulll",
+            "offset": 13,
+            "line": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            },
+            "row": 1,
+            "col": 14,
+            "uri": "text.txt",
+            "context": {
+                "text": "This text is fulll of errrorrrs.",
+                "offset": 0
+            }
+        }
+    ],
+    "info": [
+        {
+            "message": "some warnings",
+            "msgType": "Warning"
+        }
+    ],
+    "debug": [],
+    "error": [
+        {
+            "message": "something went wrong",
+            "error": {}
+        }
+    ],
+    "progress": [],
+    "result": {
+        "files": 1,
+        "filesWithIssues": [
+            "text.txt"
+        ],
+        "issues": 2,
+        "errors": 1,
+        "cachedFiles": 0
+    }
+}"
+`;
+
 exports[`getReporter throws for invalid config 1`] = `"cspell-json-reporter settings.outFile must be a string"`;

--- a/packages/cspell-json-reporter/src/utils/__snapshots__/validateSettings.test.ts.snap
+++ b/packages/cspell-json-reporter/src/utils/__snapshots__/validateSettings.test.ts.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validateSettings throws for invalid settings 1`] = `"cspell-json-reporter settings.outFile must be a string"`;
+exports[`validateSettings throws for invalid settings [] 1`] = `"cspell-json-reporter settings must be an object"`;
 
-exports[`validateSettings throws for invalid settings 2`] = `"cspell-json-reporter settings must be an object"`;
+exports[`validateSettings throws for invalid settings {"debug": [Array], "outFile": "foobar"} 1`] = `"cspell-json-reporter settings.debug must be a boolean"`;
 
-exports[`validateSettings throws for invalid settings 3`] = `"cspell-json-reporter settings.outFile must be a string"`;
+exports[`validateSettings throws for invalid settings {"outFile": "foobar", "verbose": 123} 1`] = `"cspell-json-reporter settings.verbose must be a boolean"`;
 
-exports[`validateSettings throws for invalid settings 4`] = `"cspell-json-reporter settings.outFile must be a string"`;
+exports[`validateSettings throws for invalid settings {"outFile": [Object]} 1`] = `"cspell-json-reporter settings.outFile must be a string"`;
 
-exports[`validateSettings throws for invalid settings 5`] = `"cspell-json-reporter settings.verbose must be a boolean"`;
+exports[`validateSettings throws for invalid settings {"outFile": 1} 1`] = `"cspell-json-reporter settings.outFile must be a string"`;
 
-exports[`validateSettings throws for invalid settings 6`] = `"cspell-json-reporter settings.debug must be a boolean"`;
+exports[`validateSettings throws for invalid settings false 1`] = `"cspell-json-reporter settings must be an object"`;
+
+exports[`validateSettings throws for invalid settings hello 1`] = `"cspell-json-reporter settings must be an object"`;
+
+exports[`validateSettings throws for invalid settings true 1`] = `"cspell-json-reporter settings must be an object"`;

--- a/packages/cspell-json-reporter/src/utils/validateSettings.test.ts
+++ b/packages/cspell-json-reporter/src/utils/validateSettings.test.ts
@@ -15,12 +15,14 @@ describe('validateSettings', () => {
     test.each`
         settings
         ${[]}
-        ${undefined}
-        ${{}}
+        ${false}
+        ${true}
+        ${'hello'}
+        ${{ outFile: {} }}
         ${{ outFile: 1 }}
         ${{ outFile: 'foobar', verbose: 123 }}
         ${{ outFile: 'foobar', debug: [] }}
-    `('throws for invalid settings', ({ settings }) => {
+    `('throws for invalid settings $settings', ({ settings }) => {
         expect(() => validateSettings(settings)).toThrowErrorMatchingSnapshot();
     });
 });

--- a/packages/cspell-json-reporter/src/utils/validateSettings.ts
+++ b/packages/cspell-json-reporter/src/utils/validateSettings.ts
@@ -16,7 +16,7 @@ function assertBooleanOrUndefined(key: string, value: unknown): asserts value is
  * Throws an error if passed cspell-json-reporter settings are invalid
  */
 export function validateSettings(settings: unknown): asserts settings is CSpellJSONReporterSettings {
-    if (!settings || typeof settings !== 'object') {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
         throw new AssertionError({
             message: 'cspell-json-reporter settings must be an object',
             actual: typeof settings,
@@ -24,7 +24,7 @@ export function validateSettings(settings: unknown): asserts settings is CSpellJ
         });
     }
 
-    const { outFile, debug, verbose, progress } = settings as CSpellJSONReporterSettings;
+    const { outFile = 'stdout', debug, verbose, progress } = settings as CSpellJSONReporterSettings;
 
     if (typeof outFile !== 'string') {
         throw new AssertionError({

--- a/packages/cspell-types/src/CSpellReporter.ts
+++ b/packages/cspell-types/src/CSpellReporter.ts
@@ -158,6 +158,10 @@ interface ReporterCommandLineOptions {
      * unique errors per file only.
      */
     unique?: boolean;
+    /**
+     * root directory, defaults to `cwd`
+     */
+    root?: string;
 }
 
 export interface ReporterConfiguration extends ReporterCommandLineOptions, ReporterConfigurationBase {}

--- a/packages/cspell/src/util/reporters.test.ts
+++ b/packages/cspell/src/util/reporters.test.ts
@@ -37,10 +37,10 @@ describe('mergeReporters', () => {
     });
 
     test.each`
-        reporter                               | expected
-        ${['@cspell/cspell-json-reporter']}    | ${'Failed to load reporter @cspell/cspell-json-reporter: cspell-json-reporter settings must be an object'}
-        ${['@cspell/cspell-unknown-reporter']} | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
-        ${'@cspell/cspell-unknown-reporter'}   | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
+        reporter                                   | expected
+        ${['@cspell/cspell-json-reporter', false]} | ${'Failed to load reporter @cspell/cspell-json-reporter: cspell-json-reporter settings must be an object'}
+        ${['@cspell/cspell-unknown-reporter']}     | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
+        ${'@cspell/cspell-unknown-reporter'}       | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
     `('loadReporters fail $reporter', ({ reporter, expected }) => {
         const reporters: ReporterSettings[] = [reporter];
         const fn = () => loadReporters({ reporters }, defaultReporter, {});


### PR DESCRIPTION
Enable `@cspell/cspell-json-reporter` so that it can output to `stdout` and `stderr` as well as a file.