### PR TITLE
feat: Support ESM reporters

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,22 +45,6 @@ const config = {
     plugins: ['import', 'unicorn', 'simple-import-sort'],
     overrides: [
         {
-            file: ['**/*.js'],
-            parserOptions: {
-                ecmaVersion: 2020,
-                sourceType: 'module',
-            },
-            rules: {
-                'node/no-unsupported-features/es-syntax': [
-                    'error',
-                    {
-                        version: '>=13.0.0',
-                        ignores: ['modules'],
-                    },
-                ],
-            },
-        },
-        {
             files: ['**/*.ts', '**/*.mts'],
             extends: ['plugin:@typescript-eslint/recommended', 'plugin:import/typescript'],
             parser: '@typescript-eslint/parser',
@@ -114,6 +98,16 @@ const config = {
                 'unicorn/prevent-abbreviations': 'off',
                 'unicorn/consistent-function-scoping': 'off',
                 'unicorn/filename-case': 'off',
+            },
+        },
+        {
+            files: ['**/*.js'],
+            parserOptions: {
+                ecmaVersion: 2020,
+                sourceType: 'module',
+            },
+            rules: {
+                'node/no-unsupported-features/es-syntax': 'off',
             },
         },
     ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,22 @@ const config = {
     plugins: ['import', 'unicorn', 'simple-import-sort'],
     overrides: [
         {
+            file: ['**/*.js'],
+            parserOptions: {
+                ecmaVersion: 2020,
+                sourceType: 'module',
+            },
+            rules: {
+                'node/no-unsupported-features/es-syntax': [
+                    'error',
+                    {
+                        version: '>=13.0.0',
+                        ignores: ['modules'],
+                    },
+                ],
+            },
+        },
+        {
             files: ['**/*.ts', '**/*.mts'],
             extends: ['plugin:@typescript-eslint/recommended', 'plugin:import/typescript'],
             parser: '@typescript-eslint/parser',

--- a/packages/cspell-eslint-plugin/src/worker.js
+++ b/packages/cspell-eslint-plugin/src/worker.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable node/no-missing-import */
-/* eslint-disable node/no-unsupported-features/es-syntax */
+
 // @ts-check
 
 /**

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -106,6 +106,7 @@
     "micromatch": "^4.0.5",
     "minimatch": "^6.1.6",
     "rollup": "^3.13.0",
-    "rollup-plugin-dts": "^5.1.1"
+    "rollup-plugin-dts": "^5.1.1",
+    "vitest": "^0.28.4"
   }
 }

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -75,6 +75,7 @@
   "homepage": "https://streetsidesoftware.github.io/cspell/",
   "dependencies": {
     "@cspell/cspell-pipe": "workspace:*",
+    "@cspell/dynamic-import": "workspace:*",
     "chalk": "^4.1.2",
     "commander": "^10.0.0",
     "cspell-gitignore": "workspace:*",

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -46,11 +46,13 @@
     "clean-build": "pnpm run clean && pnpm run build",
     "compile": "tsc -p .",
     "watch": "tsc --watch -p .",
-    "coverage": "jest --coverage",
-    "test-watch": "jest --watch",
+    "coverage": "pnpm coverage:vitest && pnpm coverage:fix",
+    "coverage:vitest": "vitest run --coverage",
+    "coverage:fix": "nyc report --temp-dir \"$(pwd)/coverage\" --reporter lcov --report-dir \"$(pwd)/coverage\" --cwd ../..",
+    "test-watch": "vitest",
     "prepublishOnly": "pnpm run clean-build",
-    "test": "jest --maxWorkers=1",
-    "test:update-snapshot": "jest --updateSnapshot"
+    "test": "vitest run",
+    "test:update-snapshot": "vitest run --updateSnapshot"
   },
   "repository": {
     "type": "git",
@@ -101,10 +103,10 @@
     "@types/imurmurhash": "^0.1.1",
     "@types/micromatch": "^4.0.2",
     "@types/semver": "^7.3.13",
-    "jest": "^29.4.1",
     "micromatch": "^4.0.5",
     "minimatch": "^6.1.6",
     "rollup": "^3.13.0",
-    "rollup-plugin-dts": "^5.1.1"
+    "rollup-plugin-dts": "^5.1.1",
+    "vitest-mock-process": "^1.0.4"
   }
 }

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -106,7 +106,6 @@
     "micromatch": "^4.0.5",
     "minimatch": "^6.1.6",
     "rollup": "^3.13.0",
-    "rollup-plugin-dts": "^5.1.1",
-    "vitest-mock-process": "^1.0.4"
+    "rollup-plugin-dts": "^5.1.1"
   }
 }

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -1,8 +1,8 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1
 
-exports[`Validate cli app --fail-fast no option Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app '--fail-fast no option' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app --fail-fast no option Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app '--fail-fast no option' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/fail-fast/first-fail.txt:1:1 - Unknown word (iamtypo)
 error	 0.00ms X
@@ -10,39 +10,39 @@ log	./samples/fail-fast/second-fail.txt:1:1 - Unknown word (iamtypotoo)
 error	CSpell: Files checked: 2, Issues found: 2 in 2 files"
 `;
 
-exports[`Validate cli app --fail-fast no option Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app '--fail-fast no option' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/2 [90m./samples/fail-fast/first-fail.txt[39m
 2/2 [90m./samples/fail-fast/second-fail.txt[39m"
 `;
 
-exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app '--fail-fast with config' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app '--fail-fast with config' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/fail-fast/first-fail.txt:1:1 - Unknown word (iamtypo)
 error	CSpell: Files checked: 1, Issues found: 1 in 1 files"
 `;
 
-exports[`Validate cli app --fail-fast with config Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app '--fail-fast with config' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/2 [90m./samples/fail-fast/first-fail.txt[39m"
 `;
 
-exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app '--fail-fast with option' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app '--fail-fast with option' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/fail-fast/first-fail.txt:1:1 - Unknown word (iamtypo)
 error	CSpell: Files checked: 1, Issues found: 1 in 1 files"
 `;
 
-exports[`Validate cli app --fail-fast with option Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app '--fail-fast with option' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/2 [90m./samples/fail-fast/first-fail.txt[39m"
 `;
 
-exports[`Validate cli app --help Expect Error: outputHelp 1`] = `
+exports[`Validate cli > app '--help' Expect Error: 'outputHelp' 1`] = `
 [
   "Usage: cspell [options] [command]",
   "",
@@ -67,13 +67,13 @@ exports[`Validate cli app --help Expect Error: outputHelp 1`] = `
 ]
 `;
 
-exports[`Validate cli app --help Expect Error: outputHelp 2`] = `""`;
+exports[`Validate cli > app '--help' Expect Error: 'outputHelp' 2`] = `""`;
 
-exports[`Validate cli app --help Expect Error: outputHelp 3`] = `""`;
+exports[`Validate cli > app '--help' Expect Error: 'outputHelp' 3`] = `""`;
 
-exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app '--no-fail-fast with config' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app '--no-fail-fast with config' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/fail-fast/first-fail.txt:1:1 - Unknown word (iamtypo)
 error	 0.00ms X
@@ -81,66 +81,66 @@ log	./samples/fail-fast/second-fail.txt:1:1 - Unknown word (iamtypotoo)
 error	CSpell: Files checked: 2, Issues found: 2 in 2 files"
 `;
 
-exports[`Validate cli app --no-fail-fast with config Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app '--no-fail-fast with config' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/2 [90m./samples/fail-fast/first-fail.txt[39m
 2/2 [90m./samples/fail-fast/second-fail.txt[39m"
 `;
 
-exports[`Validate cli app Explicit file:// Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'Explicit file://' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app Explicit file:// Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'Explicit file://' Expect Error: undefined 2`] = `
 "error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app Explicit file:// Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'Explicit file://' Expect Error: undefined 3`] = `
 "
 1/1 [90m./fixtures/misc/star-not.md[39m"
 `;
 
-exports[`Validate cli app Explicit not found file:// Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'Explicit not found file://' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app Explicit not found file:// Expect Error: [Function CheckFailed] 2`] = `
-"error	Linter: File not found: "./fixtures/misc/not-fond.md"
+exports[`Validate cli > app 'Explicit not found file://' Expect Error: [Function CheckFailed] 2`] = `
+"error	Linter: File not found: \\"./fixtures/misc/not-fond.md\\"
 error	 0.00ms skipped X
 error	CSpell: Files checked: 1, Issues found: 0 in 1 files"
 `;
 
-exports[`Validate cli app Explicit not found file:// Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app 'Explicit not found file://' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/1 [90m./fixtures/misc/not-fond.md[39m"
 `;
 
-exports[`Validate cli app LICENSE Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'LICENSE' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app LICENSE Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'LICENSE' Expect Error: undefined 2`] = `
 "error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app LICENSE Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'LICENSE' Expect Error: undefined 3`] = `
 "
 1/1 [90m./LICENSE[39m"
 `;
 
-exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'bad config' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 2`] = `
-"error	Configuration Error: Failed to find config file at: "./src/app.test.ts"
+exports[`Validate cli > app 'bad config' Expect Error: [Function CheckFailed] 2`] = `
+"error	Configuration Error: Failed to find config file at: \\"./src/app.test.ts\\"
 error	CSpell: Files checked: 0, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app bad config Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'bad config' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app check LICENSE Expect Error: undefined 1`] = `
+exports[`Validate cli > app 'check LICENSE' Expect Error: undefined 1`] = `
 [
   "[97mMIT License[39m",
   "[97m[39m",
   "[97mCopyright (c) 2017 Jason Dent[39m",
   "[97m[39m",
   "[97mPermission is hereby granted, free of charge, to any person obtaining a copy[39m",
-  "[97mof this software and associated documentation files (the "Software"), to deal[39m",
+  "[97mof this software and associated documentation files (the \\"Software\\"), to deal[39m",
   "[97min the Software without restriction, including without limitation the rights[39m",
   "[97mto use, copy, modify, merge, publish, distribute, sublicense, and/or sell[39m",
   "[97mcopies of the Software, and to permit persons to whom the Software is[39m",
@@ -149,7 +149,7 @@ exports[`Validate cli app check LICENSE Expect Error: undefined 1`] = `
   "[97mThe above copyright notice and this permission notice shall be included in all[39m",
   "[97mcopies or substantial portions of the Software.[39m",
   "[97m[39m",
-  "[97mTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR[39m",
+  "[97mTHE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR[39m",
   "[97mIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,[39m",
   "[97mFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE[39m",
   "[97mAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER[39m",
@@ -160,16 +160,16 @@ exports[`Validate cli app check LICENSE Expect Error: undefined 1`] = `
 ]
 `;
 
-exports[`Validate cli app check LICENSE Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'check LICENSE' Expect Error: undefined 2`] = `
 "log	Check file: ./LICENSE
 log	
 log	
 log	"
 `;
 
-exports[`Validate cli app check LICENSE Expect Error: undefined 3`] = `""`;
+exports[`Validate cli > app 'check LICENSE' Expect Error: undefined 3`] = `""`;
 
-exports[`Validate cli app check help Expect Error: outputHelp 1`] = `
+exports[`Validate cli > app 'check help' Expect Error: 'outputHelp' 1`] = `
 [
   "Usage: cspell check [options] <files...>",
   "",
@@ -190,24 +190,24 @@ exports[`Validate cli app check help Expect Error: outputHelp 1`] = `
 ]
 `;
 
-exports[`Validate cli app check help Expect Error: outputHelp 2`] = `""`;
+exports[`Validate cli > app 'check help' Expect Error: 'outputHelp' 2`] = `""`;
 
-exports[`Validate cli app check help Expect Error: outputHelp 3`] = `""`;
+exports[`Validate cli > app 'check help' Expect Error: 'outputHelp' 3`] = `""`;
 
-exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'check missing' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'check missing' Expect Error: [Function CheckFailed] 2`] = `
 "log	Check file: ./missing-file.txt
 log	
-error	File not found "./missing-file.txt""
+error	File not found \\"./missing-file.txt\\""
 `;
 
-exports[`Validate cli app check missing Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'check missing' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 1`] = `
+exports[`Validate cli > app 'check with spelling errors' Expect Error: [Function CheckFailed] 1`] = `
 [
   "[97m                              [[39m[31mNEDERLANDS[39m[97m][39m",
-  "[97m        U [39m[31mwordt[39m[97m [39m[31mvriendelijk[39m[97m [39m[31mverzocht[39m[97m om dit [39m[31mbestand[39m[97m ("README_nl_NL.txt")[39m",
+  "[97m        U [39m[31mwordt[39m[97m [39m[31mvriendelijk[39m[97m [39m[31mverzocht[39m[97m om dit [39m[31mbestand[39m[97m (\\"README_nl_NL.txt\\")[39m",
   "[97m      te [39m[31mlezen[39m[97m en mee te [39m[31mleveren[39m[97m bij [39m[31miedere[39m[97m [39m[31mkopie[39m[97m van dit [39m[31mtaalhulpbestand[39m[97m.[39m",
   "[97m[39m",
   "[97m1. [39m[31mNaam[39m[97m: [39m[31mNederlandstalige[39m[97m [39m[31mwoordenlijst[39m[97m [39m[31mvoor[39m[97m [39m[31mspellingcontrole[39m[97m - OpenTaal[39m",
@@ -235,7 +235,7 @@ exports[`Validate cli app check with spelling errors Expect Error: [Function Che
   "[97m   en het project [39m[31mprofessionaliseren[39m[97m. Uw [39m[31mdonatie[39m[97m is van harte [39m[31mwelkom[39m[97m op[39m",
   "[97m   [39m[31mrekeningnummer[39m[97m 15.62.32.782 t.n.v. [39m[31mStichting[39m[97m OpenTaal. Uw [39m[31mgiften[39m[97m [39m[31mzijn[39m[97m[39m",
   "[97m   [39m[31maftrekbaar[39m[97m van de [39m[31mbelasting[39m[97m. [39m[31mStichting[39m[97m OpenTaal is [39m[31mnamelijk[39m[97m door de[39m",
-  "[97m   [39m[31mBelastingdienst[39m[97m [39m[31merkend[39m[97m als [39m[31mANBI[39m[97m, [39m[31moftewel[39m[97m "[39m[31mAlgemeen[39m[97m Nut [39m[31mBeogende[39m[97m [39m[31mInstelling[39m[97m".[39m",
+  "[97m   [39m[31mBelastingdienst[39m[97m [39m[31merkend[39m[97m als [39m[31mANBI[39m[97m, [39m[31moftewel[39m[97m \\"[39m[31mAlgemeen[39m[97m Nut [39m[31mBeogende[39m[97m [39m[31mInstelling[39m[97m\\".[39m",
   "[97m   Zie: [39m[90mhttp://belastingdienst.nl/anbi/[39m[97m[39m",
   "[97m8. [39m[31mMeedoen[39m[97m: [39m[31mIedereen[39m[97m is [39m[31mwelkom[39m[97m om mee te [39m[31mdoen[39m[97m. Meld [39m[31mfouten[39m[97m, [39m[31mdiscussieer[39m[97m mee op[39m",
   "[97m   de [39m[31mmailinglijst[39m[97m of [39m[31mdraai[39m[97m Harvester. Door bij te [39m[31mdragen[39m[97m aan het project [39m[31mstemt[39m[97m[39m",
@@ -254,7 +254,7 @@ exports[`Validate cli app check with spelling errors Expect Error: [Function Che
   "[97m10.Contact: [39m[31mStichting[39m[97m OpenTaal, [39m[90mhttp://www.opentaal.org,[39m[97m [39m[90mbestuur@opentaal.org[39m[97m[39m",
   "[97m_________________________________________________________________________________[39m",
   "[97m                                [ENGLISH][39m",
-  "[97m        You are kindly requested to read this file "README_nl_NL.txt"[39m",
+  "[97m        You are kindly requested to read this file \\"README_nl_NL.txt\\"[39m",
   "[97m     and to keep a copy of it with every copy you make of this language file.[39m",
   "[97m[39m",
   "[97m1. Name: Dutch word list for spell checking - OpenTaal[39m",
@@ -303,39 +303,39 @@ exports[`Validate cli app check with spelling errors Expect Error: [Function Che
 ]
 `;
 
-exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'check with spelling errors' Expect Error: [Function CheckFailed] 2`] = `
 "log	Check file: ./samples/Dutch.txt
 log	
 log	
 log	"
 `;
 
-exports[`Validate cli app check with spelling errors Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'check with spelling errors' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app cspell-bad.json Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'cspell-bad.json' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app cspell-bad.json Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'cspell-bad.json' Expect Error: undefined 2`] = `
 "error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app cspell-bad.json Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'cspell-bad.json' Expect Error: undefined 3`] = `
 "
 1/1 [90m./src/app.test.ts[39m"
 `;
 
-exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'cspell-import-missing.json' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 2`] = `
-"error	Configuration Error: Failed to read config file: "./samples/intentionally-missing-file.json"
+exports[`Validate cli > app 'cspell-import-missing.json' Expect Error: [Function CheckFailed] 2`] = `
+"error	Configuration Error: Failed to read config file: \\"./samples/intentionally-missing-file.json\\"
 error	CSpell: Files checked: 0, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app cspell-import-missing.json Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'cspell-import-missing.json' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app current_file --verbose Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'current_file --verbose' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app current_file --verbose Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'current_file --verbose' Expect Error: undefined 2`] = `
 "info	
 info	cspell;
 info	Date: Sat, 03 Apr 2021 11:25:33 GMT
@@ -369,38 +369,38 @@ error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app current_file --verbose Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'current_file --verbose' Expect Error: undefined 3`] = `
 "
 1/1 [90m./src/app.test.ts[39m"
 `;
 
-exports[`Validate cli app current_file Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'current_file languageId' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app current_file Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'current_file languageId' Expect Error: undefined 2`] = `
 "error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app current_file Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'current_file languageId' Expect Error: undefined 3`] = `
 "
 1/1 [90m./src/app.test.ts[39m"
 `;
 
-exports[`Validate cli app current_file languageId Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'current_file' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app current_file languageId Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'current_file' Expect Error: undefined 2`] = `
 "error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app current_file languageId Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'current_file' Expect Error: undefined 3`] = `
 "
 1/1 [90m./src/app.test.ts[39m"
 `;
 
-exports[`Validate cli app issue-2998 --language-id Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'issue-2998 --language-id' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app issue-2998 --language-id Expect Error: undefined 2`] = `
+exports[`Validate cli > app 'issue-2998 --language-id' Expect Error: undefined 2`] = `
 "info	
 info	cspell;
 info	Date: Sat, 03 Apr 2021 11:25:33 GMT
@@ -426,53 +426,53 @@ error	 0.00ms
 error	CSpell: Files checked: 1, Issues found: 0 in 0 files"
 `;
 
-exports[`Validate cli app issue-2998 --language-id Expect Error: undefined 3`] = `
+exports[`Validate cli > app 'issue-2998 --language-id' Expect Error: undefined 3`] = `
 "
 1/1 [90m./fixtures/issue-2998/fix-words.txt[39m"
 `;
 
-exports[`Validate cli app link 1`] = `""`;
+exports[`Validate cli > app 'link add' 1`] = `""`;
 
-exports[`Validate cli app link add 1`] = `""`;
+exports[`Validate cli > app 'link list' 1`] = `""`;
 
-exports[`Validate cli app link list 1`] = `""`;
+exports[`Validate cli > app 'link ls' 1`] = `""`;
 
-exports[`Validate cli app link ls 1`] = `""`;
+exports[`Validate cli > app 'link remove' 1`] = `""`;
 
-exports[`Validate cli app link remove 1`] = `""`;
+exports[`Validate cli > app 'link' 1`] = `""`;
 
-exports[`Validate cli app must find force no error Expect Error: undefined 1`] = `[]`;
+exports[`Validate cli > app 'must find force no error' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app must find force no error Expect Error: undefined 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
+exports[`Validate cli > app 'must find force no error' Expect Error: undefined 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
-exports[`Validate cli app must find force no error Expect Error: undefined 3`] = `""`;
+exports[`Validate cli > app 'must find force no error' Expect Error: undefined 3`] = `""`;
 
-exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'must find with error' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
+exports[`Validate cli > app 'must find with error' Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
-exports[`Validate cli app must find with error Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'must find with error' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
+exports[`Validate cli > app 'no-args' Expect Error: 'outputHelp' 1`] = `
 [
   "Usage: cspell lint [options] [globs...] [file://<path> ...] [stdin[://<path>]]",
   "",
   "Patterns:",
   " - [globs...]            Glob Patterns",
-  " - [stdin]               Read from "stdin" assume text file.",
-  " - [stdin://<path>]      Read from "stdin", use <path> for file type and config.",
+  " - [stdin]               Read from \\"stdin\\" assume text file.",
+  " - [stdin://<path>]      Read from \\"stdin\\", use <path> for file type and config.",
   " - [file://<path>]       Check the file at <path>",
   "",
   "Examples:",
   "    cspell .                        Recursively check all files.",
-  "    cspell lint .                   The same as "cspell ."",
-  "    cspell "*.js"                   Check all .js files in the current directory",
-  "    cspell "**/*.js"                Check all .js files recursively",
-  "    cspell "src/**/*.js"            Only check .js under src",
-  "    cspell "**/*.txt" "**/*.js"     Check both .js and .txt files.",
-  "    cspell "**/*.{txt,js,md}"       Check .txt, .js, and .md files.",
+  "    cspell lint .                   The same as \\"cspell .\\"",
+  "    cspell \\"*.js\\"                   Check all .js files in the current directory",
+  "    cspell \\"**/*.js\\"                Check all .js files recursively",
+  "    cspell \\"src/**/*.js\\"            Only check .js under src",
+  "    cspell \\"**/*.txt\\" \\"**/*.js\\"     Check both .js and .txt files.",
+  "    cspell \\"**/*.{txt,js,md}\\"       Check .txt, .js, and .md files.",
   "    cat LICENSE | cspell stdin      Check stdin",
-  "    cspell stdin://docs/doc.md      Check stdin as if it was "./docs/doc.md"",
+  "    cspell stdin://docs/doc.md      Check stdin as if it was \\"./docs/doc.md\\"",
   "",
   "Check spelling",
   "",
@@ -481,10 +481,10 @@ exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
   "                               looks for cspell.json in the current directory.",
   "  -v, --verbose                Display more information about the files being",
   "                               checked and the configuration.",
-  "  --locale <locale>            Set language locales. i.e. "en,fr" for English",
-  "                               and French, or "en-GB" for British English.",
+  "  --locale <locale>            Set language locales. i.e. \\"en,fr\\" for English",
+  "                               and French, or \\"en-GB\\" for British English.",
   "  --language-id <language>     Force programming language for unknown",
-  "                               extensions. i.e. "php" or "scala"",
+  "                               extensions. i.e. \\"php\\" or \\"scala\\"",
   "  --words-only                 Only output the words not found in the",
   "                               dictionaries.",
   "  -u, --unique                 Only output the first instance of a word not",
@@ -509,9 +509,9 @@ exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
   "  --no-cache                   Do not use cache.",
   "  --cache-reset                Reset the cache file.",
   "  --cache-strategy <strategy>  Strategy to use for detecting changed files.",
-  "                               (choices: "metadata", "content")",
+  "                               (choices: \\"metadata\\", \\"content\\")",
   "  --cache-location <path>      Path to the cache file or directory. (default:",
-  "                               ".cspellcache")",
+  "                               \\".cspellcache\\")",
   "  --dot                        Include files and directories starting with \`.\`",
   "                               (period) when matching globs.",
   "  --gitignore                  Ignore files matching glob patterns found in",
@@ -532,9 +532,9 @@ exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
   "",
   "More Examples:",
   "",
-  "    cspell "**/*.js" --reporter @cspell/cspell-json-reporter",
-  "        This will spell check all ".js" files recursively and use",
-  "        "@cspell/cspell-json-reporter".",
+  "    cspell \\"**/*.js\\" --reporter @cspell/cspell-json-reporter",
+  "        This will spell check all \\".js\\" files recursively and use",
+  "        \\"@cspell/cspell-json-reporter\\".",
   "",
   "    cspell . --reporter default",
   "        This will force the default reporter to be used overriding",
@@ -551,19 +551,19 @@ exports[`Validate cli app no-args Expect Error: outputHelp 1`] = `
 ]
 `;
 
-exports[`Validate cli app no-args Expect Error: outputHelp 2`] = `""`;
+exports[`Validate cli > app 'no-args' Expect Error: 'outputHelp' 2`] = `""`;
 
-exports[`Validate cli app no-args Expect Error: outputHelp 3`] = `""`;
+exports[`Validate cli > app 'no-args' Expect Error: 'outputHelp' 3`] = `""`;
 
-exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'not found error by default' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
+exports[`Validate cli > app 'not found error by default' Expect Error: [Function CheckFailed] 2`] = `"error	CSpell: Files checked: 0, Issues found: 0 in 0 files"`;
 
-exports[`Validate cli app not found error by default Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'not found error by default' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'samples/Dutch.txt' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'samples/Dutch.txt' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/Dutch.txt:1:32 - Unknown word (NEDERLANDS)
 log	./samples/Dutch.txt:2:11 - Unknown word (wordt)
@@ -757,21 +757,14 @@ log	./samples/Dutch.txt:78:18 - Unknown word (ANBI)
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
-exports[`Validate cli app samples/Dutch.txt Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app 'samples/Dutch.txt' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/1 [90m./samples/Dutch.txt[39m"
 `;
 
-exports[`Validate cli app success suggest run with ["suggest", "café", "--num-suggestions=1", "--no-include-ties"] 1`] = `[]`;
+exports[`Validate cli > app 'trace café' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app success suggest run with ["suggest", "café", "--num-suggestions=1", "--no-include-ties"] 2`] = `
-"café:
- - café"
-`;
-
-exports[`Validate cli app success trace café run with ["trace", "café"] 1`] = `[]`;
-
-exports[`Validate cli app success trace café run with ["trace", "café"] 2`] = `
+exports[`Validate cli > app 'trace café' Expect Error: undefined 2`] = `
 "Word F Dictionary           Dictionary Location           
 café - [flagWords]*         From Settings \`flagWords\`
 café - [ignoreWords]*       From Settings \`ignoreWords\`
@@ -826,66 +819,9 @@ café - web-services         ../../node_modules/.pnpm...erms/dict/webServices.t
 café - workspace*           ../../cspell-dict.txt"
 `;
 
-exports[`Validate cli app success trace hello run with ["trace", "--locale=en-gb", "hello"] 1`] = `[]`;
+exports[`Validate cli > app 'trace hello' Expect Error: undefined 1`] = `[]`;
 
-exports[`Validate cli app success trace hello run with ["trace", "--locale=en-gb", "hello"] 2`] = `
-"Word  F Dictionary           Dictionary Location           
-hello - [flagWords]*         From Settings \`flagWords\`
-hello - [ignoreWords]*       From Settings \`ignoreWords\`
-hello - [words]*             From Settings \`words\`
-hello - ada                  ../../node_modules/.pnpm...ll/dict-ada/dict/ada.txt
-hello - aws*                 ../../node_modules/.pnpm...pell/dict-aws/aws.txt.gz
-hello - bash                 ../../node_modules/.pnpm...bash/dict/bash-words.txt
-hello - companies*           ../../node_modules/.pnpm...anies/dict/companies.txt
-hello * cpp                  ../../node_modules/.pnpm...pell/dict-cpp/cpp.txt.gz
-hello - cpp-refined          ../../node_modules/.pnpm...t-cpp/cpp-refined.txt.gz
-hello - cryptocurrencies*    ../../node_modules/.pnpm.../cryptocurrencies.txt.gz
-hello - csharp               ../../node_modules/.pnpm...ict-csharp/csharp.txt.gz
-hello - css                  ../../node_modules/.pnpm...ll/dict-css/dict/css.txt
-hello - dart                 ../../node_modules/.pnpm...ll/dict-dart/dart.txt.gz
-hello - django               ../../node_modules/.pnpm...t-django/dict/django.txt
-hello - docker               ../../node_modules/.pnpm...cker/docker-words.txt.gz
-hello - dotnet               ../../node_modules/.pnpm...t-dotnet/dict/dotnet.txt
-hello - elixir               ../../node_modules/.pnpm...t-elixir/dict/elixir.txt
-hello * en_us                ../../node_modules/.pnpm...dict-en_us/en_US.trie.gz
-hello * en-gb*               ../../node_modules/.pnpm...dict-en-gb/en_GB.trie.gz
-hello - filetypes*           ../../node_modules/.pnpm...letypes/filetypes.txt.gz
-hello - fonts                ../../node_modules/.pnpm.../dict-fonts/fonts.txt.gz
-hello - fullstack            ../../node_modules/.pnpm...stack/dict/fullstack.txt
-hello - gaming-terms         ../../node_modules/.pnpm...ms/dict/gaming-terms.txt
-hello * golang               ../../node_modules/.pnpm.../dict-golang/dict/go.txt
-hello - haskell              ../../node_modules/.pnpm...haskell/dict/haskell.txt
-hello - html                 ../../node_modules/.pnpm...ll/dict-html/html.txt.gz
-hello - html-symbol-entitie  ../../node_modules/.pnpm...entities/entities.txt.gz
-hello - java                 ../../node_modules/.pnpm...dict-java/dict/java.trie
-hello - k8s                  ../../node_modules/.pnpm...ll/dict-k8s/dict/k8s.txt
-hello - latex                ../../node_modules/.pnpm...ict-latex/dict/latex.txt
-hello - lorem-ipsum          ../../node_modules/.pnpm...-ipsum/dictionary.txt.gz
-hello - lua                  ../../node_modules/.pnpm...ll/dict-lua/dict/lua.txt
-hello - networking-terms     ../../node_modules/.pnpm...dict/networkingTerms.txt
-hello * node                 ../../node_modules/.pnpm.../dict-node/dict/node.txt
-hello - npm                  ../../node_modules/.pnpm...ll/dict-npm/dict/npm.txt
-hello - php                  ../../node_modules/.pnpm...ll/dict-php/dict/php.txt
-hello - powershell           ../../node_modules/.pnpm...hell/dict/powershell.txt
-hello - public-licenses*     ../../node_modules/.pnpm...s/public-licenses.txt.gz
-hello - python               ../../node_modules/.pnpm...ict-python/python.txt.gz
-hello - python-common        ../../node_modules/.pnpm...hon/python-common.txt.gz
-hello - r                    ../../node_modules/.pnpm.../@cspell/dict-r/r.txt.gz
-hello - ruby                 ../../node_modules/.pnpm.../dict-ruby/dict/ruby.txt
-hello - rust                 ../../node_modules/.pnpm.../dict-rust/dict/rust.txt
-hello - scala                ../../node_modules/.pnpm...ict-scala/dict/scala.txt
-hello - softwareTerms*       ../../node_modules/.pnpm...s/dict/softwareTerms.txt
-hello - sql                  ../../node_modules/.pnpm...pell/dict-sql/sql.txt.gz
-hello - svelte               ../../node_modules/.pnpm...t-svelte/dict/svelte.txt
-hello - swift                ../../node_modules/.pnpm.../dict-swift/swift.txt.gz
-hello - typescript           ../../node_modules/.pnpm...ript/dict/typescript.txt
-hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
-hello - workspace*           ../../cspell-dict.txt"
-`;
-
-exports[`Validate cli app success trace hello run with ["trace", "hello"] 1`] = `[]`;
-
-exports[`Validate cli app success trace hello run with ["trace", "hello"] 2`] = `
+exports[`Validate cli > app 'trace hello' Expect Error: undefined 2`] = `
 "Word  F Dictionary           Dictionary Location           
 hello - [flagWords]*         From Settings \`flagWords\`
 hello - [ignoreWords]*       From Settings \`ignoreWords\`
@@ -940,286 +876,9 @@ hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
 hello - workspace*           ../../cspell-dict.txt"
 `;
 
-exports[`Validate cli app suggest ["sug", "--stdin", "-d=en_us", "-v"] 1`] = `[]`;
+exports[`Validate cli > app 'trace hello' Expect Error: undefined 3`] = `[]`;
 
-exports[`Validate cli app suggest ["sug", "--stdin", "-d=en_us", "-v"] 2`] = `
-"mexico:
- - Mexico      -    1 en_us
- - medico      -  100 en_us
- - medic       -  190 en_us
- - melic       -  190 en_us
- - mesic       -  190 en_us
- - metic       -  190 en_us
- - Mexican     -  191 en_us
- - Mexico's    -  191 en_us"
-`;
-
-exports[`Validate cli app suggest ["sug", "--stdin", "-d=en_us", "-v"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "--dictionary=en-gb", "-v", "--num-suggestions=2"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "--dictionary=en-gb", "-v", "--num-suggestions=2"] 2`] = `
-"dutch:
- - dutch    -    0 en-gb, en_us
- - Dutch    -    1 en_us"
-`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "--dictionary=en-gb", "-v", "--num-suggestions=2"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "-v", "--num-suggestions=2"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "-v", "--num-suggestions=2"] 2`] = `
-"dutch:
- - dutch    -    0 en_us
- - Dutch    -    1 en_us"
-`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "-v", "--num-suggestions=2"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "-v", "--num-suggestions=2"] 4`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "-v", "--num-suggestions=2"] 5`] = `
-"dutch:
- - dutch    -    0 en_us
- - Dutch    -    1 en_us"
-`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "--dictionaries=en_us", "-v", "--num-suggestions=2"] 6`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "-d=en_us", "-d=en-gb", "-v", "--num-suggestions=2"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "-d=en_us", "-d=en-gb", "-v", "--num-suggestions=2"] 2`] = `
-"dutch:
- - dutch    -    0 en-gb, en_us
- - Dutch    -    1 en_us"
-`;
-
-exports[`Validate cli app suggest ["sug", "dutch", "-d=en_us", "-d=en-gb", "-v", "--num-suggestions=2"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us", "-v", "--num-suggestions=0"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us", "-v", "--num-suggestions=0"] 2`] = `
-"mexico:
- <no suggestions>"
-`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us", "-v", "--num-suggestions=0"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us", "-v"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us", "-v"] 2`] = `
-"mexico:
- - Mexico      -    1 en_us
- - medico      -  100 en_us
- - medic       -  190 en_us
- - melic       -  190 en_us
- - mesic       -  190 en_us
- - metic       -  190 en_us
- - Mexican     -  191 en_us
- - Mexico's    -  191 en_us"
-`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us", "-v"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us"] 2`] = `
-"mexico:
- - Mexico
- - medico
- - medic
- - melic
- - mesic
- - metic
- - Mexican
- - Mexico's"
-`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en_us"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en-gb"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en-gb"] 2`] = `
-"mexico:
- - mexico
- - medico
- - mexico's
- - mexican
- - medicos
- - medich
- - medici
- - medics
- - melick"
-`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en-gb"] 3`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en-us"] 1`] = `[]`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en-us"] 2`] = `""`;
-
-exports[`Validate cli app suggest ["sug", "mexico", "-d=en-us"] 3`] = `"Unknown dictionary: "en-us""`;
-
-exports[`Validate cli app suggest ["sug"] 1`] = `
-[
-  "Usage: cspell suggestions|sug [options] [words...]",
-  "",
-  "Spelling Suggestions for words.",
-  "",
-  "Options:",
-  "  -c, --config <cspell.json>            Configuration file to use.  By default",
-  "                                        cspell looks for cspell.json in the",
-  "                                        current directory.",
-  "  --locale <locale>                     Set language locales. i.e. "en,fr" for",
-  "                                        English and French, or "en-GB" for",
-  "                                        British English.",
-  "  --language-id <language>              Use programming language. i.e. "php" or",
-  "                                        "scala".",
-  "  -s, --no-strict                       Ignore case and accents when searching",
-  "                                        for words.",
-  "  --ignore-case                         Alias of --no-strict.",
-  "  --num-changes <number>                Number of changes allowed to a word",
-  "                                        (default: 4)",
-  "  --num-suggestions <number>            Number of suggestions (default: 8)",
-  "  --no-include-ties                     Force the number of suggested to be",
-  "                                        limited, by not including suggestions",
-  "                                        that have the same edit cost.",
-  "  --stdin                               Use stdin for input.",
-  "  --repl                                REPL interface for looking up",
-  "                                        suggestions.",
-  "  -v, --verbose                         Show detailed output.",
-  "  -d, --dictionary <dictionary name>    Use the dictionary specified. Only",
-  "                                        dictionaries specified will be used.",
-  "  --dictionaries <dictionary names...>  Use the dictionaries specified. Only",
-  "                                        dictionaries specified will be used.",
-  "  --no-color                            Turn off color.",
-  "  --color                               Force color",
-  "  -h, --help                            display help for command",
-  "",
-]
-`;
-
-exports[`Validate cli app suggest ["sug"] 2`] = `""`;
-
-exports[`Validate cli app suggest ["sug"] 3`] = `""`;
-
-exports[`Validate cli app trace café Expect Error: undefined 1`] = `[]`;
-
-exports[`Validate cli app trace café Expect Error: undefined 2`] = `
-"Word F Dictionary           Dictionary Location           
-café - [flagWords]*         From Settings \`flagWords\`
-café - [ignoreWords]*       From Settings \`ignoreWords\`
-café - [words]*             From Settings \`words\`
-café - ada                  ../../node_modules/.pnpm...ell/dict-ada/dict/ada.txt
-café - aws*                 ../../node_modules/.pnpm...spell/dict-aws/aws.txt.gz
-café - bash                 ../../node_modules/.pnpm...-bash/dict/bash-words.txt
-café - companies*           ../../node_modules/.pnpm...panies/dict/companies.txt
-café - cpp                  ../../node_modules/.pnpm...spell/dict-cpp/cpp.txt.gz
-café - cpp-refined          ../../node_modules/.pnpm...ct-cpp/cpp-refined.txt.gz
-café - cryptocurrencies*    ../../node_modules/.pnpm...s/cryptocurrencies.txt.gz
-café - csharp               ../../node_modules/.pnpm...dict-csharp/csharp.txt.gz
-café - css                  ../../node_modules/.pnpm...ell/dict-css/dict/css.txt
-café - dart                 ../../node_modules/.pnpm...ell/dict-dart/dart.txt.gz
-café - django               ../../node_modules/.pnpm...ct-django/dict/django.txt
-café - docker               ../../node_modules/.pnpm...ocker/docker-words.txt.gz
-café - dotnet               ../../node_modules/.pnpm...ct-dotnet/dict/dotnet.txt
-café - elixir               ../../node_modules/.pnpm...ct-elixir/dict/elixir.txt
-café * en_us*               ../../node_modules/.pnpm.../dict-en_us/en_US.trie.gz
-café * en-gb                ../../node_modules/.pnpm.../dict-en-gb/en_GB.trie.gz
-café - filetypes*           ../../node_modules/.pnpm...iletypes/filetypes.txt.gz
-café - fonts                ../../node_modules/.pnpm...l/dict-fonts/fonts.txt.gz
-café - fullstack            ../../node_modules/.pnpm...lstack/dict/fullstack.txt
-café - gaming-terms         ../../node_modules/.pnpm...rms/dict/gaming-terms.txt
-café - golang               ../../node_modules/.pnpm...l/dict-golang/dict/go.txt
-café - haskell              ../../node_modules/.pnpm...-haskell/dict/haskell.txt
-café - html                 ../../node_modules/.pnpm...ell/dict-html/html.txt.gz
-café - html-symbol-entitie  ../../node_modules/.pnpm...-entities/entities.txt.gz
-café - java                 ../../node_modules/.pnpm.../dict-java/dict/java.trie
-café - k8s                  ../../node_modules/.pnpm...ell/dict-k8s/dict/k8s.txt
-café - latex                ../../node_modules/.pnpm...dict-latex/dict/latex.txt
-café - lorem-ipsum          ../../node_modules/.pnpm...m-ipsum/dictionary.txt.gz
-café - lua                  ../../node_modules/.pnpm...ell/dict-lua/dict/lua.txt
-café - networking-terms     ../../node_modules/.pnpm.../dict/networkingTerms.txt
-café - node                 ../../node_modules/.pnpm...l/dict-node/dict/node.txt
-café - npm                  ../../node_modules/.pnpm...ell/dict-npm/dict/npm.txt
-café - php                  ../../node_modules/.pnpm...ell/dict-php/dict/php.txt
-café - powershell           ../../node_modules/.pnpm...shell/dict/powershell.txt
-café - public-licenses*     ../../node_modules/.pnpm...es/public-licenses.txt.gz
-café - python               ../../node_modules/.pnpm...dict-python/python.txt.gz
-café - python-common        ../../node_modules/.pnpm...thon/python-common.txt.gz
-café - r                    ../../node_modules/.pnpm...s/@cspell/dict-r/r.txt.gz
-café - ruby                 ../../node_modules/.pnpm...l/dict-ruby/dict/ruby.txt
-café - rust                 ../../node_modules/.pnpm...l/dict-rust/dict/rust.txt
-café - scala                ../../node_modules/.pnpm...dict-scala/dict/scala.txt
-café - softwareTerms*       ../../node_modules/.pnpm...ms/dict/softwareTerms.txt
-café - sql                  ../../node_modules/.pnpm...spell/dict-sql/sql.txt.gz
-café - svelte               ../../node_modules/.pnpm...ct-svelte/dict/svelte.txt
-café - swift                ../../node_modules/.pnpm...l/dict-swift/swift.txt.gz
-café - typescript           ../../node_modules/.pnpm...cript/dict/typescript.txt
-café - web-services         ../../node_modules/.pnpm...erms/dict/webServices.txt
-café - workspace*           ../../cspell-dict.txt"
-`;
-
-exports[`Validate cli app trace hello Expect Error: undefined 1`] = `[]`;
-
-exports[`Validate cli app trace hello Expect Error: undefined 2`] = `
-"Word  F Dictionary           Dictionary Location           
-hello - [flagWords]*         From Settings \`flagWords\`
-hello - [ignoreWords]*       From Settings \`ignoreWords\`
-hello - [words]*             From Settings \`words\`
-hello - ada                  ../../node_modules/.pnpm...ll/dict-ada/dict/ada.txt
-hello - aws*                 ../../node_modules/.pnpm...pell/dict-aws/aws.txt.gz
-hello - bash                 ../../node_modules/.pnpm...bash/dict/bash-words.txt
-hello - companies*           ../../node_modules/.pnpm...anies/dict/companies.txt
-hello * cpp                  ../../node_modules/.pnpm...pell/dict-cpp/cpp.txt.gz
-hello - cpp-refined          ../../node_modules/.pnpm...t-cpp/cpp-refined.txt.gz
-hello - cryptocurrencies*    ../../node_modules/.pnpm.../cryptocurrencies.txt.gz
-hello - csharp               ../../node_modules/.pnpm...ict-csharp/csharp.txt.gz
-hello - css                  ../../node_modules/.pnpm...ll/dict-css/dict/css.txt
-hello - dart                 ../../node_modules/.pnpm...ll/dict-dart/dart.txt.gz
-hello - django               ../../node_modules/.pnpm...t-django/dict/django.txt
-hello - docker               ../../node_modules/.pnpm...cker/docker-words.txt.gz
-hello - dotnet               ../../node_modules/.pnpm...t-dotnet/dict/dotnet.txt
-hello - elixir               ../../node_modules/.pnpm...t-elixir/dict/elixir.txt
-hello * en_us*               ../../node_modules/.pnpm...dict-en_us/en_US.trie.gz
-hello * en-gb                ../../node_modules/.pnpm...dict-en-gb/en_GB.trie.gz
-hello - filetypes*           ../../node_modules/.pnpm...letypes/filetypes.txt.gz
-hello - fonts                ../../node_modules/.pnpm.../dict-fonts/fonts.txt.gz
-hello - fullstack            ../../node_modules/.pnpm...stack/dict/fullstack.txt
-hello - gaming-terms         ../../node_modules/.pnpm...ms/dict/gaming-terms.txt
-hello * golang               ../../node_modules/.pnpm.../dict-golang/dict/go.txt
-hello - haskell              ../../node_modules/.pnpm...haskell/dict/haskell.txt
-hello - html                 ../../node_modules/.pnpm...ll/dict-html/html.txt.gz
-hello - html-symbol-entitie  ../../node_modules/.pnpm...entities/entities.txt.gz
-hello - java                 ../../node_modules/.pnpm...dict-java/dict/java.trie
-hello - k8s                  ../../node_modules/.pnpm...ll/dict-k8s/dict/k8s.txt
-hello - latex                ../../node_modules/.pnpm...ict-latex/dict/latex.txt
-hello - lorem-ipsum          ../../node_modules/.pnpm...-ipsum/dictionary.txt.gz
-hello - lua                  ../../node_modules/.pnpm...ll/dict-lua/dict/lua.txt
-hello - networking-terms     ../../node_modules/.pnpm...dict/networkingTerms.txt
-hello * node                 ../../node_modules/.pnpm.../dict-node/dict/node.txt
-hello - npm                  ../../node_modules/.pnpm...ll/dict-npm/dict/npm.txt
-hello - php                  ../../node_modules/.pnpm...ll/dict-php/dict/php.txt
-hello - powershell           ../../node_modules/.pnpm...hell/dict/powershell.txt
-hello - public-licenses*     ../../node_modules/.pnpm...s/public-licenses.txt.gz
-hello - python               ../../node_modules/.pnpm...ict-python/python.txt.gz
-hello - python-common        ../../node_modules/.pnpm...hon/python-common.txt.gz
-hello - r                    ../../node_modules/.pnpm.../@cspell/dict-r/r.txt.gz
-hello - ruby                 ../../node_modules/.pnpm.../dict-ruby/dict/ruby.txt
-hello - rust                 ../../node_modules/.pnpm.../dict-rust/dict/rust.txt
-hello - scala                ../../node_modules/.pnpm...ict-scala/dict/scala.txt
-hello - softwareTerms*       ../../node_modules/.pnpm...s/dict/softwareTerms.txt
-hello - sql                  ../../node_modules/.pnpm...pell/dict-sql/sql.txt.gz
-hello - svelte               ../../node_modules/.pnpm...t-svelte/dict/svelte.txt
-hello - swift                ../../node_modules/.pnpm.../dict-swift/swift.txt.gz
-hello - typescript           ../../node_modules/.pnpm...ript/dict/typescript.txt
-hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
-hello - workspace*           ../../cspell-dict.txt"
-`;
-
-exports[`Validate cli app trace hello Expect Error: undefined 3`] = `[]`;
-
-exports[`Validate cli app trace hello Expect Error: undefined 4`] = `
+exports[`Validate cli > app 'trace hello' Expect Error: undefined 4`] = `
 "Word  F Dictionary           Dictionary Location           
 hello - [flagWords]*         From Settings \`flagWords\`
 hello - [ignoreWords]*       From Settings \`ignoreWords\`
@@ -1274,7 +933,7 @@ hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
 hello - workspace*           ../../cspell-dict.txt"
 `;
 
-exports[`Validate cli app trace help Expect Error: outputHelp 1`] = `
+exports[`Validate cli > app 'trace help' Expect Error: 'outputHelp' 1`] = `
 [
   "Usage: cspell trace [options] [words...]",
   "",
@@ -1283,9 +942,9 @@ exports[`Validate cli app trace help Expect Error: outputHelp 1`] = `
   "Options:",
   "  -c, --config <cspell.json>  Configuration file to use.  By default cspell",
   "                              looks for cspell.json in the current directory.",
-  "  --locale <locale>           Set language locales. i.e. "en,fr" for English",
-  "                              and French, or "en-GB" for British English.",
-  "  --language-id <language>    Use programming language. i.e. "php" or "scala"",
+  "  --locale <locale>           Set language locales. i.e. \\"en,fr\\" for English",
+  "                              and French, or \\"en-GB\\" for British English.",
+  "  --language-id <language>    Use programming language. i.e. \\"php\\" or \\"scala\\"",
   "  --allow-compound-words      Turn on allowCompoundWords",
   "  --no-allow-compound-words   Turn off allowCompoundWords",
   "  --no-ignore-case            Do not ignore case and accents when searching for",
@@ -1300,11 +959,11 @@ exports[`Validate cli app trace help Expect Error: outputHelp 1`] = `
 ]
 `;
 
-exports[`Validate cli app trace help Expect Error: outputHelp 2`] = `""`;
+exports[`Validate cli > app 'trace help' Expect Error: 'outputHelp' 2`] = `""`;
 
-exports[`Validate cli app trace missing dictionary Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'trace missing dictionary' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app trace missing dictionary Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'trace missing dictionary' Expect Error: [Function CheckFailed] 2`] = `
 "Word  F Dictionary           Dictionary Location           
 hello - [flagWords]*         From Settings \`flagWords\`
 hello - [ignoreWords]*       From Settings \`ignoreWords\`
@@ -1361,9 +1020,9 @@ hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
 hello - workspace*           ../../cspell-dict.txt"
 `;
 
-exports[`Validate cli app trace not-in-any-dictionary Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'trace not-in-any-dictionary' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app trace not-in-any-dictionary Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'trace not-in-any-dictionary' Expect Error: [Function CheckFailed] 2`] = `
 "Word                  F Dictionary           Dictionary Location           
 not-in-any-dictionary - [flagWords]*         From Settings \`flagWords\`
 not-in-any-dictionary - [ignoreWords]*       From Settings \`ignoreWords\`
@@ -1418,20 +1077,20 @@ not-in-any-dictionary - web-services         ../../node_modul.../webServices.txt
 not-in-any-dictionary - workspace*           ../../cspell-dict.txt"
 `;
 
-exports[`Validate cli app typos Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app typos Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 2`] = `
 "log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, blacklists, backlist, blacklist's, blacklisted]
 log	./fixtures/features/typos/test.md:6:3 - Forbidden word (whitelist) Suggestions: [allowlist*, whitelists, whitelisted, whitefish, whitest]
 log	./fixtures/features/typos/test.md:7:3 - Forbidden word (rad) Suggestions: [cool*, rda, rads, raid, rand]
 error	CSpell: Files checked: 2, Issues found: 3 in 1 files"
 `;
 
-exports[`Validate cli app typos Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app with errors and excludes Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'with errors and excludes' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app with errors and excludes Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'with errors and excludes' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms
 error	 0.00ms
 error	 0.00ms
@@ -1448,7 +1107,7 @@ log	./samples/text.txt:5:32 - Unknown word (reead)
 error	CSpell: Files checked: 6, Issues found: 7 in 1 files"
 `;
 
-exports[`Validate cli app with errors and excludes Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app 'with errors and excludes' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/6 [90m./samples/cspell-bad.json[39m
 2/6 [90m./samples/cspell-includes.json[39m
@@ -1458,9 +1117,9 @@ exports[`Validate cli app with errors and excludes Expect Error: [Function Check
 6/6 [90m./samples/text.txt[39m"
 `;
 
-exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'with forbidden words' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'with forbidden words' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/src/sample-with-forbidden-words.md:3:3 - Forbidden word (behaviour)
 log	./samples/src/sample-with-forbidden-words.md:4:3 - Forbidden word (flavour)
@@ -1468,14 +1127,14 @@ log	./samples/src/sample-with-forbidden-words.md:5:3 - Forbidden word (colour)
 error	CSpell: Files checked: 1, Issues found: 3 in 1 files"
 `;
 
-exports[`Validate cli app with forbidden words Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app 'with forbidden words' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/1 [90m./samples/src/sample-with-forbidden-words.md[39m"
 `;
 
-exports[`Validate cli app with spelling errors --debug Dutch.txt Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'with spelling errors --debug Dutch.txt' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app with spelling errors --debug Dutch.txt Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'with spelling errors --debug Dutch.txt' Expect Error: [Function CheckFailed] 2`] = `
 "./samples/Dutch.txt:1:32 - Unknown word (NEDERLANDS)
 ./samples/Dutch.txt:2:11 - Unknown word (wordt)
 ./samples/Dutch.txt:2:17 - Unknown word (vriendelijk)
@@ -1667,15 +1326,15 @@ exports[`Validate cli app with spelling errors --debug Dutch.txt Expect Error: [
 ./samples/Dutch.txt:78:18 - Unknown word (ANBI)"
 `;
 
-exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'with spelling errors --silent Dutch.t…' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 2`] = `""`;
+exports[`Validate cli > app 'with spelling errors --silent Dutch.t…' Expect Error: [Function CheckFailed] 2`] = `""`;
 
-exports[`Validate cli app with spelling errors --silent Dutch.txt Expect Error: [Function CheckFailed] 3`] = `""`;
+exports[`Validate cli > app 'with spelling errors --silent Dutch.t…' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'with spelling errors Dutch.txt --lega…' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'with spelling errors Dutch.txt --lega…' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	./samples/Dutch.txt[1, 32]: Unknown word: NEDERLANDS
 log	./samples/Dutch.txt[2, 11]: Unknown word: wordt
@@ -1869,215 +1528,14 @@ log	./samples/Dutch.txt[78, 18]: Unknown word: ANBI
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
-exports[`Validate cli app with spelling errors Dutch.txt --legacy Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app 'with spelling errors Dutch.txt --lega…' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/1 [90m./samples/Dutch.txt[39m"
 `;
 
-exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'with spelling errors Dutch.txt words …' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 2`] = `
-"error	 0.00ms X
-log	./samples/Dutch.txt:1:32 - Unknown word (NEDERLANDS)
-log	./samples/Dutch.txt:2:11 - Unknown word (wordt)
-log	./samples/Dutch.txt:2:17 - Unknown word (vriendelijk)
-log	./samples/Dutch.txt:2:29 - Unknown word (verzocht)
-log	./samples/Dutch.txt:2:45 - Unknown word (bestand)
-log	./samples/Dutch.txt:3:10 - Unknown word (lezen)
-log	./samples/Dutch.txt:3:26 - Unknown word (leveren)
-log	./samples/Dutch.txt:3:38 - Unknown word (iedere)
-log	./samples/Dutch.txt:3:45 - Unknown word (kopie)
-log	./samples/Dutch.txt:3:59 - Unknown word (taalhulpbestand)
-log	./samples/Dutch.txt:5:4 - Unknown word (Naam)
-log	./samples/Dutch.txt:5:10 - Unknown word (Nederlandstalige)
-log	./samples/Dutch.txt:5:27 - Unknown word (woordenlijst)
-log	./samples/Dutch.txt:5:40 - Unknown word (voor)
-log	./samples/Dutch.txt:5:45 - Unknown word (spellingcontrole)
-log	./samples/Dutch.txt:6:4 - Unknown word (Versie)
-log	./samples/Dutch.txt:6:11 - Unknown word (woordenlijst)
-log	./samples/Dutch.txt:6:32 - Unknown word (versie)
-log	./samples/Dutch.txt:6:39 - Unknown word (spellingcontrole)
-log	./samples/Dutch.txt:7:4 - Unknown word (Vereisten)
-log	./samples/Dutch.txt:7:33 - Unknown word (hoger)
-log	./samples/Dutch.txt:8:4 - Unknown word (Keurmerk)
-log	./samples/Dutch.txt:8:22 - Unknown word (Nederlandse)
-log	./samples/Dutch.txt:8:34 - Unknown word (Taalunie)
-log	./samples/Dutch.txt:8:47 - Unknown word (lijst)
-log	./samples/Dutch.txt:8:57 - Unknown word (basiswoorden)
-log	./samples/Dutch.txt:9:13 - Unknown word (draagt)
-log	./samples/Dutch.txt:9:24 - Unknown word (keurmerk)
-log	./samples/Dutch.txt:9:40 - Unknown word (Nederlandse)
-log	./samples/Dutch.txt:9:52 - Unknown word (Taalunie)
-log	./samples/Dutch.txt:9:62 - Unknown word (Voor)
-log	./samples/Dutch.txt:9:67 - Unknown word (meer)
-log	./samples/Dutch.txt:10:4 - Unknown word (informatie)
-log	./samples/Dutch.txt:11:4 - Unknown word (Auteursrechten)
-log	./samples/Dutch.txt:11:60 - Unknown word (Brouwer)
-log	./samples/Dutch.txt:12:11 - Unknown word (Nederlandstalige)
-log	./samples/Dutch.txt:12:32 - Unknown word (Gebruikersgroep)
-log	./samples/Dutch.txt:13:4 - Unknown word (Licenties)
-log	./samples/Dutch.txt:13:24 - Unknown word (heeft)
-log	./samples/Dutch.txt:13:34 - Unknown word (doel)
-log	./samples/Dutch.txt:13:42 - Unknown word (vrij)
-log	./samples/Dutch.txt:13:47 - Unknown word (beschikbare)
-log	./samples/Dutch.txt:13:59 - Unknown word (Nederlandstalige)
-log	./samples/Dutch.txt:14:4 - Unknown word (taalhulpbestanden)
-log	./samples/Dutch.txt:14:25 - Unknown word (ontwikkelen)
-log	./samples/Dutch.txt:14:43 - Unknown word (verspreiden)
-log	./samples/Dutch.txt:14:70 - Unknown word (gebruik)
-log	./samples/Dutch.txt:15:4 - Unknown word (mogelijk)
-log	./samples/Dutch.txt:15:16 - Unknown word (maken)
-log	./samples/Dutch.txt:15:22 - Unknown word (zijn)
-log	./samples/Dutch.txt:15:30 - Unknown word (taalhulpbestanden)
-log	./samples/Dutch.txt:15:55 - Unknown word (beschikbaar)
-log	./samples/Dutch.txt:15:67 - Unknown word (onder)
-log	./samples/Dutch.txt:16:4 - Unknown word (onderstaande)
-log	./samples/Dutch.txt:16:18 - Unknown word (liberale)
-log	./samples/Dutch.txt:16:27 - Unknown word (licenties)
-log	./samples/Dutch.txt:16:37 - Unknown word (naar)
-log	./samples/Dutch.txt:16:42 - Unknown word (keuze)
-log	./samples/Dutch.txt:16:55 - Unknown word (gebruiker)
-log	./samples/Dutch.txt:16:68 - Unknown word (wordt)
-log	./samples/Dutch.txt:17:4 - Unknown word (zeerste)
-log	./samples/Dutch.txt:17:12 - Unknown word (aangeraden)
-log	./samples/Dutch.txt:17:26 - Unknown word (voorafgaand)
-log	./samples/Dutch.txt:17:46 - Unknown word (gebruik)
-log	./samples/Dutch.txt:17:54 - Unknown word (kennis)
-log	./samples/Dutch.txt:17:64 - Unknown word (nemen)
-log	./samples/Dutch.txt:18:4 - Unknown word (toepasselijke)
-log	./samples/Dutch.txt:18:18 - Unknown word (licentie)
-log	./samples/Dutch.txt:19:12 - Unknown word (herziene)
-log	./samples/Dutch.txt:19:21 - Unknown word (versie)
-log	./samples/Dutch.txt:20:6 - Unknown word (Volledige)
-log	./samples/Dutch.txt:20:16 - Unknown word (licentie)
-log	./samples/Dutch.txt:21:6 - Unknown word (Samenvatting)
-log	./samples/Dutch.txt:22:25 - Unknown word (Naamsvermelding)
-log	./samples/Dutch.txt:22:46 - Unknown word (unported)
-log	./samples/Dutch.txt:23:6 - Unknown word (Volledige)
-log	./samples/Dutch.txt:23:16 - Unknown word (licentie)
-log	./samples/Dutch.txt:24:6 - Unknown word (Samenvatting)
-log	./samples/Dutch.txt:25:4 - Unknown word (Steun)
-log	./samples/Dutch.txt:25:36 - Unknown word (vrijwilligersproject)
-log	./samples/Dutch.txt:25:57 - Unknown word (zonder)
-log	./samples/Dutch.txt:25:64 - Unknown word (winstoogmerk)
-log	./samples/Dutch.txt:26:13 - Unknown word (kleine)
-log	./samples/Dutch.txt:26:21 - Unknown word (financiële)
-log	./samples/Dutch.txt:26:32 - Unknown word (steun)
-log	./samples/Dutch.txt:26:51 - Unknown word (meer)
-log	./samples/Dutch.txt:26:56 - Unknown word (activiteiten)
-log	./samples/Dutch.txt:26:69 - Unknown word (ontplooien)
-log	./samples/Dutch.txt:27:19 - Unknown word (professionaliseren)
-log	./samples/Dutch.txt:27:42 - Unknown word (donatie)
-log	./samples/Dutch.txt:27:63 - Unknown word (welkom)
-log	./samples/Dutch.txt:28:4 - Unknown word (rekeningnummer)
-log	./samples/Dutch.txt:28:39 - Unknown word (Stichting)
-log	./samples/Dutch.txt:28:62 - Unknown word (giften)
-log	./samples/Dutch.txt:28:69 - Unknown word (zijn)
-log	./samples/Dutch.txt:29:4 - Unknown word (aftrekbaar)
-log	./samples/Dutch.txt:29:22 - Unknown word (belasting)
-log	./samples/Dutch.txt:29:33 - Unknown word (Stichting)
-log	./samples/Dutch.txt:29:55 - Unknown word (namelijk)
-log	./samples/Dutch.txt:30:4 - Unknown word (Belastingdienst)
-log	./samples/Dutch.txt:30:20 - Unknown word (erkend)
-log	./samples/Dutch.txt:30:31 - Unknown word (ANBI)
-log	./samples/Dutch.txt:30:37 - Unknown word (oftewel)
-log	./samples/Dutch.txt:30:46 - Unknown word (Algemeen)
-log	./samples/Dutch.txt:30:59 - Unknown word (Beogende)
-log	./samples/Dutch.txt:30:68 - Unknown word (Instelling)
-log	./samples/Dutch.txt:32:4 - Unknown word (Meedoen)
-log	./samples/Dutch.txt:32:13 - Unknown word (Iedereen)
-log	./samples/Dutch.txt:32:25 - Unknown word (welkom)
-log	./samples/Dutch.txt:32:42 - Unknown word (doen)
-log	./samples/Dutch.txt:32:53 - Unknown word (fouten)
-log	./samples/Dutch.txt:32:61 - Unknown word (discussieer)
-log	./samples/Dutch.txt:33:7 - Unknown word (mailinglijst)
-log	./samples/Dutch.txt:33:23 - Unknown word (draai)
-log	./samples/Dutch.txt:33:52 - Unknown word (dragen)
-log	./samples/Dutch.txt:33:75 - Unknown word (stemt)
-log	./samples/Dutch.txt:34:6 - Unknown word (ermee)
-log	./samples/Dutch.txt:34:22 - Unknown word (bijdrage)
-log	./samples/Dutch.txt:34:39 - Unknown word (desbetreffende)
-log	./samples/Dutch.txt:34:54 - Unknown word (taalhulpbestand)
-log	./samples/Dutch.txt:34:70 - Unknown word (beschikbaar)
-log	./samples/Dutch.txt:35:4 - Unknown word (komt)
-log	./samples/Dutch.txt:35:9 - Unknown word (onder)
-log	./samples/Dutch.txt:35:15 - Unknown word (vrije)
-log	./samples/Dutch.txt:35:27 - Unknown word (opensource)
-log	./samples/Dutch.txt:35:38 - Unknown word (licenties)
-log	./samples/Dutch.txt:35:49 - Unknown word (Indien)
-log	./samples/Dutch.txt:35:62 - Unknown word (wenst)
-log	./samples/Dutch.txt:36:4 - Unknown word (naam)
-log	./samples/Dutch.txt:36:23 - Unknown word (genoemd)
-log	./samples/Dutch.txt:36:31 - Unknown word (worden)
-log	./samples/Dutch.txt:36:42 - Unknown word (ontvangen)
-log	./samples/Dutch.txt:36:55 - Unknown word (schriftelijk)
-log	./samples/Dutch.txt:36:68 - Unknown word (verzoek)
-log	./samples/Dutch.txt:37:4 - Unknown word (daarvoor)
-log	./samples/Dutch.txt:37:13 - Unknown word (graag)
-log	./samples/Dutch.txt:38:4 - Unknown word (Rechten)
-log	./samples/Dutch.txt:38:16 - Unknown word (derden)
-log	./samples/Dutch.txt:38:33 - Unknown word (respecteert)
-log	./samples/Dutch.txt:38:48 - Unknown word (rechten)
-log	./samples/Dutch.txt:38:60 - Unknown word (derden)
-log	./samples/Dutch.txt:39:13 - Unknown word (gegevens)
-log	./samples/Dutch.txt:39:22 - Unknown word (vrij)
-log	./samples/Dutch.txt:39:27 - Unknown word (beschikbaar)
-log	./samples/Dutch.txt:39:39 - Unknown word (houden)
-log	./samples/Dutch.txt:39:47 - Unknown word (Voor)
-log	./samples/Dutch.txt:39:52 - Unknown word (bijdragen)
-log	./samples/Dutch.txt:40:6 - Unknown word (daarom)
-log	./samples/Dutch.txt:40:13 - Unknown word (niet)
-log	./samples/Dutch.txt:40:18 - Unknown word (zonder)
-log	./samples/Dutch.txt:40:25 - Unknown word (toestemming)
-log	./samples/Dutch.txt:40:37 - Unknown word (gebruikmaken)
-log	./samples/Dutch.txt:40:54 - Unknown word (beschermde)
-log	./samples/Dutch.txt:40:65 - Unknown word (naslagwerken)
-log	./samples/Dutch.txt:41:4 - Unknown word (zoals)
-log	./samples/Dutch.txt:41:10 - Unknown word (woordenboeken)
-log	./samples/Dutch.txt:41:36 - Unknown word (toegestaan)
-log	./samples/Dutch.txt:41:50 - Unknown word (gebruik)
-log	./samples/Dutch.txt:41:61 - Unknown word (maken)
-log	./samples/Dutch.txt:42:4 - Unknown word (materialen)
-log	./samples/Dutch.txt:42:22 - Unknown word (Nederlandse)
-log	./samples/Dutch.txt:42:34 - Unknown word (Taalunie)
-log	./samples/Dutch.txt:42:44 - Unknown word (zoals)
-log	./samples/Dutch.txt:42:53 - Unknown word (leidraad)
-log	./samples/Dutch.txt:42:68 - Unknown word (woordenlijst)
-log	./samples/Dutch.txt:43:4 - Unknown word (Indien)
-log	./samples/Dutch.txt:43:17 - Unknown word (mening)
-log	./samples/Dutch.txt:43:42 - Unknown word (inbreuk)
-log	./samples/Dutch.txt:43:50 - Unknown word (maakt)
-log	./samples/Dutch.txt:43:62 - Unknown word (rechten)
-log	./samples/Dutch.txt:44:4 - Unknown word (verzoeken)
-log	./samples/Dutch.txt:44:19 - Unknown word (hierover)
-log	./samples/Dutch.txt:44:31 - Unknown word (spoedig)
-log	./samples/Dutch.txt:44:39 - Unknown word (mogelijk)
-log	./samples/Dutch.txt:44:48 - Unknown word (schriftelijk)
-log	./samples/Dutch.txt:45:7 - Unknown word (nemen)
-log	./samples/Dutch.txt:46:13 - Unknown word (Stichting)
-log	./samples/Dutch.txt:59:56 - Unknown word (Brouwer)
-log	./samples/Dutch.txt:60:11 - Unknown word (Nederlandstalige)
-log	./samples/Dutch.txt:60:32 - Unknown word (Gebruikersgroep)
-log	./samples/Dutch.txt:68:42 - Unknown word (unported)
-log	./samples/Dutch.txt:74:39 - Unknown word (RABONL)
-log	./samples/Dutch.txt:74:49 - Unknown word (IBAN)
-log	./samples/Dutch.txt:74:59 - Unknown word (RABO)
-log	./samples/Dutch.txt:75:4 - Unknown word (Stichting)
-log	./samples/Dutch.txt:77:58 - Unknown word (algemeen)
-log	./samples/Dutch.txt:77:71 - Unknown word (beogende)
-log	./samples/Dutch.txt:78:4 - Unknown word (instelling)
-log	./samples/Dutch.txt:78:18 - Unknown word (ANBI)
-error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
-`;
-
-exports[`Validate cli app with spelling errors Dutch.txt Expect Error: [Function CheckFailed] 3`] = `
-"
-1/1 [90m./samples/Dutch.txt[39m"
-`;
-
-exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 1`] = `[]`;
-
-exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'with spelling errors Dutch.txt words …' Expect Error: [Function CheckFailed] 2`] = `
 "error	 0.00ms X
 log	NEDERLANDS
 log	wordt
@@ -2271,7 +1729,549 @@ log	ANBI
 error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
 `;
 
-exports[`Validate cli app with spelling errors Dutch.txt words only Expect Error: [Function CheckFailed] 3`] = `
+exports[`Validate cli > app 'with spelling errors Dutch.txt words …' Expect Error: [Function CheckFailed] 3`] = `
 "
 1/1 [90m./samples/Dutch.txt[39m"
 `;
+
+exports[`Validate cli > app 'with spelling errors Dutch.txt' Expect Error: [Function CheckFailed] 1`] = `[]`;
+
+exports[`Validate cli > app 'with spelling errors Dutch.txt' Expect Error: [Function CheckFailed] 2`] = `
+"error	 0.00ms X
+log	./samples/Dutch.txt:1:32 - Unknown word (NEDERLANDS)
+log	./samples/Dutch.txt:2:11 - Unknown word (wordt)
+log	./samples/Dutch.txt:2:17 - Unknown word (vriendelijk)
+log	./samples/Dutch.txt:2:29 - Unknown word (verzocht)
+log	./samples/Dutch.txt:2:45 - Unknown word (bestand)
+log	./samples/Dutch.txt:3:10 - Unknown word (lezen)
+log	./samples/Dutch.txt:3:26 - Unknown word (leveren)
+log	./samples/Dutch.txt:3:38 - Unknown word (iedere)
+log	./samples/Dutch.txt:3:45 - Unknown word (kopie)
+log	./samples/Dutch.txt:3:59 - Unknown word (taalhulpbestand)
+log	./samples/Dutch.txt:5:4 - Unknown word (Naam)
+log	./samples/Dutch.txt:5:10 - Unknown word (Nederlandstalige)
+log	./samples/Dutch.txt:5:27 - Unknown word (woordenlijst)
+log	./samples/Dutch.txt:5:40 - Unknown word (voor)
+log	./samples/Dutch.txt:5:45 - Unknown word (spellingcontrole)
+log	./samples/Dutch.txt:6:4 - Unknown word (Versie)
+log	./samples/Dutch.txt:6:11 - Unknown word (woordenlijst)
+log	./samples/Dutch.txt:6:32 - Unknown word (versie)
+log	./samples/Dutch.txt:6:39 - Unknown word (spellingcontrole)
+log	./samples/Dutch.txt:7:4 - Unknown word (Vereisten)
+log	./samples/Dutch.txt:7:33 - Unknown word (hoger)
+log	./samples/Dutch.txt:8:4 - Unknown word (Keurmerk)
+log	./samples/Dutch.txt:8:22 - Unknown word (Nederlandse)
+log	./samples/Dutch.txt:8:34 - Unknown word (Taalunie)
+log	./samples/Dutch.txt:8:47 - Unknown word (lijst)
+log	./samples/Dutch.txt:8:57 - Unknown word (basiswoorden)
+log	./samples/Dutch.txt:9:13 - Unknown word (draagt)
+log	./samples/Dutch.txt:9:24 - Unknown word (keurmerk)
+log	./samples/Dutch.txt:9:40 - Unknown word (Nederlandse)
+log	./samples/Dutch.txt:9:52 - Unknown word (Taalunie)
+log	./samples/Dutch.txt:9:62 - Unknown word (Voor)
+log	./samples/Dutch.txt:9:67 - Unknown word (meer)
+log	./samples/Dutch.txt:10:4 - Unknown word (informatie)
+log	./samples/Dutch.txt:11:4 - Unknown word (Auteursrechten)
+log	./samples/Dutch.txt:11:60 - Unknown word (Brouwer)
+log	./samples/Dutch.txt:12:11 - Unknown word (Nederlandstalige)
+log	./samples/Dutch.txt:12:32 - Unknown word (Gebruikersgroep)
+log	./samples/Dutch.txt:13:4 - Unknown word (Licenties)
+log	./samples/Dutch.txt:13:24 - Unknown word (heeft)
+log	./samples/Dutch.txt:13:34 - Unknown word (doel)
+log	./samples/Dutch.txt:13:42 - Unknown word (vrij)
+log	./samples/Dutch.txt:13:47 - Unknown word (beschikbare)
+log	./samples/Dutch.txt:13:59 - Unknown word (Nederlandstalige)
+log	./samples/Dutch.txt:14:4 - Unknown word (taalhulpbestanden)
+log	./samples/Dutch.txt:14:25 - Unknown word (ontwikkelen)
+log	./samples/Dutch.txt:14:43 - Unknown word (verspreiden)
+log	./samples/Dutch.txt:14:70 - Unknown word (gebruik)
+log	./samples/Dutch.txt:15:4 - Unknown word (mogelijk)
+log	./samples/Dutch.txt:15:16 - Unknown word (maken)
+log	./samples/Dutch.txt:15:22 - Unknown word (zijn)
+log	./samples/Dutch.txt:15:30 - Unknown word (taalhulpbestanden)
+log	./samples/Dutch.txt:15:55 - Unknown word (beschikbaar)
+log	./samples/Dutch.txt:15:67 - Unknown word (onder)
+log	./samples/Dutch.txt:16:4 - Unknown word (onderstaande)
+log	./samples/Dutch.txt:16:18 - Unknown word (liberale)
+log	./samples/Dutch.txt:16:27 - Unknown word (licenties)
+log	./samples/Dutch.txt:16:37 - Unknown word (naar)
+log	./samples/Dutch.txt:16:42 - Unknown word (keuze)
+log	./samples/Dutch.txt:16:55 - Unknown word (gebruiker)
+log	./samples/Dutch.txt:16:68 - Unknown word (wordt)
+log	./samples/Dutch.txt:17:4 - Unknown word (zeerste)
+log	./samples/Dutch.txt:17:12 - Unknown word (aangeraden)
+log	./samples/Dutch.txt:17:26 - Unknown word (voorafgaand)
+log	./samples/Dutch.txt:17:46 - Unknown word (gebruik)
+log	./samples/Dutch.txt:17:54 - Unknown word (kennis)
+log	./samples/Dutch.txt:17:64 - Unknown word (nemen)
+log	./samples/Dutch.txt:18:4 - Unknown word (toepasselijke)
+log	./samples/Dutch.txt:18:18 - Unknown word (licentie)
+log	./samples/Dutch.txt:19:12 - Unknown word (herziene)
+log	./samples/Dutch.txt:19:21 - Unknown word (versie)
+log	./samples/Dutch.txt:20:6 - Unknown word (Volledige)
+log	./samples/Dutch.txt:20:16 - Unknown word (licentie)
+log	./samples/Dutch.txt:21:6 - Unknown word (Samenvatting)
+log	./samples/Dutch.txt:22:25 - Unknown word (Naamsvermelding)
+log	./samples/Dutch.txt:22:46 - Unknown word (unported)
+log	./samples/Dutch.txt:23:6 - Unknown word (Volledige)
+log	./samples/Dutch.txt:23:16 - Unknown word (licentie)
+log	./samples/Dutch.txt:24:6 - Unknown word (Samenvatting)
+log	./samples/Dutch.txt:25:4 - Unknown word (Steun)
+log	./samples/Dutch.txt:25:36 - Unknown word (vrijwilligersproject)
+log	./samples/Dutch.txt:25:57 - Unknown word (zonder)
+log	./samples/Dutch.txt:25:64 - Unknown word (winstoogmerk)
+log	./samples/Dutch.txt:26:13 - Unknown word (kleine)
+log	./samples/Dutch.txt:26:21 - Unknown word (financiële)
+log	./samples/Dutch.txt:26:32 - Unknown word (steun)
+log	./samples/Dutch.txt:26:51 - Unknown word (meer)
+log	./samples/Dutch.txt:26:56 - Unknown word (activiteiten)
+log	./samples/Dutch.txt:26:69 - Unknown word (ontplooien)
+log	./samples/Dutch.txt:27:19 - Unknown word (professionaliseren)
+log	./samples/Dutch.txt:27:42 - Unknown word (donatie)
+log	./samples/Dutch.txt:27:63 - Unknown word (welkom)
+log	./samples/Dutch.txt:28:4 - Unknown word (rekeningnummer)
+log	./samples/Dutch.txt:28:39 - Unknown word (Stichting)
+log	./samples/Dutch.txt:28:62 - Unknown word (giften)
+log	./samples/Dutch.txt:28:69 - Unknown word (zijn)
+log	./samples/Dutch.txt:29:4 - Unknown word (aftrekbaar)
+log	./samples/Dutch.txt:29:22 - Unknown word (belasting)
+log	./samples/Dutch.txt:29:33 - Unknown word (Stichting)
+log	./samples/Dutch.txt:29:55 - Unknown word (namelijk)
+log	./samples/Dutch.txt:30:4 - Unknown word (Belastingdienst)
+log	./samples/Dutch.txt:30:20 - Unknown word (erkend)
+log	./samples/Dutch.txt:30:31 - Unknown word (ANBI)
+log	./samples/Dutch.txt:30:37 - Unknown word (oftewel)
+log	./samples/Dutch.txt:30:46 - Unknown word (Algemeen)
+log	./samples/Dutch.txt:30:59 - Unknown word (Beogende)
+log	./samples/Dutch.txt:30:68 - Unknown word (Instelling)
+log	./samples/Dutch.txt:32:4 - Unknown word (Meedoen)
+log	./samples/Dutch.txt:32:13 - Unknown word (Iedereen)
+log	./samples/Dutch.txt:32:25 - Unknown word (welkom)
+log	./samples/Dutch.txt:32:42 - Unknown word (doen)
+log	./samples/Dutch.txt:32:53 - Unknown word (fouten)
+log	./samples/Dutch.txt:32:61 - Unknown word (discussieer)
+log	./samples/Dutch.txt:33:7 - Unknown word (mailinglijst)
+log	./samples/Dutch.txt:33:23 - Unknown word (draai)
+log	./samples/Dutch.txt:33:52 - Unknown word (dragen)
+log	./samples/Dutch.txt:33:75 - Unknown word (stemt)
+log	./samples/Dutch.txt:34:6 - Unknown word (ermee)
+log	./samples/Dutch.txt:34:22 - Unknown word (bijdrage)
+log	./samples/Dutch.txt:34:39 - Unknown word (desbetreffende)
+log	./samples/Dutch.txt:34:54 - Unknown word (taalhulpbestand)
+log	./samples/Dutch.txt:34:70 - Unknown word (beschikbaar)
+log	./samples/Dutch.txt:35:4 - Unknown word (komt)
+log	./samples/Dutch.txt:35:9 - Unknown word (onder)
+log	./samples/Dutch.txt:35:15 - Unknown word (vrije)
+log	./samples/Dutch.txt:35:27 - Unknown word (opensource)
+log	./samples/Dutch.txt:35:38 - Unknown word (licenties)
+log	./samples/Dutch.txt:35:49 - Unknown word (Indien)
+log	./samples/Dutch.txt:35:62 - Unknown word (wenst)
+log	./samples/Dutch.txt:36:4 - Unknown word (naam)
+log	./samples/Dutch.txt:36:23 - Unknown word (genoemd)
+log	./samples/Dutch.txt:36:31 - Unknown word (worden)
+log	./samples/Dutch.txt:36:42 - Unknown word (ontvangen)
+log	./samples/Dutch.txt:36:55 - Unknown word (schriftelijk)
+log	./samples/Dutch.txt:36:68 - Unknown word (verzoek)
+log	./samples/Dutch.txt:37:4 - Unknown word (daarvoor)
+log	./samples/Dutch.txt:37:13 - Unknown word (graag)
+log	./samples/Dutch.txt:38:4 - Unknown word (Rechten)
+log	./samples/Dutch.txt:38:16 - Unknown word (derden)
+log	./samples/Dutch.txt:38:33 - Unknown word (respecteert)
+log	./samples/Dutch.txt:38:48 - Unknown word (rechten)
+log	./samples/Dutch.txt:38:60 - Unknown word (derden)
+log	./samples/Dutch.txt:39:13 - Unknown word (gegevens)
+log	./samples/Dutch.txt:39:22 - Unknown word (vrij)
+log	./samples/Dutch.txt:39:27 - Unknown word (beschikbaar)
+log	./samples/Dutch.txt:39:39 - Unknown word (houden)
+log	./samples/Dutch.txt:39:47 - Unknown word (Voor)
+log	./samples/Dutch.txt:39:52 - Unknown word (bijdragen)
+log	./samples/Dutch.txt:40:6 - Unknown word (daarom)
+log	./samples/Dutch.txt:40:13 - Unknown word (niet)
+log	./samples/Dutch.txt:40:18 - Unknown word (zonder)
+log	./samples/Dutch.txt:40:25 - Unknown word (toestemming)
+log	./samples/Dutch.txt:40:37 - Unknown word (gebruikmaken)
+log	./samples/Dutch.txt:40:54 - Unknown word (beschermde)
+log	./samples/Dutch.txt:40:65 - Unknown word (naslagwerken)
+log	./samples/Dutch.txt:41:4 - Unknown word (zoals)
+log	./samples/Dutch.txt:41:10 - Unknown word (woordenboeken)
+log	./samples/Dutch.txt:41:36 - Unknown word (toegestaan)
+log	./samples/Dutch.txt:41:50 - Unknown word (gebruik)
+log	./samples/Dutch.txt:41:61 - Unknown word (maken)
+log	./samples/Dutch.txt:42:4 - Unknown word (materialen)
+log	./samples/Dutch.txt:42:22 - Unknown word (Nederlandse)
+log	./samples/Dutch.txt:42:34 - Unknown word (Taalunie)
+log	./samples/Dutch.txt:42:44 - Unknown word (zoals)
+log	./samples/Dutch.txt:42:53 - Unknown word (leidraad)
+log	./samples/Dutch.txt:42:68 - Unknown word (woordenlijst)
+log	./samples/Dutch.txt:43:4 - Unknown word (Indien)
+log	./samples/Dutch.txt:43:17 - Unknown word (mening)
+log	./samples/Dutch.txt:43:42 - Unknown word (inbreuk)
+log	./samples/Dutch.txt:43:50 - Unknown word (maakt)
+log	./samples/Dutch.txt:43:62 - Unknown word (rechten)
+log	./samples/Dutch.txt:44:4 - Unknown word (verzoeken)
+log	./samples/Dutch.txt:44:19 - Unknown word (hierover)
+log	./samples/Dutch.txt:44:31 - Unknown word (spoedig)
+log	./samples/Dutch.txt:44:39 - Unknown word (mogelijk)
+log	./samples/Dutch.txt:44:48 - Unknown word (schriftelijk)
+log	./samples/Dutch.txt:45:7 - Unknown word (nemen)
+log	./samples/Dutch.txt:46:13 - Unknown word (Stichting)
+log	./samples/Dutch.txt:59:56 - Unknown word (Brouwer)
+log	./samples/Dutch.txt:60:11 - Unknown word (Nederlandstalige)
+log	./samples/Dutch.txt:60:32 - Unknown word (Gebruikersgroep)
+log	./samples/Dutch.txt:68:42 - Unknown word (unported)
+log	./samples/Dutch.txt:74:39 - Unknown word (RABONL)
+log	./samples/Dutch.txt:74:49 - Unknown word (IBAN)
+log	./samples/Dutch.txt:74:59 - Unknown word (RABO)
+log	./samples/Dutch.txt:75:4 - Unknown word (Stichting)
+log	./samples/Dutch.txt:77:58 - Unknown word (algemeen)
+log	./samples/Dutch.txt:77:71 - Unknown word (beogende)
+log	./samples/Dutch.txt:78:4 - Unknown word (instelling)
+log	./samples/Dutch.txt:78:18 - Unknown word (ANBI)
+error	CSpell: Files checked: 1, Issues found: 189 in 1 files"
+`;
+
+exports[`Validate cli > app 'with spelling errors Dutch.txt' Expect Error: [Function CheckFailed] 3`] = `
+"
+1/1 [90m./samples/Dutch.txt[39m"
+`;
+
+exports[`Validate cli > app success 'suggest' run with [ 'suggest', 'café', …(2) ] 1`] = `[]`;
+
+exports[`Validate cli > app success 'suggest' run with [ 'suggest', 'café', …(2) ] 2`] = `
+"café:
+ - café"
+`;
+
+exports[`Validate cli > app success 'trace café' run with [ 'trace', 'café' ] 1`] = `[]`;
+
+exports[`Validate cli > app success 'trace café' run with [ 'trace', 'café' ] 2`] = `
+"Word F Dictionary           Dictionary Location           
+café - [flagWords]*         From Settings \`flagWords\`
+café - [ignoreWords]*       From Settings \`ignoreWords\`
+café - [words]*             From Settings \`words\`
+café - ada                  ../../node_modules/.pnpm...ell/dict-ada/dict/ada.txt
+café - aws*                 ../../node_modules/.pnpm...spell/dict-aws/aws.txt.gz
+café - bash                 ../../node_modules/.pnpm...-bash/dict/bash-words.txt
+café - companies*           ../../node_modules/.pnpm...panies/dict/companies.txt
+café - cpp                  ../../node_modules/.pnpm...spell/dict-cpp/cpp.txt.gz
+café - cpp-refined          ../../node_modules/.pnpm...ct-cpp/cpp-refined.txt.gz
+café - cryptocurrencies*    ../../node_modules/.pnpm...s/cryptocurrencies.txt.gz
+café - csharp               ../../node_modules/.pnpm...dict-csharp/csharp.txt.gz
+café - css                  ../../node_modules/.pnpm...ell/dict-css/dict/css.txt
+café - dart                 ../../node_modules/.pnpm...ell/dict-dart/dart.txt.gz
+café - django               ../../node_modules/.pnpm...ct-django/dict/django.txt
+café - docker               ../../node_modules/.pnpm...ocker/docker-words.txt.gz
+café - dotnet               ../../node_modules/.pnpm...ct-dotnet/dict/dotnet.txt
+café - elixir               ../../node_modules/.pnpm...ct-elixir/dict/elixir.txt
+café * en_us*               ../../node_modules/.pnpm.../dict-en_us/en_US.trie.gz
+café * en-gb                ../../node_modules/.pnpm.../dict-en-gb/en_GB.trie.gz
+café - filetypes*           ../../node_modules/.pnpm...iletypes/filetypes.txt.gz
+café - fonts                ../../node_modules/.pnpm...l/dict-fonts/fonts.txt.gz
+café - fullstack            ../../node_modules/.pnpm...lstack/dict/fullstack.txt
+café - gaming-terms         ../../node_modules/.pnpm...rms/dict/gaming-terms.txt
+café - golang               ../../node_modules/.pnpm...l/dict-golang/dict/go.txt
+café - haskell              ../../node_modules/.pnpm...-haskell/dict/haskell.txt
+café - html                 ../../node_modules/.pnpm...ell/dict-html/html.txt.gz
+café - html-symbol-entitie  ../../node_modules/.pnpm...-entities/entities.txt.gz
+café - java                 ../../node_modules/.pnpm.../dict-java/dict/java.trie
+café - k8s                  ../../node_modules/.pnpm...ell/dict-k8s/dict/k8s.txt
+café - latex                ../../node_modules/.pnpm...dict-latex/dict/latex.txt
+café - lorem-ipsum          ../../node_modules/.pnpm...m-ipsum/dictionary.txt.gz
+café - lua                  ../../node_modules/.pnpm...ell/dict-lua/dict/lua.txt
+café - networking-terms     ../../node_modules/.pnpm.../dict/networkingTerms.txt
+café - node                 ../../node_modules/.pnpm...l/dict-node/dict/node.txt
+café - npm                  ../../node_modules/.pnpm...ell/dict-npm/dict/npm.txt
+café - php                  ../../node_modules/.pnpm...ell/dict-php/dict/php.txt
+café - powershell           ../../node_modules/.pnpm...shell/dict/powershell.txt
+café - public-licenses*     ../../node_modules/.pnpm...es/public-licenses.txt.gz
+café - python               ../../node_modules/.pnpm...dict-python/python.txt.gz
+café - python-common        ../../node_modules/.pnpm...thon/python-common.txt.gz
+café - r                    ../../node_modules/.pnpm...s/@cspell/dict-r/r.txt.gz
+café - ruby                 ../../node_modules/.pnpm...l/dict-ruby/dict/ruby.txt
+café - rust                 ../../node_modules/.pnpm...l/dict-rust/dict/rust.txt
+café - scala                ../../node_modules/.pnpm...dict-scala/dict/scala.txt
+café - softwareTerms*       ../../node_modules/.pnpm...ms/dict/softwareTerms.txt
+café - sql                  ../../node_modules/.pnpm...spell/dict-sql/sql.txt.gz
+café - svelte               ../../node_modules/.pnpm...ct-svelte/dict/svelte.txt
+café - swift                ../../node_modules/.pnpm...l/dict-swift/swift.txt.gz
+café - typescript           ../../node_modules/.pnpm...cript/dict/typescript.txt
+café - web-services         ../../node_modules/.pnpm...erms/dict/webServices.txt
+café - workspace*           ../../cspell-dict.txt"
+`;
+
+exports[`Validate cli > app success 'trace hello' run with [ 'trace', '--locale=en-gb', 'hello' ] 1`] = `[]`;
+
+exports[`Validate cli > app success 'trace hello' run with [ 'trace', '--locale=en-gb', 'hello' ] 2`] = `
+"Word  F Dictionary           Dictionary Location           
+hello - [flagWords]*         From Settings \`flagWords\`
+hello - [ignoreWords]*       From Settings \`ignoreWords\`
+hello - [words]*             From Settings \`words\`
+hello - ada                  ../../node_modules/.pnpm...ll/dict-ada/dict/ada.txt
+hello - aws*                 ../../node_modules/.pnpm...pell/dict-aws/aws.txt.gz
+hello - bash                 ../../node_modules/.pnpm...bash/dict/bash-words.txt
+hello - companies*           ../../node_modules/.pnpm...anies/dict/companies.txt
+hello * cpp                  ../../node_modules/.pnpm...pell/dict-cpp/cpp.txt.gz
+hello - cpp-refined          ../../node_modules/.pnpm...t-cpp/cpp-refined.txt.gz
+hello - cryptocurrencies*    ../../node_modules/.pnpm.../cryptocurrencies.txt.gz
+hello - csharp               ../../node_modules/.pnpm...ict-csharp/csharp.txt.gz
+hello - css                  ../../node_modules/.pnpm...ll/dict-css/dict/css.txt
+hello - dart                 ../../node_modules/.pnpm...ll/dict-dart/dart.txt.gz
+hello - django               ../../node_modules/.pnpm...t-django/dict/django.txt
+hello - docker               ../../node_modules/.pnpm...cker/docker-words.txt.gz
+hello - dotnet               ../../node_modules/.pnpm...t-dotnet/dict/dotnet.txt
+hello - elixir               ../../node_modules/.pnpm...t-elixir/dict/elixir.txt
+hello * en_us                ../../node_modules/.pnpm...dict-en_us/en_US.trie.gz
+hello * en-gb*               ../../node_modules/.pnpm...dict-en-gb/en_GB.trie.gz
+hello - filetypes*           ../../node_modules/.pnpm...letypes/filetypes.txt.gz
+hello - fonts                ../../node_modules/.pnpm.../dict-fonts/fonts.txt.gz
+hello - fullstack            ../../node_modules/.pnpm...stack/dict/fullstack.txt
+hello - gaming-terms         ../../node_modules/.pnpm...ms/dict/gaming-terms.txt
+hello * golang               ../../node_modules/.pnpm.../dict-golang/dict/go.txt
+hello - haskell              ../../node_modules/.pnpm...haskell/dict/haskell.txt
+hello - html                 ../../node_modules/.pnpm...ll/dict-html/html.txt.gz
+hello - html-symbol-entitie  ../../node_modules/.pnpm...entities/entities.txt.gz
+hello - java                 ../../node_modules/.pnpm...dict-java/dict/java.trie
+hello - k8s                  ../../node_modules/.pnpm...ll/dict-k8s/dict/k8s.txt
+hello - latex                ../../node_modules/.pnpm...ict-latex/dict/latex.txt
+hello - lorem-ipsum          ../../node_modules/.pnpm...-ipsum/dictionary.txt.gz
+hello - lua                  ../../node_modules/.pnpm...ll/dict-lua/dict/lua.txt
+hello - networking-terms     ../../node_modules/.pnpm...dict/networkingTerms.txt
+hello * node                 ../../node_modules/.pnpm.../dict-node/dict/node.txt
+hello - npm                  ../../node_modules/.pnpm...ll/dict-npm/dict/npm.txt
+hello - php                  ../../node_modules/.pnpm...ll/dict-php/dict/php.txt
+hello - powershell           ../../node_modules/.pnpm...hell/dict/powershell.txt
+hello - public-licenses*     ../../node_modules/.pnpm...s/public-licenses.txt.gz
+hello - python               ../../node_modules/.pnpm...ict-python/python.txt.gz
+hello - python-common        ../../node_modules/.pnpm...hon/python-common.txt.gz
+hello - r                    ../../node_modules/.pnpm.../@cspell/dict-r/r.txt.gz
+hello - ruby                 ../../node_modules/.pnpm.../dict-ruby/dict/ruby.txt
+hello - rust                 ../../node_modules/.pnpm.../dict-rust/dict/rust.txt
+hello - scala                ../../node_modules/.pnpm...ict-scala/dict/scala.txt
+hello - softwareTerms*       ../../node_modules/.pnpm...s/dict/softwareTerms.txt
+hello - sql                  ../../node_modules/.pnpm...pell/dict-sql/sql.txt.gz
+hello - svelte               ../../node_modules/.pnpm...t-svelte/dict/svelte.txt
+hello - swift                ../../node_modules/.pnpm.../dict-swift/swift.txt.gz
+hello - typescript           ../../node_modules/.pnpm...ript/dict/typescript.txt
+hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
+hello - workspace*           ../../cspell-dict.txt"
+`;
+
+exports[`Validate cli > app success 'trace hello' run with [ 'trace', 'hello' ] 1`] = `[]`;
+
+exports[`Validate cli > app success 'trace hello' run with [ 'trace', 'hello' ] 2`] = `
+"Word  F Dictionary           Dictionary Location           
+hello - [flagWords]*         From Settings \`flagWords\`
+hello - [ignoreWords]*       From Settings \`ignoreWords\`
+hello - [words]*             From Settings \`words\`
+hello - ada                  ../../node_modules/.pnpm...ll/dict-ada/dict/ada.txt
+hello - aws*                 ../../node_modules/.pnpm...pell/dict-aws/aws.txt.gz
+hello - bash                 ../../node_modules/.pnpm...bash/dict/bash-words.txt
+hello - companies*           ../../node_modules/.pnpm...anies/dict/companies.txt
+hello * cpp                  ../../node_modules/.pnpm...pell/dict-cpp/cpp.txt.gz
+hello - cpp-refined          ../../node_modules/.pnpm...t-cpp/cpp-refined.txt.gz
+hello - cryptocurrencies*    ../../node_modules/.pnpm.../cryptocurrencies.txt.gz
+hello - csharp               ../../node_modules/.pnpm...ict-csharp/csharp.txt.gz
+hello - css                  ../../node_modules/.pnpm...ll/dict-css/dict/css.txt
+hello - dart                 ../../node_modules/.pnpm...ll/dict-dart/dart.txt.gz
+hello - django               ../../node_modules/.pnpm...t-django/dict/django.txt
+hello - docker               ../../node_modules/.pnpm...cker/docker-words.txt.gz
+hello - dotnet               ../../node_modules/.pnpm...t-dotnet/dict/dotnet.txt
+hello - elixir               ../../node_modules/.pnpm...t-elixir/dict/elixir.txt
+hello * en_us*               ../../node_modules/.pnpm...dict-en_us/en_US.trie.gz
+hello * en-gb                ../../node_modules/.pnpm...dict-en-gb/en_GB.trie.gz
+hello - filetypes*           ../../node_modules/.pnpm...letypes/filetypes.txt.gz
+hello - fonts                ../../node_modules/.pnpm.../dict-fonts/fonts.txt.gz
+hello - fullstack            ../../node_modules/.pnpm...stack/dict/fullstack.txt
+hello - gaming-terms         ../../node_modules/.pnpm...ms/dict/gaming-terms.txt
+hello * golang               ../../node_modules/.pnpm.../dict-golang/dict/go.txt
+hello - haskell              ../../node_modules/.pnpm...haskell/dict/haskell.txt
+hello - html                 ../../node_modules/.pnpm...ll/dict-html/html.txt.gz
+hello - html-symbol-entitie  ../../node_modules/.pnpm...entities/entities.txt.gz
+hello - java                 ../../node_modules/.pnpm...dict-java/dict/java.trie
+hello - k8s                  ../../node_modules/.pnpm...ll/dict-k8s/dict/k8s.txt
+hello - latex                ../../node_modules/.pnpm...ict-latex/dict/latex.txt
+hello - lorem-ipsum          ../../node_modules/.pnpm...-ipsum/dictionary.txt.gz
+hello - lua                  ../../node_modules/.pnpm...ll/dict-lua/dict/lua.txt
+hello - networking-terms     ../../node_modules/.pnpm...dict/networkingTerms.txt
+hello * node                 ../../node_modules/.pnpm.../dict-node/dict/node.txt
+hello - npm                  ../../node_modules/.pnpm...ll/dict-npm/dict/npm.txt
+hello - php                  ../../node_modules/.pnpm...ll/dict-php/dict/php.txt
+hello - powershell           ../../node_modules/.pnpm...hell/dict/powershell.txt
+hello - public-licenses*     ../../node_modules/.pnpm...s/public-licenses.txt.gz
+hello - python               ../../node_modules/.pnpm...ict-python/python.txt.gz
+hello - python-common        ../../node_modules/.pnpm...hon/python-common.txt.gz
+hello - r                    ../../node_modules/.pnpm.../@cspell/dict-r/r.txt.gz
+hello - ruby                 ../../node_modules/.pnpm.../dict-ruby/dict/ruby.txt
+hello - rust                 ../../node_modules/.pnpm.../dict-rust/dict/rust.txt
+hello - scala                ../../node_modules/.pnpm...ict-scala/dict/scala.txt
+hello - softwareTerms*       ../../node_modules/.pnpm...s/dict/softwareTerms.txt
+hello - sql                  ../../node_modules/.pnpm...pell/dict-sql/sql.txt.gz
+hello - svelte               ../../node_modules/.pnpm...t-svelte/dict/svelte.txt
+hello - swift                ../../node_modules/.pnpm.../dict-swift/swift.txt.gz
+hello - typescript           ../../node_modules/.pnpm...ript/dict/typescript.txt
+hello - web-services         ../../node_modules/.pnpm...rms/dict/webServices.txt
+hello - workspace*           ../../cspell-dict.txt"
+`;
+
+exports[`Validate cli > app suggest [ 'sug' ] 1`] = `
+[
+  "Usage: cspell suggestions|sug [options] [words...]",
+  "",
+  "Spelling Suggestions for words.",
+  "",
+  "Options:",
+  "  -c, --config <cspell.json>            Configuration file to use.  By default",
+  "                                        cspell looks for cspell.json in the",
+  "                                        current directory.",
+  "  --locale <locale>                     Set language locales. i.e. \\"en,fr\\" for",
+  "                                        English and French, or \\"en-GB\\" for",
+  "                                        British English.",
+  "  --language-id <language>              Use programming language. i.e. \\"php\\" or",
+  "                                        \\"scala\\".",
+  "  -s, --no-strict                       Ignore case and accents when searching",
+  "                                        for words.",
+  "  --ignore-case                         Alias of --no-strict.",
+  "  --num-changes <number>                Number of changes allowed to a word",
+  "                                        (default: 4)",
+  "  --num-suggestions <number>            Number of suggestions (default: 8)",
+  "  --no-include-ties                     Force the number of suggested to be",
+  "                                        limited, by not including suggestions",
+  "                                        that have the same edit cost.",
+  "  --stdin                               Use stdin for input.",
+  "  --repl                                REPL interface for looking up",
+  "                                        suggestions.",
+  "  -v, --verbose                         Show detailed output.",
+  "  -d, --dictionary <dictionary name>    Use the dictionary specified. Only",
+  "                                        dictionaries specified will be used.",
+  "  --dictionaries <dictionary names...>  Use the dictionaries specified. Only",
+  "                                        dictionaries specified will be used.",
+  "  --no-color                            Turn off color.",
+  "  --color                               Force color",
+  "  -h, --help                            display help for command",
+  "",
+]
+`;
+
+exports[`Validate cli > app suggest [ 'sug' ] 2`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug' ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', '--stdin', '-d=en_us', '-v' ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', '--stdin', '-d=en_us', '-v' ] 2`] = `
+"mexico:
+ - Mexico      -    1 en_us
+ - medico      -  100 en_us
+ - medic       -  190 en_us
+ - melic       -  190 en_us
+ - mesic       -  190 en_us
+ - metic       -  190 en_us
+ - Mexican     -  191 en_us
+ - Mexico's    -  191 en_us"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', '--stdin', '-d=en_us', '-v' ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', '-d=en_us', …(3) ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', '-d=en_us', …(3) ] 2`] = `
+"dutch:
+ - dutch    -    0 en-gb, en_us
+ - Dutch    -    1 en_us"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', '-d=en_us', …(3) ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(3) ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(3) ] 2`] = `
+"dutch:
+ - dutch    -    0 en_us
+ - Dutch    -    1 en_us"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(3) ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(3) ] 4`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(3) ] 5`] = `
+"dutch:
+ - dutch    -    0 en_us
+ - Dutch    -    1 en_us"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(3) ] 6`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(4) ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(4) ] 2`] = `
+"dutch:
+ - dutch    -    0 en-gb, en_us
+ - Dutch    -    1 en_us"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'dutch', …(4) ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us' ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us' ] 2`] = `
+"mexico:
+ - Mexico
+ - medico
+ - medic
+ - melic
+ - mesic
+ - metic
+ - Mexican
+ - Mexico's"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us' ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us', '-v' ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us', '-v' ] 2`] = `
+"mexico:
+ - Mexico      -    1 en_us
+ - medico      -  100 en_us
+ - medic       -  190 en_us
+ - melic       -  190 en_us
+ - mesic       -  190 en_us
+ - metic       -  190 en_us
+ - Mexican     -  191 en_us
+ - Mexico's    -  191 en_us"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us', '-v' ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us', …(2) ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us', …(2) ] 2`] = `
+"mexico:
+ <no suggestions>"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en_us', …(2) ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-gb' ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-gb' ] 2`] = `
+"mexico:
+ - mexico
+ - medico
+ - mexico's
+ - mexican
+ - medicos
+ - medich
+ - medici
+ - medics
+ - melick"
+`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-gb' ] 3`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-us' ] 1`] = `[]`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-us' ] 2`] = `""`;
+
+exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-us' ] 3`] = `"Unknown dictionary: \\"en-us\\""`;

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -4,14 +4,15 @@ import * as Path from 'path';
 import * as readline from 'readline';
 import stripAnsi from 'strip-ansi';
 import * as Util from 'util';
+import { afterEach, beforeEach, describe, expect, test, vi, type Constructable } from 'vitest';
 import { URI } from 'vscode-uri';
 
 import * as app from './app';
 import * as Link from './link';
 import { mergeAsyncIterables } from './util/async';
 
-jest.mock('readline');
-const mockCreateInterface = jest.mocked(readline.createInterface);
+vi.mock('readline');
+const mockCreateInterface = vi.mocked(readline.createInterface);
 
 const hideOutput = true;
 
@@ -39,7 +40,7 @@ function pathFix(...parts: string[]): string {
 }
 
 // [message, args, resolve, error, log, info]
-type ErrorCheck = undefined | jest.Constructable | string | RegExp;
+type ErrorCheck = undefined | Constructable | string | RegExp;
 
 interface TestCase {
     msg: string;
@@ -99,12 +100,12 @@ const colorLevel = chalk.level;
 
 describe('Validate cli', () => {
     const logger = makeLogger();
-    let error = jest.spyOn(console, 'error').mockName('console.error').mockImplementation(logger.error);
-    let log = jest.spyOn(console, 'log').mockName('console.log').mockImplementation(logger.log);
-    let info = jest.spyOn(console, 'info').mockName('console.info').mockImplementation(logger.info);
-    const listGlobalImports = jest.spyOn(Link, 'listGlobalImports').mockName('istGlobalImports');
-    const addPathsToGlobalImports = jest.spyOn(Link, 'addPathsToGlobalImports').mockName('addPathsToGlobalImports');
-    const removePathsFromGlobalImports = jest
+    let error = vi.spyOn(console, 'error').mockName('console.error').mockImplementation(logger.error);
+    let log = vi.spyOn(console, 'log').mockName('console.log').mockImplementation(logger.log);
+    let info = vi.spyOn(console, 'info').mockName('console.info').mockImplementation(logger.info);
+    const listGlobalImports = vi.spyOn(Link, 'listGlobalImports').mockName('istGlobalImports');
+    const addPathsToGlobalImports = vi.spyOn(Link, 'addPathsToGlobalImports').mockName('addPathsToGlobalImports');
+    const removePathsFromGlobalImports = vi
         .spyOn(Link, 'removePathsFromGlobalImports')
         .mockName('removePathsFromGlobalImports');
     const captureStdout = new RecordStdStream();
@@ -113,9 +114,9 @@ describe('Validate cli', () => {
     beforeEach(() => {
         mockCreateInterface.mockClear();
         logger.clear();
-        error = jest.spyOn(console, 'error').mockName('console.error').mockImplementation(logger.error);
-        log = jest.spyOn(console, 'log').mockName('console.log').mockImplementation(logger.log);
-        info = jest.spyOn(console, 'info').mockName('console.info').mockImplementation(logger.info);
+        error = vi.spyOn(console, 'error').mockName('console.error').mockImplementation(logger.error);
+        log = vi.spyOn(console, 'log').mockName('console.log').mockImplementation(logger.log);
+        info = vi.spyOn(console, 'info').mockName('console.info').mockImplementation(logger.info);
         captureStdout.startCapture();
         captureStderr.startCapture();
         chalk.level = 3;

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -4,7 +4,7 @@ import * as Path from 'path';
 import * as readline from 'readline';
 import stripAnsi from 'strip-ansi';
 import * as Util from 'util';
-import { afterEach, beforeEach, describe, expect, test, vi, type Constructable } from 'vitest';
+import { afterEach, beforeEach, type Constructable, describe, expect, test, vi } from 'vitest';
 import { URI } from 'vscode-uri';
 
 import * as app from './app';
@@ -178,17 +178,15 @@ describe('Validate cli', () => {
         const args = argv(...testArgs);
         const result = app.run(commander, args);
         if (!errorCheck) {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).resolves.toBeUndefined();
         } else {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).rejects.toThrow(errorCheck);
         }
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eError ? expect(error).toHaveBeenCalled() : expect(error).not.toHaveBeenCalled();
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
         expect(captureStdout.text).toMatchSnapshot();
         expect(logger.normalizedHistory()).toMatchSnapshot();
@@ -210,17 +208,15 @@ describe('Validate cli', () => {
         const args = argv(...testArgs);
         const result = app.run(commander, args);
         if (!errorCheck) {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).resolves.toBeUndefined();
         } else {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).rejects.toThrow(errorCheck);
         }
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eError ? expect(error).toHaveBeenCalled() : expect(error).not.toHaveBeenCalled();
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
         expect(captureStdout.text).toMatchSnapshot();
         expect(normalizeLogCalls(log.mock.calls)).toMatchSnapshot();
@@ -256,17 +252,15 @@ describe('Validate cli', () => {
         const args = argv(...testArgs);
         const result = app.run(commander, args);
         if (!errorCheck) {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).resolves.toBeUndefined();
         } else {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).rejects.toThrow(errorCheck);
         }
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eError ? expect(error).toHaveBeenCalled() : expect(error).not.toHaveBeenCalled();
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eLog ? expect(log).toHaveBeenCalled() : expect(log).not.toHaveBeenCalled();
-        // eslint-disable-next-line jest/no-conditional-expect
+
         eInfo ? expect(info).toHaveBeenCalled() : expect(info).not.toHaveBeenCalled();
         expect(normalizeOutput(captureStdout.text)).toMatchSnapshot();
     });
@@ -297,10 +291,8 @@ describe('Validate cli', () => {
         const args = argv(...testArgs);
         const result = app.run(commander, args);
         if (!errorCheck) {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).resolves.toBeUndefined();
         } else {
-            // eslint-disable-next-line jest/no-conditional-expect
             await expect(result).rejects.toThrow(errorCheck);
         }
         expect(captureStdout.text).toMatchSnapshot();

--- a/packages/cspell/src/application.test.ts
+++ b/packages/cspell/src/application.test.ts
@@ -1,9 +1,9 @@
 import type { Issue, RunResult } from '@cspell/cspell-types';
 import * as fs from 'fs/promises';
+import getStdin from 'get-stdin';
 import * as path from 'path';
 import { resolve as r } from 'path';
-import getStdin from 'get-stdin';
-import { describe, expect, test, vi, afterEach } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import * as App from './application';
 import type { LinterOptions, TraceOptions } from './options';
@@ -153,7 +153,7 @@ describe('Validate the Application', () => {
                 cspell:ignore badspellingintext
                 We can ignore values within the text: badspellingintext
             `;
-            const mockGetStdin = vi.mocked(getStdin).mockImplementation(async () => text);
+            vi.mocked(getStdin).mockImplementation(async () => text);
 
             const lint = App.lint(files, options, reporter);
             const result = await lint;

--- a/packages/cspell/src/cli-reporter.test.ts
+++ b/packages/cspell/src/cli-reporter.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import type { ReporterIssue } from './cli-reporter';
 import { __testing__ } from './cli-reporter';
 

--- a/packages/cspell/src/emitters/__snapshots__/suggestionsEmitter.test.ts.snap
+++ b/packages/cspell/src/emitters/__snapshots__/suggestionsEmitter.test.ts.snap
@@ -1,31 +1,31 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1
 
-exports[`suggestionsEmitter emitSuggestionResult walk {"compoundWord": undefined, "cost": 0, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walk"} {"compoundWord": undefined, "cost": 2, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walked"} {"verbose": 1} 1`] = `
+exports[`suggestionsEmitter > emitSuggestionResult 'walk' { word: 'walk', cost: +0, …(4) } { word: 'walked', cost: 2, …(4) } { verbose: 1 } 1`] = `
 "walk:
  - walk      -    0 dict-a
  - walked    -    2 dict-a"
 `;
 
-exports[`suggestionsEmitter emitSuggestionResult walk {"compoundWord": undefined, "cost": 0, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walk"} {"compoundWord": undefined, "cost": 2, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walked"} {} 1`] = `
-"walk:
- - walk
- - walked"
-`;
-
-exports[`suggestionsEmitter emitSuggestionResult walk {"compoundWord": undefined, "cost": 0, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walk"} {"compoundWord": undefined, "cost": 2, "dictionaries": [Array], "forbidden": false, "noSuggest": true, "word": "walked"} {"verbose": 1} 1`] = `
+exports[`suggestionsEmitter > emitSuggestionResult 'walk' { word: 'walk', cost: +0, …(4) } { word: 'walked', cost: 2, …(4) } { verbose: 1 } 2`] = `
 "walk:
  - walk      -    0 dict-a
  - walked  N -    2 dict-a"
 `;
 
-exports[`suggestionsEmitter emitSuggestionResult walk {"compoundWord": undefined, "cost": 0, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walk"} {"compoundWord": undefined, "cost": 2, "dictionaries": [Array], "forbidden": true, "noSuggest": false, "word": "walked"} {"verbose": 1} 1`] = `
+exports[`suggestionsEmitter > emitSuggestionResult 'walk' { word: 'walk', cost: +0, …(4) } { word: 'walked', cost: 2, …(4) } { verbose: 1 } 3`] = `
 "walk:
  - walk      -    0 dict-a
  - walked X  -    2 dict-a"
 `;
 
-exports[`suggestionsEmitter emitSuggestionResult walk {"compoundWord": undefined, "cost": 0, "dictionaries": [Array], "forbidden": false, "noSuggest": false, "word": "walk"} {"compoundWord": undefined, "cost": 2, "dictionaries": [Array], "forbidden": true, "noSuggest": true, "word": "walked"} {"verbose": 1} 1`] = `
+exports[`suggestionsEmitter > emitSuggestionResult 'walk' { word: 'walk', cost: +0, …(4) } { word: 'walked', cost: 2, …(4) } { verbose: 1 } 4`] = `
 "walk:
  - walk      -    0 dict-a
  - walked XN -    2 dict-a"
+`;
+
+exports[`suggestionsEmitter > emitSuggestionResult 'walk' { word: 'walk', cost: +0, …(4) } { word: 'walked', cost: 2, …(4) } {} 1`] = `
+"walk:
+ - walk
+ - walked"
 `;

--- a/packages/cspell/src/emitters/suggestionsEmitter.test.ts
+++ b/packages/cspell/src/emitters/suggestionsEmitter.test.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import type { SuggestedWord } from 'cspell-lib';
+import { describe, expect, test, vi } from 'vitest';
 
 import type { EmitSuggestionOptions } from './suggestionsEmitter';
 import { emitSuggestionResult } from './suggestionsEmitter';
@@ -15,7 +16,7 @@ describe('suggestionsEmitter', () => {
         ${'walk'} | ${sw('walk', 0)} | ${sw('walked', 2, { forbidden: true })}                  | ${opts({ verbose: 1 })}
         ${'walk'} | ${sw('walk', 0)} | ${sw('walked', 2, { forbidden: true, noSuggest: true })} | ${opts({ verbose: 1 })}
     `('emitSuggestionResult $word $sug1 $sug2 $options', ({ word, sug1, sug2, options }) => {
-        const log = jest.fn();
+        const log = vi.fn();
         const sr = {
             word,
             suggestions: [sug1, sug2].filter((a) => !!a),

--- a/packages/cspell/src/emitters/traceEmitter.test.ts
+++ b/packages/cspell/src/emitters/traceEmitter.test.ts
@@ -1,4 +1,5 @@
 import strip from 'strip-ansi';
+import { describe, expect, test, vi } from 'vitest';
 
 import type { TraceResult } from '../application';
 import { emitTraceResults } from './traceEmitter';
@@ -6,14 +7,14 @@ import { emitTraceResults } from './traceEmitter';
 describe('traceEmitter', () => {
     test('empty', () => {
         const lines: string[] = [];
-        jest.spyOn(console, 'log').mockImplementation((a) => lines.push(strip(a)));
+        vi.spyOn(console, 'log').mockImplementation((a) => lines.push(strip(a)));
         emitTraceResults([], { cwd: '/', lineWidth: 80 });
         expect(lines).toEqual(['Word F Dictionary           Dictionary Location           ']);
     });
 
     test('narrow screen with compound words', () => {
         const lines: string[] = [];
-        jest.spyOn(console, 'log').mockImplementation((a) => lines.push(strip(a)));
+        vi.spyOn(console, 'log').mockImplementation((a) => lines.push(strip(a)));
         const lineWidth = 80;
         emitTraceResults(sampleResults(), { cwd: '/this_is_a_very/long/path', lineWidth });
         expect(lines.reduce((a, b) => Math.max(a, b.length), 0)).toBeLessThanOrEqual(lineWidth);

--- a/packages/cspell/src/featureFlags/featureFlags.test.ts
+++ b/packages/cspell/src/featureFlags/featureFlags.test.ts
@@ -1,8 +1,10 @@
+import { describe, expect, test, vi } from 'vitest';
+
 import { getFeatureFlags, parseFeatureFlags } from './featureFlags';
 
 describe('featureFlags', () => {
     test('Unknown flag', () => {
-        const warn = jest.spyOn(console, 'warn').mockImplementation();
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
         parseFeatureFlags(['unknown-flag']);
         expect(warn).toHaveBeenCalledWith('Unknown flag: "unknown-flag"');
     });

--- a/packages/cspell/src/index.test.ts
+++ b/packages/cspell/src/index.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 // Make sure the types are exported.
 import type { CSpellApplicationOptions } from './index';
 import * as index from './index';

--- a/packages/cspell/src/link.test.ts
+++ b/packages/cspell/src/link.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import { addPathsToGlobalImportsResultToTable, listGlobalImportsResultToTable } from './link';
 
 const esc = expect.stringContaining;

--- a/packages/cspell/src/lint/lint.test.ts
+++ b/packages/cspell/src/lint/lint.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import * as path from 'path';
 
 import { CheckFailed } from '../app';

--- a/packages/cspell/src/lint/lint.test.ts
+++ b/packages/cspell/src/lint/lint.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, test } from 'vitest';
-
 import * as path from 'path';
+import { describe, expect, test } from 'vitest';
 
 import { CheckFailed } from '../app';
 import { InMemoryReporter } from '../util/InMemoryReporter';

--- a/packages/cspell/src/lint/lint.ts
+++ b/packages/cspell/src/lint/lint.ts
@@ -277,7 +277,7 @@ export async function runLint(cfg: LintRequest): Promise<RunResult> {
 
         const reporters = cfg.options.reporter ?? configInfo.config.reporters;
 
-        reporter = mergeReporters(...loadReporters(reporters, cfg.reporter, reporterConfig));
+        reporter = mergeReporters(...(await loadReporters(reporters, cfg.reporter, reporterConfig)));
         cspell.setLogger(getLoggerFromReporter(reporter));
 
         const globInfo = await determineGlobs(configInfo, cfg);

--- a/packages/cspell/src/options.test.ts
+++ b/packages/cspell/src/options.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import { fixLegacy } from './options';
 
 describe('options', () => {

--- a/packages/cspell/src/util/__snapshots__/reporters.test.ts.snap
+++ b/packages/cspell/src/util/__snapshots__/reporters.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1
 
-exports[`mergeReporters processes a multiple reporters 1`] = `
+exports[`mergeReporters > processes a multiple reporters 1`] = `
 {
   "issues": [
     {
@@ -41,7 +41,7 @@ exports[`mergeReporters processes a multiple reporters 1`] = `
 }
 `;
 
-exports[`mergeReporters processes a multiple reporters 2`] = `
+exports[`mergeReporters > processes a multiple reporters 2`] = `
 {
   "issues": [
     {
@@ -82,7 +82,7 @@ exports[`mergeReporters processes a multiple reporters 2`] = `
 }
 `;
 
-exports[`mergeReporters processes a multiple reporters 3`] = `
+exports[`mergeReporters > processes a multiple reporters 3`] = `
 {
   "issues": [
     {
@@ -123,7 +123,7 @@ exports[`mergeReporters processes a multiple reporters 3`] = `
 }
 `;
 
-exports[`mergeReporters processes a single reporter 1`] = `
+exports[`mergeReporters > processes a single reporter 1`] = `
 {
   "issues": [
     {

--- a/packages/cspell/src/util/cache/DiskCache.test.ts
+++ b/packages/cspell/src/util/cache/DiskCache.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test, vi, type Mock } from 'vitest';
-
 import { createFromFile } from 'file-entry-cache';
 import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
 import * as fileHelper from '../../util/fileHelper';
 import type { CachedFileResult, CSpellCacheMeta } from './DiskCache';
-import { DiskCache, __testing__ } from './DiskCache';
+import { __testing__, DiskCache } from './DiskCache';
 
 const { calcVersion } = __testing__;
 

--- a/packages/cspell/src/util/cache/ObjectCollection.test.ts
+++ b/packages/cspell/src/util/cache/ObjectCollection.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import { Collection, ShallowObjectCollection } from './ObjectCollection';
 
 const objects = (function () {

--- a/packages/cspell/src/util/cache/createCache.test.ts
+++ b/packages/cspell/src/util/cache/createCache.test.ts
@@ -1,15 +1,16 @@
 import * as path from 'path';
 import { resolve as r } from 'path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CacheOptions } from './CacheOptions';
 import type { CreateCacheSettings } from './createCache';
-import { __testing__, calcCacheSettings, createCache } from './createCache';
+import { calcCacheSettings, createCache, __testing__ } from './createCache';
 import { DiskCache } from './DiskCache';
 import { DummyCache } from './DummyCache';
 
-jest.mock('./DiskCache');
+vi.mock('./DiskCache');
 
-const mockedDiskCache = jest.mocked(DiskCache);
+const mockedDiskCache = vi.mocked(DiskCache);
 
 const version = '5.20.0-alpha.192';
 

--- a/packages/cspell/src/util/cache/createCache.test.ts
+++ b/packages/cspell/src/util/cache/createCache.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CacheOptions } from './CacheOptions';
 import type { CreateCacheSettings } from './createCache';
-import { calcCacheSettings, createCache, __testing__ } from './createCache';
+import { __testing__, calcCacheSettings, createCache } from './createCache';
 import { DiskCache } from './DiskCache';
 import { DummyCache } from './DummyCache';
 

--- a/packages/cspell/src/util/cache/fileEntryCache.ts
+++ b/packages/cspell/src/util/cache/fileEntryCache.ts
@@ -3,10 +3,11 @@
  */
 
 export type { FileDescriptor } from 'file-entry-cache';
+import { isMainThread } from 'node:worker_threads';
+
 import type { FileEntryCache as FecFileEntryCache } from 'file-entry-cache';
 import * as file_entry_cache from 'file-entry-cache';
 import { mkdirSync } from 'fs';
-import { isMainThread } from 'node:worker_threads';
 import * as path from 'path';
 
 export type FileEntryCache = FecFileEntryCache;

--- a/packages/cspell/src/util/cache/fileEntryCache.ts
+++ b/packages/cspell/src/util/cache/fileEntryCache.ts
@@ -6,6 +6,7 @@ export type { FileDescriptor } from 'file-entry-cache';
 import type { FileEntryCache as FecFileEntryCache } from 'file-entry-cache';
 import * as file_entry_cache from 'file-entry-cache';
 import { mkdirSync } from 'fs';
+import { isMainThread } from 'node:worker_threads';
 import * as path from 'path';
 
 export type FileEntryCache = FecFileEntryCache;
@@ -71,10 +72,10 @@ export function createFromFile(pathToCache: string, useCheckSum: boolean, useRel
         return (...params: P) => {
             const cwd = process.cwd();
             try {
-                process.chdir(relDir);
+                isMainThread && process.chdir(relDir);
                 return fn(cwd, ...params);
             } finally {
-                process.chdir(cwd);
+                isMainThread && process.chdir(cwd);
             }
         };
     }

--- a/packages/cspell/src/util/errors.test.ts
+++ b/packages/cspell/src/util/errors.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from 'vitest';
+
 import { ApplicationError, CheckFailed, IOError, isError, toApplicationError, toError } from './errors';
 
 const oc = expect.objectContaining;

--- a/packages/cspell/src/util/fileHelper.test.ts
+++ b/packages/cspell/src/util/fileHelper.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import getStdin from 'get-stdin';
 
 import { asyncIterableToArray } from './async';
 import { IOError } from './errors';
@@ -13,6 +14,10 @@ import {
     resolveFilename,
 } from './fileHelper';
 
+vi.mock('get-stdin', () => ({
+    default: vi.fn(),
+}));
+
 const packageRoot = path.join(__dirname, '../..');
 const fixtures = path.join(packageRoot, 'fixtures/fileHelper');
 const fileListFile = path.join(fixtures, 'file-list.txt');
@@ -22,14 +27,16 @@ const oc = expect.objectContaining;
 const r = path.resolve;
 
 describe('fileHelper', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
     test('readFileListFile', async () => {
         try {
             const files = ['a', 'b', 'c'];
-            process.stdin.isTTY = false;
+            const mockGetStdin = vi.mocked(getStdin);
+            mockGetStdin.mockImplementation(async () => files.join('\n'));
             const pResult = readFileListFile('stdin');
-            process.stdin.push(files.join('\n'));
-            // need to delay the `end` event or it might become a race condition.
-            setTimeout(() => process.stdin.emit('end'), 1);
             const r = await pResult;
             expect(r).toEqual(files.map((f) => path.resolve(f)));
         } finally {

--- a/packages/cspell/src/util/fileHelper.test.ts
+++ b/packages/cspell/src/util/fileHelper.test.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
-import { describe, test, expect, vi, afterEach } from 'vitest';
 import getStdin from 'get-stdin';
+import * as path from 'path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { asyncIterableToArray } from './async';
 import { IOError } from './errors';

--- a/packages/cspell/src/util/fileHelper.test.ts
+++ b/packages/cspell/src/util/fileHelper.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { describe, test, expect } from 'vitest';
 
 import { asyncIterableToArray } from './async';
 import { IOError } from './errors';

--- a/packages/cspell/src/util/glob.test.ts
+++ b/packages/cspell/src/util/glob.test.ts
@@ -4,7 +4,7 @@ import micromatch from 'micromatch';
 import type { MinimatchOptions } from 'minimatch';
 import { minimatch } from 'minimatch';
 import * as path from 'path';
-import { describe, test, expect, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { calcGlobs, normalizeGlobsToRoot } from './glob';
 

--- a/packages/cspell/src/util/glob.test.ts
+++ b/packages/cspell/src/util/glob.test.ts
@@ -4,6 +4,7 @@ import micromatch from 'micromatch';
 import type { MinimatchOptions } from 'minimatch';
 import { minimatch } from 'minimatch';
 import * as path from 'path';
+import { describe, test, expect, vi } from 'vitest';
 
 import { calcGlobs, normalizeGlobsToRoot } from './glob';
 
@@ -11,8 +12,8 @@ const getStdinResult = {
     value: '',
 };
 
-jest.mock('get-stdin', () => {
-    return jest.fn(() => Promise.resolve(getStdinResult.value));
+vi.mock('get-stdin', () => {
+    return vi.fn(() => Promise.resolve(getStdinResult.value));
 });
 
 describe('Validate minimatch assumptions', () => {

--- a/packages/cspell/src/util/reporters.test.ts
+++ b/packages/cspell/src/util/reporters.test.ts
@@ -1,27 +1,31 @@
 import type { CSpellReporter, ReporterSettings } from '@cspell/cspell-types';
 import { MessageTypes } from '@cspell/cspell-types';
+import { describe, test, expect, vi } from 'vitest';
 
 import { InMemoryReporter } from './InMemoryReporter';
 import { loadReporters, mergeReporters } from './reporters';
 
 const defaultReporter: CSpellReporter = {
-    issue: jest.fn(),
-    info: jest.fn(),
-    debug: jest.fn(),
-    error: jest.fn(),
-    progress: jest.fn(),
-    result: jest.fn(),
+    issue: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    progress: vi.fn(),
+    result: vi.fn(),
 };
 
+const oc = (obj: unknown) => expect.objectContaining(obj);
+const sc = (s: string) => expect.stringContaining(s);
+
 describe('mergeReporters', () => {
-    it('processes a single reporter', async () => {
+    test('processes a single reporter', async () => {
         const reporter = new InMemoryReporter();
         await runReporter(mergeReporters(reporter));
 
         expect(reporter.dump()).toMatchSnapshot();
     });
 
-    it('processes a multiple reporters', async () => {
+    test('processes a multiple reporters', async () => {
         const reporters = [new InMemoryReporter(), new InMemoryReporter(), new InMemoryReporter()];
         await runReporter(mergeReporters(...reporters));
 
@@ -30,21 +34,21 @@ describe('mergeReporters', () => {
         });
     });
 
-    test('loadReporters', () => {
+    test('loadReporters', async () => {
         const reporters: ReporterSettings[] = [['@cspell/cspell-json-reporter', { outFile: 'out.json' }]];
-        const loaded = loadReporters(reporters, defaultReporter, {});
+        const loaded = await loadReporters(reporters, defaultReporter, {});
         expect(loaded).toEqual([expect.objectContaining({})]);
     });
 
     test.each`
         reporter                                   | expected
-        ${['@cspell/cspell-json-reporter', false]} | ${'Failed to load reporter @cspell/cspell-json-reporter: cspell-json-reporter settings must be an object'}
-        ${['@cspell/cspell-unknown-reporter']}     | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
-        ${'@cspell/cspell-unknown-reporter'}       | ${"Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find module '@cspell/cspell-unknown-reporter' from 'src/util/reporters.ts'"}
-    `('loadReporters fail $reporter', ({ reporter, expected }) => {
+        ${['@cspell/cspell-json-reporter', false]} | ${Error('Failed to load reporter @cspell/cspell-json-reporter: cspell-json-reporter settings must be an object')}
+        ${['@cspell/cspell-unknown-reporter']}     | ${oc({ message: sc("Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find package '@cspell/cspell-unknown-reporter' imported from") })}
+        ${'@cspell/cspell-unknown-reporter'}       | ${oc({ message: sc("Failed to load reporter @cspell/cspell-unknown-reporter: Cannot find package '@cspell/cspell-unknown-reporter'") })}
+    `('loadReporters fail $reporter', async ({ reporter, expected }) => {
         const reporters: ReporterSettings[] = [reporter];
-        const fn = () => loadReporters(reporters, defaultReporter, {});
-        expect(fn).toThrow(expected);
+        const r = loadReporters(reporters, defaultReporter, {});
+        await expect(r).rejects.toEqual(expected);
     });
 });
 

--- a/packages/cspell/src/util/reporters.test.ts
+++ b/packages/cspell/src/util/reporters.test.ts
@@ -1,6 +1,6 @@
 import type { CSpellReporter, ReporterSettings } from '@cspell/cspell-types';
 import { MessageTypes } from '@cspell/cspell-types';
-import { describe, test, expect, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { InMemoryReporter } from './InMemoryReporter';
 import { loadReporters, mergeReporters } from './reporters';

--- a/packages/cspell/src/util/reporters.ts
+++ b/packages/cspell/src/util/reporters.ts
@@ -70,8 +70,10 @@ export function loadReporters(
         const [moduleName, settings] = reporterSettings;
 
         try {
+            const fullPath = require.resolve(moduleName, { paths: [process.cwd(), __dirname] });
+            console.log('Reporter:\n module %o\n path: %o', moduleName, fullPath);
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const { getReporter }: CSpellReporterModule = require(moduleName);
+            const { getReporter }: CSpellReporterModule = require(fullPath);
             return getReporter(settings, config);
         } catch (e: unknown) {
             throw new ApplicationError(`Failed to load reporter ${moduleName}: ${toError(e).message}`);

--- a/packages/cspell/src/util/reporters.ts
+++ b/packages/cspell/src/util/reporters.ts
@@ -6,8 +6,8 @@ import type {
     ReporterSettings,
     RunResult,
 } from '@cspell/cspell-types';
-
 import { dynamicImport } from '@cspell/dynamic-import';
+
 import { ApplicationError, toError } from './errors';
 
 type StandardEmitters = Omit<CSpellReporter, 'result'>;

--- a/packages/cspell/src/util/stdin.test.ts
+++ b/packages/cspell/src/util/stdin.test.ts
@@ -1,5 +1,5 @@
 import * as readline from 'readline';
-import { describe, test, expect, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { asyncIterableToArray, mergeAsyncIterables } from './async';
 import { readStdin } from './stdin';

--- a/packages/cspell/src/util/stdin.test.ts
+++ b/packages/cspell/src/util/stdin.test.ts
@@ -1,10 +1,11 @@
 import * as readline from 'readline';
+import { describe, test, expect, vi } from 'vitest';
 
 import { asyncIterableToArray, mergeAsyncIterables } from './async';
 import { readStdin } from './stdin';
 
-jest.mock('readline');
-const mockCreateInterface = jest.mocked(readline.createInterface);
+vi.mock('readline');
+const mockCreateInterface = vi.mocked(readline.createInterface);
 
 describe('stdin', () => {
     test('reading stdin', async () => {

--- a/packages/cspell/src/util/table.test.ts
+++ b/packages/cspell/src/util/table.test.ts
@@ -1,4 +1,5 @@
 import strip from 'strip-ansi';
+import { describe, test, expect } from 'vitest';
 
 import type { Table } from './table';
 import { tableToLines } from './table';

--- a/packages/cspell/src/util/table.test.ts
+++ b/packages/cspell/src/util/table.test.ts
@@ -1,5 +1,5 @@
 import strip from 'strip-ansi';
-import { describe, test, expect } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import type { Table } from './table';
 import { tableToLines } from './table';

--- a/packages/cspell/src/util/util.test.ts
+++ b/packages/cspell/src/util/util.test.ts
@@ -1,3 +1,5 @@
+import { describe, test, expect } from 'vitest';
+
 import * as util from './util';
 
 describe('Validate util', () => {

--- a/packages/cspell/src/util/util.test.ts
+++ b/packages/cspell/src/util/util.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import * as util from './util';
 

--- a/packages/cspell/tsconfig.json
+++ b/packages/cspell/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../tsconfig.json",
+    "extends": "../../tsconfig.cjs.json",
     "compilerOptions": {
         "skipLibCheck": true,
         "exactOptionalPropertyTypes": false, // make this true

--- a/packages/cspell/vitest.config.ts
+++ b/packages/cspell/vitest.config.ts
@@ -1,0 +1,16 @@
+import { mergeConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
+
+import viteConfig from '../../vitest.config';
+
+export default mergeConfig(
+    viteConfig,
+    defineConfig({
+        test: {
+            include: ['src/**/*.test.{ts,mts}'],
+            exclude: ['content/**', 'fixtures/**', 'bin.mjs', '_snapshots_'],
+            root: __dirname,
+            testTimeout: 10000,
+        },
+    })
+);

--- a/packages/cspell/vitest.config.ts
+++ b/packages/cspell/vitest.config.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line node/no-extraneous-import
 import { mergeConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
 

--- a/packages/dynamic-import/.gitignore
+++ b/packages/dynamic-import/.gitignore
@@ -1,0 +1,4 @@
+# Sample .gitignore
+
+dist
+temp

--- a/packages/dynamic-import/.vscode/launch.json
+++ b/packages/dynamic-import/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "cspell-pipe: Jest current-file",
+            "program": "${workspaceFolder}/../../node_modules/jest/bin/jest.js",
+            "args": ["--runInBand", "${fileBasename}"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/../../node_modules/jest/bin/jest"
+            }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "cspell-pipe: Jest All",
+            "program": "${workspaceFolder}/../../node_modules/jest/bin/jest.js",
+            "args": ["--runInBand"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/../../node_modules/jest/bin/jest"
+            }
+        }
+    ]
+}

--- a/packages/dynamic-import/.vscode/tasks.json
+++ b/packages/dynamic-import/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$tsc"
+        },
+        {
+            "label": "Clean Build",
+            "type": "npm",
+            "script": "clean-build",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/packages/dynamic-import/LICENSE
+++ b/packages/dynamic-import/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Jason Dent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/dynamic-import/README.md
+++ b/packages/dynamic-import/README.md
@@ -1,0 +1,31 @@
+# `@cspell/dynamic-import`
+
+A small library to assist with dynamically loading CommonJS and ESM Modules from either CommonJS or ESM Modules.
+
+## Install
+
+```sh
+npm install -S @cspell/dynamic-import
+```
+
+## Usage
+
+**TypeScript**
+
+```ts
+import { dynamicImport } from '@cspell/dynamic-import';
+```
+
+<!--- @@inject: ../../static/footer.md --->
+
+<br/>
+
+---
+
+<p align="center">
+Brought to you by <a href="https://streetsidesoftware.com" title="Street Side Software">
+<img width="16" alt="Street Side Software Logo" src="https://i.imgur.com/CyduuVY.png" /> Street Side Software
+</a>
+</p>
+
+<!--- @@inject-end: ../../static/footer.md --->

--- a/packages/dynamic-import/fixtures/hello_world.d.mts
+++ b/packages/dynamic-import/fixtures/hello_world.d.mts
@@ -1,0 +1,1 @@
+export function sayHello(name: string): void;

--- a/packages/dynamic-import/fixtures/hello_world.mjs
+++ b/packages/dynamic-import/fixtures/hello_world.mjs
@@ -1,0 +1,3 @@
+export function sayHello(name) {
+    console.log('Hello ' + name);
+}

--- a/packages/dynamic-import/lib/dImport.d.ts
+++ b/packages/dynamic-import/lib/dImport.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Thunk Layer for `import` to allow dynamic imports.
+ * @param {string} module - name of module to load
+ * @returns
+ */
+export function dImport(module: string): Promise<any>;

--- a/packages/dynamic-import/lib/dImport.js
+++ b/packages/dynamic-import/lib/dImport.js
@@ -1,0 +1,8 @@
+/**
+ * Thunk Layer for `import` to allow dynamic imports.
+ * @param {string} module - name of module to load
+ * @returns
+ */
+export function dImport(module) {
+    return import(module.toString());
+}

--- a/packages/dynamic-import/lib/dynamicImport.d.ts
+++ b/packages/dynamic-import/lib/dynamicImport.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Dynamically import a module using `import`.
+ * @param moduleName - name of module, or relative path.
+ * @param searchPath - absolute search path, URL, or array of paths. Note: Paths must be absolute.
+ *    The last path element of the URL will be removed if it does not end in a `/`.
+ * @returns Promise resolving to the loaded module.
+ */
+export declare function dynamicImportFrom<T>(
+    moduleName: string,
+    searchPath: (string | URL)[] | string | URL
+): Promise<T>;

--- a/packages/dynamic-import/lib/dynamicImport.js
+++ b/packages/dynamic-import/lib/dynamicImport.js
@@ -18,7 +18,7 @@ let pImportResolve;
  * @returns the loaded module.
  */
 export async function dynamicImportFrom(moduleName, paths) {
-    paths = Array.isArray(paths) ? paths : [paths];
+    paths = Array.isArray(paths) ? paths : paths ? [paths] : undefined;
     if (!paths || !paths.length || typeof moduleName !== 'string') {
         try {
             return await dImport(moduleName);

--- a/packages/dynamic-import/lib/dynamicImport.js
+++ b/packages/dynamic-import/lib/dynamicImport.js
@@ -1,0 +1,52 @@
+import { dImport } from './dImport.js';
+import { sep as pathSep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Lazy load the importer so we can use an ESM packages inside a cjs file.
+ */
+
+/**
+ * @type {Promise<typeof import('import-meta-resolve')> | undefined}
+ */
+let pImportResolve;
+
+/**
+ * Dynamically import a module using `import`.
+ * @param {string} moduleName - name of module, or relative path.
+ * @param {(string | URL)[] | string | URL} paths - search paths
+ * @returns the loaded module.
+ */
+export async function dynamicImportFrom(moduleName, paths) {
+    paths = Array.isArray(paths) ? paths : [paths];
+    if (!paths || !paths.length || typeof moduleName !== 'string') {
+        try {
+            return await dImport(moduleName);
+        } catch (err) {
+            err.code = err.code ?? 'ERR_MODULE_NOT_FOUND';
+            throw err;
+        }
+    }
+
+    const importResolveModule = await (pImportResolve || (pImportResolve = dImport('import-meta-resolve')));
+
+    const { resolve } = importResolveModule;
+
+    let lastError = undefined;
+
+    for (const parent of paths) {
+        try {
+            const url =
+                typeof parent === 'string'
+                    ? parent.startsWith('file://')
+                        ? new URL(parent)
+                        : pathToFileURL(parent + pathSep)
+                    : parent;
+            const location = await resolve(moduleName, url);
+            return await dImport(location);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
+}

--- a/packages/dynamic-import/lib/index.d.ts
+++ b/packages/dynamic-import/lib/index.d.ts
@@ -1,0 +1,1 @@
+export { dynamicImportFrom as dynamicImport } from './dynamicImport';

--- a/packages/dynamic-import/lib/index.js
+++ b/packages/dynamic-import/lib/index.js
@@ -1,0 +1,1 @@
+export { dynamicImportFrom as dynamicImport } from './dynamicImport.js';

--- a/packages/dynamic-import/lib/index.test.ts
+++ b/packages/dynamic-import/lib/index.test.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from 'vitest';
-import { dynamicImport } from './index.js';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import * as helloWorld from '../fixtures/hello_world.mjs';
+
+import { describe, expect, test } from 'vitest';
+
+import type * as helloWorld from '../fixtures/hello_world.mjs';
+import { dynamicImport } from './index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-function oc(obj: any) {
+function oc(obj: unknown) {
     return expect.objectContaining(obj);
 }
 

--- a/packages/dynamic-import/lib/index.test.ts
+++ b/packages/dynamic-import/lib/index.test.ts
@@ -17,7 +17,7 @@ describe('index', () => {
         ${'../fixtures/hello_world.mjs'}                                      | ${undefined}
         ${'./hello_world.mjs'}                                                | ${[path.join(__dirname, '../fixtures')]}
         ${'./hello_world.mjs'}                                                | ${path.join(__dirname, '../fixtures')}
-        ${'./hello_world.mjs'}                                                | ${pathToFileURL(path.join(__dirname, '../fixtures'))}
+        ${'./hello_world.mjs'}                                                | ${pathToFileURL(path.join(__dirname, '../fixtures/'))}
         ${'./hello_world.mjs'}                                                | ${[__dirname, path.join(__dirname, '../fixtures')]}
         ${path.join(__dirname, '../fixtures/hello_world.mjs')}                | ${undefined}
         ${pathToFileURL(path.join(__dirname, '../fixtures/hello_world.mjs'))} | ${undefined}

--- a/packages/dynamic-import/lib/index.test.ts
+++ b/packages/dynamic-import/lib/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { dynamicImport } from './index.js';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import * as helloWorld from '../fixtures/hello_world.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function oc(obj: any) {
+    return expect.objectContaining(obj);
+}
+
+describe('index', () => {
+    test.each`
+        moduleName                                                            | parents
+        ${'../fixtures/hello_world.mjs'}                                      | ${undefined}
+        ${'./hello_world.mjs'}                                                | ${[path.join(__dirname, '../fixtures')]}
+        ${'./hello_world.mjs'}                                                | ${path.join(__dirname, '../fixtures')}
+        ${'./hello_world.mjs'}                                                | ${pathToFileURL(path.join(__dirname, '../fixtures'))}
+        ${'./hello_world.mjs'}                                                | ${[__dirname, path.join(__dirname, '../fixtures')]}
+        ${path.join(__dirname, '../fixtures/hello_world.mjs')}                | ${undefined}
+        ${pathToFileURL(path.join(__dirname, '../fixtures/hello_world.mjs'))} | ${undefined}
+    `('dynamicImportFrom $moduleName $parents', async ({ moduleName, parents }) => {
+        const pModule = dynamicImport<typeof helloWorld>(moduleName, parents);
+        const m = await pModule;
+        expect(m.sayHello).toBeTypeOf('function');
+    });
+
+    test.each`
+        moduleName             | parents        | expected
+        ${'./hello_world.mjs'} | ${undefined}   | ${oc({ message: expect.stringMatching(/^Failed to load url/), code: 'ERR_MODULE_NOT_FOUND' })}
+        ${'./hello_world.mjs'} | ${[__dirname]} | ${oc({ message: expect.stringMatching(/^Cannot find module/), code: 'ERR_MODULE_NOT_FOUND' })}
+    `('dynamicImportFrom NOT FOUND $moduleName $parents', async ({ moduleName, parents, expected }) => {
+        const pModule = dynamicImport<typeof helloWorld>(moduleName, parents);
+        await expect(pModule).rejects.toBeInstanceOf(Error);
+        await expect(pModule).rejects.toEqual(expected);
+    });
+});

--- a/packages/dynamic-import/package.json
+++ b/packages/dynamic-import/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@cspell/dynamic-import",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "6.21.0",
+  "description": "Dynamic Module Loader",
+  "keywords": [
+    "module",
+    "esm",
+    "cjs",
+    "import",
+    "require"
+  ],
+  "author": "Jason Dent <jason@streetsidesoftware.nl>",
+  "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/dynamic-import#readme",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/cjs/index.cjs",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "dist",
+    "!**/__mocks__",
+    "!**/*.spec.*",
+    "!**/*.test.*",
+    "!**/test/**",
+    "!**/*.map"
+  ],
+  "scripts": {
+    "build": "pnpm build:cjs",
+    "build:cjs": "rollup -c rollup.config.mjs",
+    "coverage:vitest": "vitest run --coverage",
+    "coverage:fix": "nyc report --temp-dir \"$(pwd)/coverage\" --reporter lcov --report-dir \"$(pwd)/coverage\" --cwd ../..",
+    "test-watch": "vitest",
+    "test": "vitest run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/streetsidesoftware/cspell.git"
+  },
+  "bugs": {
+    "url": "https://github.com/streetsidesoftware/cspell/labels/cspell-pipe"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "rollup": "^3.13.0",
+    "vitest": "^0.28.4"
+  },
+  "dependencies": {
+    "import-meta-resolve": "^2.2.1"
+  }
+}

--- a/packages/dynamic-import/rollup.config.mjs
+++ b/packages/dynamic-import/rollup.config.mjs
@@ -1,0 +1,52 @@
+/* eslint-disable node/no-extraneous-import */
+import rollupPluginNodeResolve from '@rollup/plugin-node-resolve';
+import rollupPluginJson from '@rollup/plugin-json';
+import rollupPluginCommonjs from '@rollup/plugin-commonjs';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
+
+/** @type {import('rollup').RollupOptions} */
+const common = {
+    input: 'lib/index.js',
+
+    output: {
+        sourcemap: true,
+    },
+
+    treeshake: {
+        annotations: true,
+        moduleSideEffects: [],
+        propertyReadSideEffects: false,
+        unknownGlobalSideEffects: false,
+    },
+};
+
+/**
+ * Get new instances of all the common plugins.
+ */
+function getPlugins() {
+    return [
+        rollupPluginNodeResolve({
+            mainFields: ['module', 'exports', 'es', 'es6', 'esm', 'main'],
+            extensions: ['.ts', '.js', '.mjs', '.mts', '.node', '.json'],
+            preferBuiltins: true,
+        }),
+        rollupPluginCommonjs({
+            transformMixedEsModules: true,
+        }),
+        rollupPluginJson(),
+    ];
+}
+
+const plugins = getPlugins();
+
+/** @type {import('rollup').RollupOptions[]} */
+const configs = [
+    {
+        ...common,
+        output: [{ ...common.output, file: pkg.main, format: 'cjs' }],
+        plugins,
+    },
+];
+export default configs;

--- a/packages/dynamic-import/rollup.config.mjs
+++ b/packages/dynamic-import/rollup.config.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-extraneous-import */
 import rollupPluginNodeResolve from '@rollup/plugin-node-resolve';
 import rollupPluginJson from '@rollup/plugin-json';
 import rollupPluginCommonjs from '@rollup/plugin-commonjs';

--- a/packages/dynamic-import/t.js
+++ b/packages/dynamic-import/t.js
@@ -1,4 +1,4 @@
-import { dynamicImportFrom } from './lib/index.js';
+import { dynamicImport } from './lib/index.js';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 import * as path from 'node:path';
 
@@ -11,5 +11,5 @@ callHello(pathToFileURL('./fixtures/hello_world.mjs'), [fileURLToPath(fixtures)]
 
 async function callHello(file, paths) {
     console.log('%o %o', file.toString(), paths?.toString());
-    (await dynamicImportFrom(file, paths)).sayHello('Bob.');
+    (await dynamicImport(file, paths)).sayHello('Bob.');
 }

--- a/packages/dynamic-import/t.js
+++ b/packages/dynamic-import/t.js
@@ -1,0 +1,15 @@
+import { dynamicImportFrom } from './lib/index.js';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+
+const fixtures = pathToFileURL('./fixtures/');
+callHello(pathToFileURL('./fixtures/hello_world.mjs'));
+callHello(path.resolve('./fixtures/hello_world.mjs'));
+callHello('./hello_world.mjs', [fixtures]);
+callHello('./hello_world.mjs', [fileURLToPath(fixtures)]);
+callHello(pathToFileURL('./fixtures/hello_world.mjs'), [fileURLToPath(fixtures)]);
+
+async function callHello(file, paths) {
+    console.log('%o %o', file.toString(), paths?.toString());
+    (await dynamicImportFrom(file, paths)).sayHello('Bob.');
+}

--- a/packages/dynamic-import/tsconfig.json
+++ b/packages/dynamic-import/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "extends": "../../tsconfig.esm.json",
+    "compilerOptions": {
+        "skipLibCheck": true,
+        "moduleResolution": "node16",
+        "lib": ["es2020", "DOM"],
+        "module": "ES2020",
+        "target": "es2020",
+        "outDir": "dist/esm",
+        "types": ["node"]
+    },
+    "include": [
+        "."
+    ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -904,9 +904,11 @@ importers:
 
   test-packages/dynamic-import/test-dynamic-import-cjs:
     specifiers:
+      '@cspell/cspell-pipe': workspace:*
       '@cspell/dynamic-import': workspace:*
       vitest: ^0.28.4
     dependencies:
+      '@cspell/cspell-pipe': link:../../../packages/cspell-pipe
       '@cspell/dynamic-import': link:../../../packages/dynamic-import
     devDependencies:
       vitest: 0.28.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -926,9 +926,11 @@ importers:
 
   test-packages/dynamic-import/test-dynamic-import-rollup:
     specifiers:
+      '@cspell/cspell-pipe': workspace:*
       '@cspell/dynamic-import': workspace:*
       vitest: ^0.28.4
     dependencies:
+      '@cspell/cspell-pipe': link:../../../packages/cspell-pipe
       '@cspell/dynamic-import': link:../../../packages/dynamic-import
     devDependencies:
       vitest: 0.28.4
@@ -15356,7 +15358,7 @@ packages:
       '@babel/core': 7.20.12
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1_@types+node@18.11.18
+      jest: 29.4.1
       jest-util: 29.4.1
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,6 @@ importers:
       file-entry-cache: ^6.0.1
       get-stdin: ^8.0.0
       imurmurhash: ^0.1.4
-      jest: ^29.4.1
       micromatch: ^4.0.5
       minimatch: ^6.1.6
       rollup: ^3.13.0
@@ -182,7 +181,6 @@ importers:
       '@types/imurmurhash': 0.1.1
       '@types/micromatch': 4.0.2
       '@types/semver': 7.3.13
-      jest: 29.4.1
       micromatch: 4.0.5
       minimatch: 6.1.6
       rollup: 3.13.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
       '@cspell/cspell-json-reporter': workspace:*
       '@cspell/cspell-pipe': workspace:*
       '@cspell/cspell-types': workspace:*
+      '@cspell/dynamic-import': workspace:*
       '@types/file-entry-cache': ^5.0.2
       '@types/glob': ^8.0.1
       '@types/imurmurhash': ^0.1.1
@@ -159,6 +160,7 @@ importers:
       vscode-uri: ^3.0.7
     dependencies:
       '@cspell/cspell-pipe': link:../cspell-pipe
+      '@cspell/dynamic-import': link:../dynamic-import
       chalk: 4.1.2
       commander: 10.0.0
       cspell-gitignore: link:../cspell-gitignore
@@ -644,6 +646,23 @@ importers:
       jest: 29.4.1
       ts-json-schema-generator: 1.2.0
       typescript: 4.9.5
+      vitest: 0.28.4
+
+  packages/dynamic-import:
+    specifiers:
+      '@rollup/plugin-commonjs': ^24.0.1
+      '@rollup/plugin-json': ^6.0.0
+      '@rollup/plugin-node-resolve': ^15.0.1
+      import-meta-resolve: ^2.2.1
+      rollup: ^3.13.0
+      vitest: ^0.28.4
+    dependencies:
+      import-meta-resolve: 2.2.1
+    devDependencies:
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.13.0
+      '@rollup/plugin-json': 6.0.0_rollup@3.13.0
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.13.0
+      rollup: 3.13.0
       vitest: 0.28.4
 
   packages/hunspell-reader:
@@ -5316,7 +5335,7 @@ packages:
   /@types/sax/1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 18.11.18
     dev: false
 
   /@types/scheduler/0.16.2:
@@ -9795,6 +9814,10 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+
+  /import-meta-resolve/2.2.1:
+    resolution: {integrity: sha512-C6lLL7EJPY44kBvA80gq4uMsVFw5x3oSKfuMl1cuZ2RkI5+UJqQXgn+6hlUew0y4ig7Ypt4CObAAIzU53Nfpuw==}
+    dev: false
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,6 +902,35 @@ importers:
       '@cspell/cspell-tools': link:../../../packages/cspell-tools
       cspell: link:../../../packages/cspell
 
+  test-packages/dynamic-import/test-dynamic-import-cjs:
+    specifiers:
+      '@cspell/dynamic-import': workspace:*
+      vitest: ^0.28.4
+    dependencies:
+      '@cspell/dynamic-import': link:../../../packages/dynamic-import
+    devDependencies:
+      vitest: 0.28.4
+
+  test-packages/dynamic-import/test-dynamic-import-esm:
+    specifiers:
+      '@cspell/cspell-pipe': workspace:*
+      '@cspell/dynamic-import': workspace:*
+      vitest: ^0.28.4
+    dependencies:
+      '@cspell/cspell-pipe': link:../../../packages/cspell-pipe
+      '@cspell/dynamic-import': link:../../../packages/dynamic-import
+    devDependencies:
+      vitest: 0.28.4
+
+  test-packages/dynamic-import/test-dynamic-import-rollup:
+    specifiers:
+      '@cspell/dynamic-import': workspace:*
+      vitest: ^0.28.4
+    dependencies:
+      '@cspell/dynamic-import': link:../../../packages/dynamic-import
+    devDependencies:
+      vitest: 0.28.4
+
   test-packages/examples/example-cspell-lib-single-doc:
     specifiers:
       cspell-lib: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,7 @@ importers:
       rollup-plugin-dts: ^5.1.1
       semver: ^7.3.8
       strip-ansi: ^6.0.1
+      vitest: ^0.28.4
       vscode-uri: ^3.0.7
     dependencies:
       '@cspell/cspell-pipe': link:../cspell-pipe
@@ -185,6 +186,7 @@ importers:
       minimatch: 6.1.6
       rollup: 3.13.0
       rollup-plugin-dts: 5.1.1_46fwwqbvuxlme2l3loxirmrppi
+      vitest: 0.28.4
 
   packages/cspell-bundled-dicts:
     specifiers:
@@ -15354,7 +15356,7 @@ packages:
       '@babel/core': 7.20.12
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1
+      jest: 29.4.1_@types+node@18.11.18
       jest-util: 29.4.1
       json5: 2.2.3
       lodash.memoize: 4.1.2

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/CHANGELOG.md
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 6.21.0 (2023-02-03)
+
+**Note:** Version bump only for package test-cspell-pipe
+
+## 6.20.1 (2023-02-01)
+
+### Bug Fixes
+
+* Correct .gitignore comment detection ([#4083](https://github.com/streetsidesoftware/cspell/issues/4083)) ([cadfbc4](https://github.com/streetsidesoftware/cspell/commit/cadfbc489f17db348459a09e7bd49514d07152a2))
+
+# 6.20.0 (2023-02-01)
+
+**Note:** Version bump only for package test-cspell-pipe
+
+## 6.19.2 (2023-01-17)
+
+**Note:** Version bump only for package test-cspell-pipe
+
+## 6.19.1 (2023-01-17)
+
+### Bug Fixes
+
+* Remove `vitest` as a dependency ([#4031](https://github.com/streetsidesoftware/cspell/issues/4031)) ([2784b75](https://github.com/streetsidesoftware/cspell/commit/2784b75feefc81aa95806ac748fafb140c72b5fa))
+
+# 6.19.0 (2023-01-16)
+
+**Note:** Version bump only for package test-cspell-pipe

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/README.md
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/README.md
@@ -1,0 +1,7 @@
+# External Dependency Test
+
+This package is NOT to be published.
+
+External dependency test of `@cspell/dynamic-import`.
+
+Environment CommonJS.

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/bin.cjs
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/bin.cjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const { getPipes } = require('./dist/index');
+
+async function t() {
+    const pipes = await getPipes();
+
+    assert(typeof pipes.opFirst === 'function');
+}
+
+t();

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/package.json
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "test-dynamic-import-cjs",
+  "version": "6.21.0",
+  "description": "Pure testing package for @cspell/dynamic-import.",
+  "private": true,
+  "type": "commonjs",
+  "bin": "./bin.cjs",
+  "scripts": {
+    "clean": "shx rm -rf dist .tsbuildinfo",
+    "build": "pnpm run compile",
+    "build-dev": "tsc -p tsconfig.dev.json",
+    "clean-build": "pnpm run clean && pnpm run build",
+    "compile": "tsc -p .",
+    "test": "pnpm test:unit && pnpm test:smoke",
+    "test:smoke": "node ./bin.cjs",
+    "test:unit": "vitest run"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@cspell/cspell-pipe": "workspace:*",
+    "@cspell/dynamic-import": "workspace:*"
+  },
+  "main": "index.js",
+  "keywords": [],
+  "devDependencies": {
+    "vitest": "^0.28.4"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/src/index.test.ts
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/src/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+
+import { getPipes } from './index';
+
+describe('index', () => {
+    test('getPipes', async () => {
+        await expect(getPipes()).resolves.toBeDefined();
+    });
+});

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/src/index.ts
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/src/index.ts
@@ -1,0 +1,5 @@
+import { dynamicImport } from '@cspell/dynamic-import';
+
+export function getPipes(): Promise<typeof import('@cspell/cspell-pipe')> {
+    return dynamicImport('@cspell/cspell-pipe', __dirname);
+}

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/src/index.ts
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/src/index.ts
@@ -1,5 +1,6 @@
 import { dynamicImport } from '@cspell/dynamic-import';
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export function getPipes(): Promise<typeof import('@cspell/cspell-pipe')> {
     return dynamicImport('@cspell/cspell-pipe', __dirname);
 }

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.dev.json
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": ".tsbuildinfo"
+    }
+}

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.json
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "types": ["node"]
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.json
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../../../tsconfig.cjs.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
     "include": [
         "src"
     ]

--- a/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.json
+++ b/test-packages/dynamic-import/test-dynamic-import-cjs/tsconfig.json
@@ -1,9 +1,5 @@
 {
-    "extends": "../../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "dist",
-        "types": ["node"]
-    },
+    "extends": "../../../tsconfig.cjs.json",
     "include": [
         "src"
     ]

--- a/test-packages/dynamic-import/test-dynamic-import-esm/CHANGELOG.md
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 6.21.0 (2023-02-03)
+
+**Note:** Version bump only for package test-cspell-pipe-esm
+
+## 6.20.1 (2023-02-01)
+
+### Bug Fixes
+
+* Correct .gitignore comment detection ([#4083](https://github.com/streetsidesoftware/cspell/issues/4083)) ([cadfbc4](https://github.com/streetsidesoftware/cspell/commit/cadfbc489f17db348459a09e7bd49514d07152a2))
+
+# 6.20.0 (2023-02-01)
+
+**Note:** Version bump only for package test-cspell-pipe-esm
+
+## 6.19.2 (2023-01-17)
+
+**Note:** Version bump only for package test-cspell-pipe-esm
+
+## 6.19.1 (2023-01-17)
+
+### Bug Fixes
+
+* Remove `vitest` as a dependency ([#4031](https://github.com/streetsidesoftware/cspell/issues/4031)) ([2784b75](https://github.com/streetsidesoftware/cspell/commit/2784b75feefc81aa95806ac748fafb140c72b5fa))
+
+# 6.19.0 (2023-01-16)
+
+**Note:** Version bump only for package test-cspell-pipe-esm

--- a/test-packages/dynamic-import/test-dynamic-import-esm/README.md
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/README.md
@@ -1,0 +1,7 @@
+# External Dependency Test
+
+This package is NOT to be published.
+
+External dependency test of `@cspell/dynamic-import`.
+
+Environment ESM Modules.

--- a/test-packages/dynamic-import/test-dynamic-import-esm/bin.mjs
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/bin.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable node/shebang */
 import assert from 'assert';
 import { getPipes } from './dist/index.js';
 
@@ -7,4 +8,4 @@ async function t() {
     assert(typeof pipes.opFirst === 'function');
 }
 
-await t();
+t();

--- a/test-packages/dynamic-import/test-dynamic-import-esm/bin.mjs
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/bin.mjs
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import { getPipes } from './dist/index.js';
+
+async function t() {
+    const pipes = await getPipes();
+
+    assert(typeof pipes.opFirst === 'function');
+}
+
+await t();

--- a/test-packages/dynamic-import/test-dynamic-import-esm/package.json
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "test-dynamic-import-esm",
+  "version": "6.21.0",
+  "description": "Pure testing package for @cspell/dynamic-import.",
+  "private": true,
+  "bin": "./bin.mjs",
+  "type": "module",
+  "scripts": {
+    "clean": "shx rm -rf dist .tsbuildinfo",
+    "build": "pnpm run compile",
+    "build-dev": "tsc -p tsconfig.dev.json",
+    "clean-build": "pnpm run clean && pnpm run build",
+    "compile": "tsc -p .",
+    "test": "pnpm test:unit && pnpm test:smoke",
+    "test:smoke": "node ./bin.mjs",
+    "test:unit": "vitest run"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@cspell/cspell-pipe": "workspace:*",
+    "@cspell/dynamic-import": "workspace:*"
+  },
+  "main": "index.js",
+  "keywords": [],
+  "devDependencies": {
+    "vitest": "^0.28.4"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/test-packages/dynamic-import/test-dynamic-import-esm/src/index.test.ts
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/src/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+
+import { getPipes } from './index.js';
+
+describe('index', () => {
+    test('getPipes', async () => {
+        const pVitest = getPipes();
+        await expect(pVitest).resolves.toBeDefined();
+    });
+});

--- a/test-packages/dynamic-import/test-dynamic-import-esm/src/index.ts
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/src/index.ts
@@ -1,0 +1,5 @@
+import { dynamicImport } from '@cspell/dynamic-import';
+
+export function getPipes(): Promise<typeof import('@cspell/cspell-pipe')> {
+    return dynamicImport('@cspell/cspell-pipe', import.meta.url);
+}

--- a/test-packages/dynamic-import/test-dynamic-import-esm/src/index.ts
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/src/index.ts
@@ -1,5 +1,6 @@
 import { dynamicImport } from '@cspell/dynamic-import';
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export function getPipes(): Promise<typeof import('@cspell/cspell-pipe')> {
     return dynamicImport('@cspell/cspell-pipe', import.meta.url);
 }

--- a/test-packages/dynamic-import/test-dynamic-import-esm/tsconfig.dev.json
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": ".tsbuildinfo"
+    }
+}

--- a/test-packages/dynamic-import/test-dynamic-import-esm/tsconfig.json
+++ b/test-packages/dynamic-import/test-dynamic-import-esm/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../tsconfig.esm.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/CHANGELOG.md
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 6.21.0 (2023-02-03)
+
+**Note:** Version bump only for package test-cspell-pipe-rollup
+
+## 6.20.1 (2023-02-01)
+
+### Bug Fixes
+
+* Correct .gitignore comment detection ([#4083](https://github.com/streetsidesoftware/cspell/issues/4083)) ([cadfbc4](https://github.com/streetsidesoftware/cspell/commit/cadfbc489f17db348459a09e7bd49514d07152a2))
+
+# 6.20.0 (2023-02-01)
+
+**Note:** Version bump only for package test-cspell-pipe-rollup
+
+## 6.19.2 (2023-01-17)
+
+**Note:** Version bump only for package test-cspell-pipe-rollup
+
+## 6.19.1 (2023-01-17)
+
+### Bug Fixes
+
+* Remove `vitest` as a dependency ([#4031](https://github.com/streetsidesoftware/cspell/issues/4031)) ([2784b75](https://github.com/streetsidesoftware/cspell/commit/2784b75feefc81aa95806ac748fafb140c72b5fa))
+
+# 6.19.0 (2023-01-16)
+
+**Note:** Version bump only for package test-cspell-pipe-rollup

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/README.md
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/README.md
@@ -1,0 +1,7 @@
+# External Dependency Test
+
+This package is NOT to be published.
+
+External dependency test of `@cspell/dynamic-import`.
+
+Environment Rollup.

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/bin.cjs
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/bin.cjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const { getPipes } = require('./dist/index.cjs');
+
+async function t() {
+    const pipes = await getPipes();
+
+    assert(typeof pipes.opFirst === 'function');
+}
+
+t();

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/bin.mjs
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/bin.mjs
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import { getPipes } from './dist/index.mjs';
+
+async function t() {
+    const pipes = await getPipes();
+
+    assert(typeof pipes.opFirst === 'function');
+}
+
+await t();

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/bin.mjs
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/bin.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import assert from 'assert';
 import { getPipes } from './dist/index.mjs';
 
@@ -7,4 +9,4 @@ async function t() {
     assert(typeof pipes.opFirst === 'function');
 }
 
-await t();
+t();

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/package.json
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "test-dynamic-import-rollup",
+  "version": "6.21.0",
+  "description": "Pure testing package for @cspell/dynamic-import.",
+  "private": true,
+  "bin": {
+    "mjs": "bin.mjs",
+    "csj": "bin.cjs"
+  },
+  "browser": "./dist/browser.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "type": "module",
+  "scripts": {
+    "clean": "shx rm -rf dist .tsbuildinfo",
+    "build": "rollup -c rollup.config.mjs",
+    "build-dev": "tsc -p tsconfig.dev.json",
+    "clean-build": "pnpm run clean && pnpm run build",
+    "compile": "tsc -p .",
+    "test": "pnpm test:unit && pnpm test:smoke",
+    "test:smoke": "node ./bin.mjs && node ./bin.cjs",
+    "test:unit": "vitest run"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@cspell/dynamic-import": "workspace:*"
+  },
+  "keywords": [],
+  "devDependencies": {
+    "vitest": "^0.28.4"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/package.json
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/package.json
@@ -24,6 +24,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@cspell/cspell-pipe": "workspace:*",
     "@cspell/dynamic-import": "workspace:*"
   },
   "keywords": [],

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/src/index.mts
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/src/index.mts
@@ -1,0 +1,5 @@
+import { dynamicImport } from '@cspell/dynamic-import';
+
+export function getPipes(): Promise<typeof import('@cspell/cspell-pipe')> {
+    return dynamicImport('@cspell/cspell-pipe', import.meta.url);
+}

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/src/index.mts
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/src/index.mts
@@ -1,5 +1,6 @@
 import { dynamicImport } from '@cspell/dynamic-import';
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export function getPipes(): Promise<typeof import('@cspell/cspell-pipe')> {
     return dynamicImport('@cspell/cspell-pipe', import.meta.url);
 }

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/src/index.test.mts
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/src/index.test.mts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+
+import { getPipes } from './index.mjs';
+
+describe('index', () => {
+    test('getPipes', async () => {
+        const pVitest = getPipes();
+        await expect(pVitest).resolves.toBeDefined();
+    });
+});

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/tsconfig.dev.json
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "incremental": true,
+        "tsBuildInfoFile": ".tsbuildinfo"
+    }
+}

--- a/test-packages/dynamic-import/test-dynamic-import-rollup/tsconfig.json
+++ b/test-packages/dynamic-import/test-dynamic-import-rollup/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../tsconfig.esm.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,6 +3,7 @@
     "display": "CSpell Monorepo Base Config",
     "extends": "./tsconfig-base.json",
     "compilerOptions": {
-        "types": ["node"]
+        "types": ["node"],
+        "lib": ["es2020", "DOM"]
     }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "CSpell Monorepo Base Config",
+    "extends": "./tsconfig-base.json",
+    "compilerOptions": {
+        "types": ["node"]
+    }
+}


### PR DESCRIPTION
It is now possible to write reporters as `.mjs` files.

## Changes
fix: make sure to resolve the reporter first.
feat: Add new module `@cspell/dynamic-import` to support loading ESM modules dynamically.
