### PR TITLE
fix(lint): make reporter parameter partial

### DIFF
--- a/packages/cspell/src/application.ts
+++ b/packages/cspell/src/application.ts
@@ -28,7 +28,7 @@ export { IncludeExcludeFlag } from 'cspell-lib';
 
 export type AppError = NodeJS.ErrnoException;
 
-export function lint(fileGlobs: string[], options: LinterCliOptions, reporter?: CSpellReporter): Promise<RunResult> {
+export function lint(fileGlobs: string[], options: LinterCliOptions, reporter?: Partial<CSpellReporter>): Promise<RunResult> {
     options = fixLegacy(options);
     const cfg = new LintRequest(
         fileGlobs,


### PR DESCRIPTION
None of the emitters in the `reporter` object are required because they go through `finalizeReporter` and `mergeReporters`. The types should reflect that by enclosing `CSpellReporter` in `Partial`. Otherwise, if you only wanted to use the `issue` emitter, you'd be stuck with:

```ts
await lint(
	program.processedArgs[0],
	{},
	{
		debug: () => {},
		info: () => {},
		progress: () => {},
		result: () => {},
		error: () => {},
		issue: handleIssueOrSomething
	}
);
```