### PR TITLE
feat: Emit suggestions matching source case

### DIFF
--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.ts
@@ -23,25 +23,30 @@ export interface SuggestOptions {
      * `NONE` is the best option.
      */
     compoundMethod?: CompoundWordsMethod | undefined;
+
     /**
      * The limit on the number of suggestions to generate. If `allowTies` is true, it is possible
      * for more suggestions to be generated.
      */
     numSuggestions?: number | undefined;
+
     /**
      * Max number of changes / edits to the word to get to a suggestion matching suggestion.
      */
     numChanges?: number | undefined;
+
     /**
      * Allow for case-ingestive checking.
      */
     ignoreCase?: boolean | undefined;
+
     /**
      * If multiple suggestions have the same edit / change "cost", then included them even if
      * it causes more than `numSuggestions` to be returned.
      * @default false
      */
     includeTies?: boolean | undefined;
+
     /**
      * Maximum amount of time to allow for generating suggestions.
      */

--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.ts
@@ -22,30 +22,30 @@ export interface SuggestOptions {
      * Compounding Mode.
      * `NONE` is the best option.
      */
-    compoundMethod?: CompoundWordsMethod;
+    compoundMethod?: CompoundWordsMethod | undefined;
     /**
      * The limit on the number of suggestions to generate. If `allowTies` is true, it is possible
      * for more suggestions to be generated.
      */
-    numSuggestions?: number;
+    numSuggestions?: number | undefined;
     /**
      * Max number of changes / edits to the word to get to a suggestion matching suggestion.
      */
-    numChanges?: number;
+    numChanges?: number | undefined;
     /**
      * Allow for case-ingestive checking.
      */
-    ignoreCase?: boolean;
+    ignoreCase?: boolean | undefined;
     /**
      * If multiple suggestions have the same edit / change "cost", then included them even if
      * it causes more than `numSuggestions` to be returned.
      * @default false
      */
-    includeTies?: boolean;
+    includeTies?: boolean | undefined;
     /**
      * Maximum amount of time to allow for generating suggestions.
      */
-    timeout?: number;
+    timeout?: number | undefined;
 }
 
 export type FindOptions = SearchOptions;

--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionaryCollection.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionaryCollection.ts
@@ -1,7 +1,6 @@
 import { CASE_INSENSITIVE_PREFIX } from 'cspell-trie-lib';
 import { genSequence } from 'gensequence';
 
-import { clean } from '../util/clean';
 import { isDefined } from '../util/util';
 import * as Defaults from './defaults';
 import type {
@@ -91,17 +90,15 @@ class SpellingDictionaryCollectionImpl implements SpellingDictionaryCollection {
                 !this.isNoSuggestWord(word, suggestOptions)
             );
         };
-        const collector = suggestionCollector(
-            word,
-            clean({
-                numSuggestions,
-                filter,
-                changeLimit: numChanges,
-                includeTies,
-                ignoreCase,
-                timeout,
-            })
-        );
+        const collectorOptions = {
+            numSuggestions,
+            filter,
+            changeLimit: numChanges,
+            includeTies,
+            ignoreCase,
+            timeout,
+        };
+        const collector = suggestionCollector(word, collectorOptions);
         this.genSuggestions(collector, suggestOptions);
         return collector.suggestions.map((r) => ({ ...r, word: r.word }));
     }

--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionaryMethods.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionaryMethods.ts
@@ -2,7 +2,6 @@ import type { DictionaryInformation } from '@cspell/cspell-types';
 import type { SuggestionResult, WeightMap } from 'cspell-trie-lib';
 import { mapDictionaryInformationToWeightMap } from 'cspell-trie-lib';
 
-import { clean } from '../util/clean';
 import { isUpperCase, removeUnboundAccents, ucFirst } from '../util/text';
 import type { HasOptions, SearchOptions, SuggestArgs, SuggestOptions } from './SpellingDictionary';
 
@@ -97,14 +96,12 @@ export function suggestArgsToSuggestOptions(args: SuggestArgs): SuggestOptions {
     const suggestOptions: SuggestOptions =
         typeof options === 'object'
             ? options
-            : clean({
+            : {
                   numSuggestions: options,
                   compoundMethod,
                   numChanges,
                   ignoreCase,
-                  includeTies: undefined,
-                  timeout: undefined,
-              });
+              };
     return suggestOptions;
 }
 export function createWeightMapFromDictionaryInformation(di: undefined): undefined;

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -4,7 +4,7 @@ export * from '@cspell/cspell-types';
 import { URI } from 'vscode-uri';
 import { WeightMap } from 'cspell-trie-lib';
 export { CompoundWordsMethod } from 'cspell-trie-lib';
-import { CachingDictionary, SpellingDictionaryCollection, SuggestionResult, SuggestOptions } from 'cspell-dictionary';
+import { CachingDictionary, SpellingDictionaryCollection, SuggestOptions, SuggestionResult } from 'cspell-dictionary';
 export { SpellingDictionary, SpellingDictionaryCollection, SuggestOptions, SuggestionCollector, SuggestionResult, createSpellingDictionary, createCollection as createSpellingDictionaryCollection } from 'cspell-dictionary';
 export { asyncIterableToArray, readFile, readFileSync, writeToFile, writeToFileIterable, writeToFileIterableP } from 'cspell-io';
 
@@ -488,8 +488,18 @@ declare function getDefaultBundledSettings(): CSpellSettingsInternal;
 declare function combineTextAndLanguageSettings(settings: CSpellUserSettings, text: string, languageId: string | string[]): CSpellSettingsInternal;
 
 interface ExtendedSuggestion {
+    /**
+     * The suggestion.
+     */
     word: string;
+    /**
+     * The word is preferred above others, except other "preferred" words.
+     */
     isPreferred?: boolean;
+    /**
+     * The suggested word adjusted to match the original case.
+     */
+    wordAdjustedToMatchCase?: string;
 }
 
 interface ValidationResult extends TextOffset, Pick<Issue, 'message' | 'issueType'> {
@@ -780,11 +790,13 @@ interface DetermineFinalDocumentSettingsResult {
  */
 declare function determineFinalDocumentSettings(document: DocumentWithText, settings: CSpellUserSettings): DetermineFinalDocumentSettingsResult;
 
-interface SuggestedWordBase extends SuggestionResult {
+interface WordSuggestion extends SuggestionResult {
     /**
      * The suggested word adjusted to match the original case.
      */
     wordAdjustedToMatchCase?: string;
+}
+interface SuggestedWordBase extends WordSuggestion {
     /**
      * dictionary names
      */

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -4,7 +4,7 @@ export * from '@cspell/cspell-types';
 import { URI } from 'vscode-uri';
 import { WeightMap } from 'cspell-trie-lib';
 export { CompoundWordsMethod } from 'cspell-trie-lib';
-import { CachingDictionary, SpellingDictionaryCollection, SuggestionResult } from 'cspell-dictionary';
+import { CachingDictionary, SpellingDictionaryCollection, SuggestionResult, SuggestOptions } from 'cspell-dictionary';
 export { SpellingDictionary, SpellingDictionaryCollection, SuggestOptions, SuggestionCollector, SuggestionResult, createSpellingDictionary, createCollection as createSpellingDictionaryCollection } from 'cspell-dictionary';
 export { asyncIterableToArray, readFile, readFileSync, writeToFile, writeToFileIterable, writeToFileIterableP } from 'cspell-io';
 
@@ -572,11 +572,6 @@ interface ValidateTextOptions {
      */
     validateDirectives?: boolean;
 }
-/**
- * @deprecated
- * @deprecationMessage Use spellCheckDocument
- */
-declare function validateText(text: string, settings: CSpellUserSettings, options?: ValidateTextOptions): Promise<ValidationIssue[]>;
 
 interface DocumentValidatorOptions extends ValidateTextOptions {
     /**
@@ -595,7 +590,6 @@ interface DocumentValidatorOptions extends ValidateTextOptions {
     noConfigSearch?: boolean;
 }
 declare class DocumentValidator {
-    readonly options: DocumentValidatorOptions;
     readonly settings: CSpellUserSettings;
     private _document;
     private _ready;
@@ -604,6 +598,7 @@ declare class DocumentValidator {
     private _preparations;
     private _preparationTime;
     private _suggestions;
+    readonly options: DocumentValidatorOptions;
     /**
      * @param doc - Document to validate
      * @param config - configuration to use (not finalized).
@@ -717,6 +712,12 @@ interface CheckTextOptions extends DocumentValidatorOptions {
  */
 declare function checkTextDocument(doc: TextDocument | Document, options: CheckTextOptions, settings?: CSpellUserSettings): Promise<CheckTextInfo>;
 
+/**
+ * @deprecated
+ * @deprecationMessage Use spellCheckDocument
+ */
+declare function validateText(text: string, settings: CSpellUserSettings, options?: ValidateTextOptions): Promise<ValidationIssue[]>;
+
 interface SpellCheckFileOptions extends ValidateTextOptions {
     /**
      * Optional path to a configuration file.
@@ -780,6 +781,13 @@ interface DetermineFinalDocumentSettingsResult {
 declare function determineFinalDocumentSettings(document: DocumentWithText, settings: CSpellUserSettings): DetermineFinalDocumentSettingsResult;
 
 interface SuggestedWordBase extends SuggestionResult {
+    /**
+     * The suggested word adjusted to match the original case.
+     */
+    wordAdjustedToMatchCase?: string;
+    /**
+     * dictionary names
+     */
     dictionaries: string[];
 }
 interface SuggestedWord extends SuggestedWordBase {
@@ -790,7 +798,8 @@ interface SuggestionsForWordResult {
     word: string;
     suggestions: SuggestedWord[];
 }
-interface SuggestionOptions {
+type FromSuggestOptions = Pick<SuggestOptions, 'numChanges' | 'numSuggestions' | 'includeTies'>;
+interface SuggestionOptions extends FromSuggestOptions {
     /**
      * languageId to use when determining file type.
      */
@@ -812,18 +821,18 @@ interface SuggestionOptions {
      * The number of suggestions to make.
      * @default 8
      */
-    numSuggestions?: number;
+    numSuggestions?: number | undefined;
     /**
      * Max number of changes / edits to the word to get to a suggestion matching suggestion.
      * @default 4
      */
-    numChanges?: number;
+    numChanges?: number | undefined;
     /**
      * If multiple suggestions have the same edit / change "cost", then included them even if
      * it causes more than `numSuggestions` to be returned.
      * @default true
      */
-    includeTies?: boolean;
+    includeTies?: boolean | undefined;
     /**
      * By default we want to use the default configuration, but there are cases
      * where someone might not want that.

--- a/packages/cspell-lib/src/Models/Suggestion.ts
+++ b/packages/cspell-lib/src/Models/Suggestion.ts
@@ -1,4 +1,14 @@
 export interface ExtendedSuggestion {
+    /**
+     * The suggestion.
+     */
     word: string;
+    /**
+     * The word is preferred above others, except other "preferred" words.
+     */
     isPreferred?: boolean;
+    /**
+     * The suggested word adjusted to match the original case.
+     */
+    wordAdjustedToMatchCase?: string;
 }

--- a/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.test.ts
@@ -126,6 +126,28 @@ describe('Validate LanguageSettings', () => {
         expect([...localeSet]).toEqual(expected);
     });
 
+    test.each`
+        locales                          | expected
+        ${''}                            | ${[]}
+        ${'en, en-GB, fr-fr, nl_NL'}     | ${['en', 'en-GB', 'fr-FR', 'nl-NL']}
+        ${['en, en-GB', 'fr-fr, nl_NL']} | ${['en', 'en-GB', 'fr-FR', 'nl-NL']}
+    `('normalizeLocaleIntl $locales', ({ locales, expected }) => {
+        const localeSet = LS.normalizeLocaleIntl(locales);
+        expect([...localeSet]).toEqual(expected);
+    });
+
+    test.each`
+        locales                              | strict       | expected
+        ${''}                                | ${undefined} | ${false}
+        ${'fr-fr'}                           | ${undefined} | ${true}
+        ${'fr-fr'}                           | ${true}      | ${false}
+        ${['en', 'en-GB', 'fr-FR', 'nl-NL']} | ${undefined} | ${true}
+        ${['en', 'en-GB', 'fr-FR', 'nl-NL']} | ${true}      | ${true}
+        ${['en, en-GB', 'fr-fr, nl_NL']}     | ${undefined} | ${false}
+    `('isValidLocaleIntlFormat $locales', ({ locales, strict, expected }) => {
+        expect(LS.isValidLocaleIntlFormat(locales, strict)).toEqual(expected);
+    });
+
     test('normalizeLocale $locales', () => {
         const localeSet = LS.normalizeLocale('en, en-GB, fr-fr,nl_NL');
         expect(localeSet.has('en')).toBe(true);

--- a/packages/cspell-lib/src/Settings/LanguageSettings.ts
+++ b/packages/cspell-lib/src/Settings/LanguageSettings.ts
@@ -56,9 +56,38 @@ export function normalizeLocale(locale: LocaleId | LocaleId[]): Set<LocaleId> {
     return _normalizeLocale(locale);
 }
 
+export function normalizeLocaleIntl(locale: LocaleId | LocaleId[]): Set<LocaleId> {
+    const values = [...normalizeLocale(locale)].map((locale) =>
+        locale.replace(/^([a-z]{2})-?([a-z]{2})$/, (_, lang: string, locale?: string) =>
+            locale ? `${lang}-${locale.toUpperCase()}` : lang
+        )
+    );
+    return new Set(values);
+}
+
 export function isLocaleInSet(locale: LocaleId | LocaleId[], setOfLocals: Set<LocaleId>): boolean {
     const locales = normalizeLocale(locale);
     return doSetsIntersect(locales, setOfLocals);
+}
+
+const regExpValidIntlLocaleStrict = /^[a-z]{2}(-[A-Z]{2})?$/;
+const regExpValidIntlLocale = new RegExp(regExpValidIntlLocaleStrict, 'i');
+
+/**
+ * Test if a locale should be ok with Intl
+ * @param locale - locale string
+ * @param strict - case must match
+ * @returns true if it matches the standard 2 letter or 4 letter forms.
+ */
+export function isValidLocaleIntlFormat(locale: LocaleId | LocaleId[], strict = false): boolean {
+    if (typeof locale === 'string')
+        return strict ? regExpValidIntlLocaleStrict.test(locale) : regExpValidIntlLocale.test(locale);
+
+    for (const item of locale) {
+        if (!isValidLocaleIntlFormat(item, strict)) return false;
+    }
+
+    return locale.length > 0;
 }
 
 export function calcSettingsForLanguage(

--- a/packages/cspell-lib/src/suggestions.ts
+++ b/packages/cspell-lib/src/suggestions.ts
@@ -1,13 +1,24 @@
 import type { CSpellSettings, LocaleId } from '@cspell/cspell-types';
+import assert from 'assert';
 
 import type { LanguageId } from './LanguageIds';
 import { finalizeSettings, getDefaultSettings, getGlobalSettings, mergeSettings } from './Settings';
-import { calcSettingsForLanguageId } from './Settings/LanguageSettings';
+import { calcSettingsForLanguageId, isValidLocaleIntlFormat, normalizeLocaleIntl } from './Settings/LanguageSettings';
 import type { FindOptions, SpellingDictionaryCollection, SuggestionResult, SuggestOptions } from './SpellingDictionary';
 import { getDictionaryInternal, refreshDictionaryCache } from './SpellingDictionary';
+import { createAutoResolveCache } from './util/AutoResolve';
+import { memorizeLastCall } from './util/memorizeLastCall';
 import * as util from './util/util';
 
 interface SuggestedWordBase extends SuggestionResult {
+    /**
+     * The suggested word adjusted to match the original case.
+     */
+    wordAdjustedToMatchCase?: string;
+
+    /**
+     * dictionary names
+     */
     dictionaries: string[];
 }
 export interface SuggestedWord extends SuggestedWordBase {
@@ -20,7 +31,9 @@ export interface SuggestionsForWordResult {
     suggestions: SuggestedWord[];
 }
 
-export interface SuggestionOptions {
+type FromSuggestOptions = Pick<SuggestOptions, 'numChanges' | 'numSuggestions' | 'includeTies'>;
+
+export interface SuggestionOptions extends FromSuggestOptions {
     /**
      * languageId to use when determining file type.
      */
@@ -46,20 +59,20 @@ export interface SuggestionOptions {
      * The number of suggestions to make.
      * @default 8
      */
-    numSuggestions?: number;
+    numSuggestions?: number | undefined;
 
     /**
      * Max number of changes / edits to the word to get to a suggestion matching suggestion.
      * @default 4
      */
-    numChanges?: number;
+    numChanges?: number | undefined;
 
     /**
      * If multiple suggestions have the same edit / change "cost", then included them even if
      * it causes more than `numSuggestions` to be returned.
      * @default true
      */
-    includeTies?: boolean;
+    includeTies?: boolean | undefined;
 
     /**
      * By default we want to use the default configuration, but there are cases
@@ -70,20 +83,41 @@ export interface SuggestionOptions {
     // allowCompoundWords?: boolean; don't allow for now (maybe never)
 }
 
+const emptySuggestionOptions = Object.freeze({});
+const emptyCSpellSettings = Object.freeze({});
+
 export async function* suggestionsForWords(
     words: Iterable<string> | AsyncIterable<string>,
     options?: SuggestionOptions,
-    settings: CSpellSettings = {}
+    settings?: CSpellSettings
 ): AsyncIterable<SuggestionsForWordResult> {
     for await (const word of words) {
         yield await suggestionsForWord(word, options, settings);
     }
 }
 
-export async function suggestionsForWord(
+const memorizeSuggestions = memorizeLastCall(cacheSuggestionsForWord);
+
+function cacheSuggestionsForWord(
+    options: SuggestOptions,
+    settings: CSpellSettings
+): (word: string) => Promise<SuggestionsForWordResult> {
+    const cache = createAutoResolveCache<string, Promise<SuggestionsForWordResult>>();
+    return (word) => cache.get(word, (word) => _suggestionsForWord(word, options, settings));
+}
+
+export function suggestionsForWord(
     word: string,
-    options?: SuggestionOptions,
-    settings: CSpellSettings = {}
+    options: SuggestionOptions = emptySuggestionOptions,
+    settings: CSpellSettings = emptyCSpellSettings
+): Promise<SuggestionsForWordResult> {
+    return memorizeSuggestions(options, settings)(word);
+}
+
+async function _suggestionsForWord(
+    word: string,
+    options: SuggestionOptions,
+    settings: CSpellSettings
 ): Promise<SuggestionsForWordResult> {
     const {
         languageId,
@@ -94,7 +128,7 @@ export async function suggestionsForWord(
         includeTies = true,
         includeDefaultConfig = true,
         dictionaries,
-    } = options || {};
+    } = options;
     const ignoreCase = !strict;
 
     async function determineDictionaries(config: CSpellSettings): Promise<{
@@ -131,13 +165,18 @@ export async function suggestionsForWord(
         : settings;
     const { dictionaryCollection, allDictionaryCollection } = await determineDictionaries(config);
     const opts: SuggestOptions = { ignoreCase, numChanges, numSuggestions, includeTies };
-    const suggestionsByDictionary = dictionaryCollection.dictionaries.map((dict) =>
+    const suggestionsByDictionary = dictionaryCollection.dictionaries.flatMap((dict) =>
         dict.suggest(word, opts).map((r) => ({ ...r, dictName: dict.name }))
     );
-    const combined = combine(
-        util.flatten(suggestionsByDictionary).sort((a, b) => a.cost - b.cost || (a.word <= b.word ? -1 : 1))
-    );
     const findOpts: FindOptions = {};
+    const locale = adjustLocale(language || config.language || undefined);
+    const collator = Intl.Collator(locale);
+    const combined = limitResults(
+        combine(suggestionsByDictionary.sort((a, b) => a.cost - b.cost || collator.compare(a.word, b.word))),
+        numSuggestions,
+        includeTies
+    );
+    adjustCase(combined, word, locale, ignoreCase, allDictionaryCollection, findOpts);
     const allSugs = combined.map((sug) => {
         const found = allDictionaryCollection.find(sug.word, findOpts);
         return {
@@ -172,7 +211,42 @@ function combine(suggestions: SuggestionResultWithDictionaryName[]): SuggestedWo
     return [...words.values()];
 }
 
-function limitResults(suggestions: SuggestedWord[], numSuggestions: number, includeTies: boolean): SuggestedWord[] {
+function adjustLocale(locale: string | undefined): string | string[] | undefined {
+    if (!locale) return undefined;
+    const locales = [...normalizeLocaleIntl(locale)].filter((locale) => isValidLocaleIntlFormat(locale));
+    if (!locales.length) return undefined;
+    if (locales.length === 1) return locales[0];
+    return locales;
+}
+
+function adjustCase(
+    combined: SuggestedWordBase[],
+    word: string,
+    locale: string | string[] | undefined,
+    ignoreCase: boolean,
+    allDictionaryCollection: SpellingDictionaryCollection,
+    findOpts: FindOptions
+): void {
+    const knownSugs = new Set(combined.map((sug) => sug.word));
+    const matchStyle = { ...analyzeCase(word), locale, ignoreCase };
+    /* Add adjusted words */
+    combined.forEach((sug) => {
+        const alt = matchCase(sug.word, !!sug.isPreferred, matchStyle);
+        if (alt !== sug.word && !knownSugs.has(alt)) {
+            const found = allDictionaryCollection.find(alt, findOpts);
+            if (!found || !found.forbidden || !found.noSuggest) {
+                sug.wordAdjustedToMatchCase = alt;
+                knownSugs.add(alt);
+            }
+        }
+    });
+}
+
+function limitResults<T extends SuggestedWordBase>(
+    suggestions: T[],
+    numSuggestions: number,
+    includeTies: boolean
+): T[] {
     let cost = suggestions[0]?.cost;
     let i = 0;
     for (; i < suggestions.length; ++i) {
@@ -194,6 +268,63 @@ function validateDictionaries(settings: CSpellSettings, dictionaries: string[] |
             throw new SuggestionError(`Unknown dictionary: "${dict}"`, 'E_dictionary_unknown');
         }
     }
+}
+
+function matchCase(word: string, isPreferred: boolean, style: CaseStyle): string {
+    const locale = style.locale;
+    if (style.isMixedCaps) {
+        /**
+         * Do not try matching mixed caps.
+         */
+        return word;
+    }
+    if (hasCaps(word)) {
+        if (style.isAllCaps) return word.toLocaleUpperCase(locale);
+        if (!style.ignoreCase || style.hasCaps || isPreferred) return word;
+        if (isTitleCase(word) || isAllCaps(word)) return word.toLocaleLowerCase(locale);
+        return word;
+    }
+    if (!style.hasCaps) return word;
+    if (style.isAllCaps) return word.toLocaleUpperCase(locale);
+    assert(style.isTitleCase);
+    return word.replace(/^\p{L}/u, (firstLetter) => firstLetter.toLocaleUpperCase(locale));
+}
+
+interface CaseStyle extends AnalyzeCaseResult {
+    locale: string | string[] | undefined;
+    ignoreCase: boolean;
+}
+
+interface AnalyzeCaseResult {
+    isAllCaps: boolean;
+    hasCaps: boolean;
+    isMixedCaps: boolean;
+    isTitleCase: boolean;
+}
+
+const regExpHasCaps = /\p{Lu}/u;
+const regExpIsAllCaps = /^[\P{L}\p{Lu}]+$/u;
+const regExpIsTitleCase = /^\p{Lu}[\P{L}\p{Ll}]+$/u;
+
+function analyzeCase(word: string): AnalyzeCaseResult {
+    const hasCaps = regExpHasCaps.test(word);
+    const isAllCaps = hasCaps && regExpIsAllCaps.test(word);
+    const isTitleCase = hasCaps && !isAllCaps && regExpIsTitleCase.test(word);
+    const isMixedCaps = hasCaps && !isAllCaps && !isTitleCase;
+
+    return { hasCaps, isAllCaps, isMixedCaps, isTitleCase };
+}
+
+function hasCaps(word: string): boolean {
+    return regExpHasCaps.test(word);
+}
+
+function isTitleCase(word: string): boolean {
+    return regExpIsTitleCase.test(word);
+}
+
+function isAllCaps(word: string): boolean {
+    return regExpIsAllCaps.test(word);
 }
 
 export class SuggestionError extends Error {

--- a/packages/cspell-lib/src/textValidation/ValidateTextOptions.ts
+++ b/packages/cspell-lib/src/textValidation/ValidateTextOptions.ts
@@ -1,0 +1,16 @@
+export interface ValidateTextOptions {
+    /**
+     * Generate suggestions where there are spelling issues.
+     */
+    generateSuggestions?: boolean;
+
+    /**
+     * The number of suggestions to generate. The higher the number the longer it takes.
+     */
+    numSuggestions?: number;
+
+    /**
+     * Verify that the in-document directives are correct.
+     */
+    validateDirectives?: boolean;
+}

--- a/packages/cspell-lib/src/textValidation/docValidator.ts
+++ b/packages/cspell-lib/src/textValidation/docValidator.ts
@@ -31,10 +31,10 @@ import type { TextValidator } from './lineValidatorFactory';
 import { textValidatorFactory } from './lineValidatorFactory';
 import type { SimpleRange } from './parsedText';
 import { createMappedTextSegmenter } from './parsedText';
+import { settingsToValidateOptions } from './settingsToValidateOptions';
 import { calcTextInclusionRanges } from './textValidator';
+import type { ValidateTextOptions } from './ValidateTextOptions';
 import type { MappedTextValidationResult, ValidationOptions } from './ValidationTypes';
-import type { ValidateTextOptions } from './validator';
-import { settingsToValidateOptions } from './validator';
 
 export interface DocumentValidatorOptions extends ValidateTextOptions {
     /**

--- a/packages/cspell-lib/src/textValidation/index.ts
+++ b/packages/cspell-lib/src/textValidation/index.ts
@@ -6,6 +6,6 @@ export type { DocumentValidatorOptions } from './docValidator';
 export { DocumentValidator } from './docValidator';
 export type { Offset, SimpleRange } from './parsedText';
 export { calcTextInclusionRanges } from './textValidator';
+export type { ValidateTextOptions } from './ValidateTextOptions';
 export type { CheckOptions, IncludeExcludeOptions, ValidationOptions } from './ValidationTypes';
-export type { ValidateTextOptions } from './validator';
 export { validateText } from './validator';

--- a/packages/cspell-lib/src/textValidation/settingsToValidateOptions.ts
+++ b/packages/cspell-lib/src/textValidation/settingsToValidateOptions.ts
@@ -1,0 +1,10 @@
+import { CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef';
+import { ValidationOptions } from './ValidationTypes';
+
+export function settingsToValidateOptions(settings: CSpellSettingsInternalFinalized): ValidationOptions {
+    const opt: ValidationOptions = {
+        ...settings,
+        ignoreCase: !(settings.caseSensitive ?? false),
+    };
+    return opt;
+}

--- a/packages/cspell-lib/src/textValidation/settingsToValidateOptions.ts
+++ b/packages/cspell-lib/src/textValidation/settingsToValidateOptions.ts
@@ -1,5 +1,5 @@
-import { CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef';
-import { ValidationOptions } from './ValidationTypes';
+import type { CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef';
+import type { ValidationOptions } from './ValidationTypes';
 
 export function settingsToValidateOptions(settings: CSpellSettingsInternalFinalized): ValidationOptions {
     const opt: ValidationOptions = {

--- a/packages/cspell-lib/src/textValidation/textValidator.test.ts
+++ b/packages/cspell-lib/src/textValidation/textValidator.test.ts
@@ -9,7 +9,7 @@ import { FreqCounter } from '../util/FreqCounter';
 import * as Text from '../util/text';
 import { _testMethods, calcTextInclusionRanges, validateText } from './textValidator';
 import type { ValidationOptions } from './ValidationTypes';
-import { settingsToValidateOptions } from './validator';
+import { settingsToValidateOptions } from './settingsToValidateOptions';
 
 function sToV(settings: CSpellUserSettings) {
     return settingsToValidateOptions(finalizeSettings(settings));

--- a/packages/cspell-lib/src/textValidation/textValidator.test.ts
+++ b/packages/cspell-lib/src/textValidation/textValidator.test.ts
@@ -7,9 +7,9 @@ import type { SpellingDictionaryOptions } from '../SpellingDictionary';
 import { createCollection, createSpellingDictionary, getDictionaryInternal } from '../SpellingDictionary';
 import { FreqCounter } from '../util/FreqCounter';
 import * as Text from '../util/text';
+import { settingsToValidateOptions } from './settingsToValidateOptions';
 import { _testMethods, calcTextInclusionRanges, validateText } from './textValidator';
 import type { ValidationOptions } from './ValidationTypes';
-import { settingsToValidateOptions } from './settingsToValidateOptions';
 
 function sToV(settings: CSpellUserSettings) {
     return settingsToValidateOptions(finalizeSettings(settings));

--- a/packages/cspell-lib/src/textValidation/validator.ts
+++ b/packages/cspell-lib/src/textValidation/validator.ts
@@ -1,34 +1,17 @@
 import type { CSpellUserSettings } from '@cspell/cspell-types';
 import { IssueType } from '@cspell/cspell-types';
 
-import type { CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef';
 import { createTextDocument } from '../Models/TextDocument';
 import type { ValidationIssue } from '../Models/ValidationIssue';
 import * as Settings from '../Settings';
 import type { DirectiveIssue } from '../Settings/InDocSettings';
 import { validateInDocumentSettings } from '../Settings/InDocSettings';
 import { CompoundWordsMethod, getDictionaryInternal } from '../SpellingDictionary';
-import { clean } from '../util/util';
+import { settingsToValidateOptions } from './settingsToValidateOptions';
 import { validateText as validateFullText } from './textValidator';
-import type { ValidationOptions } from './ValidationTypes';
+import type { ValidateTextOptions } from './ValidateTextOptions';
 
 export const diagSource = 'cSpell Checker';
-
-export interface ValidateTextOptions {
-    /**
-     * Generate suggestions where there are spelling issues.
-     */
-    generateSuggestions?: boolean;
-    /**
-     * The number of suggestions to generate. The higher the number the longer it takes.
-     */
-    numSuggestions?: number;
-
-    /**
-     * Verify that the in-document directives are correct.
-     */
-    validateDirectives?: boolean;
-}
 
 /**
  * @deprecated
@@ -50,14 +33,14 @@ export async function validateText(
     if (!options.generateSuggestions) {
         return issues;
     }
-    const sugOptions = clean({
+    const sugOptions = {
         numSuggestions: options.numSuggestions,
         compoundMethod: CompoundWordsMethod.NONE,
         includeTies: false,
         ignoreCase: !(settings.caseSensitive ?? false),
         timeout: settings.suggestionsTimeout,
         numChanges: settings.suggestionNumChanges,
-    });
+    };
     const withSugs = issues.map((t) => {
         const text = t.text;
         const suggestionsEx = dict
@@ -89,12 +72,4 @@ function mapValidationIssues(text: string, valIssues: Iterable<DirectiveIssue>):
     }
 
     return issues.map(toValidationIssue);
-}
-
-export function settingsToValidateOptions(settings: CSpellSettingsInternalFinalized): ValidationOptions {
-    const opt: ValidationOptions = {
-        ...settings,
-        ignoreCase: !(settings.caseSensitive ?? false),
-    };
-    return opt;
 }

--- a/packages/cspell-trie-lib/src/lib/suggestions/suggestCollector.ts
+++ b/packages/cspell-trie-lib/src/lib/suggestions/suggestCollector.ts
@@ -124,7 +124,7 @@ export interface SuggestionCollectorOptions extends Omit<GenSuggestionOptionsStr
      * I.E. to remove forbidden terms.
      * @default () => true
      */
-    filter?: FilterWordFn;
+    filter?: FilterWordFn | undefined;
 
     /**
      * The number of letters that can be changed when looking for a match
@@ -136,7 +136,7 @@ export interface SuggestionCollectorOptions extends Omit<GenSuggestionOptionsStr
      * Include suggestions with tied cost even if the number is greater than `numSuggestions`.
      * @default true
      */
-    includeTies?: boolean;
+    includeTies?: boolean | undefined;
 
     /**
      * specify if case / accents should be ignored when looking for suggestions.

--- a/packages/cspell-types/src/CSpellReporter.ts
+++ b/packages/cspell-types/src/CSpellReporter.ts
@@ -6,6 +6,10 @@ export interface Suggestion {
      */
     word: string;
     /**
+     * The suggested word adjusted to match the original case.
+     */
+    wordAdjustedToMatchCase?: string;
+    /**
      * `true` - if this suggestion can be an automatic fix.
      */
     isPreferred?: boolean;

--- a/packages/cspell/cspell.json
+++ b/packages/cspell/cspell.json
@@ -14,6 +14,7 @@
         "dist/**",
         "package.json",
         ".cspell.json",
+        "cspell.json",
         ".vscode/**"
     ],
     "flagWords": ["blacklist: denylist", "blackList: denyList", "whitelist: allowlist"],

--- a/packages/cspell/fixtures/features/typos/code.ts
+++ b/packages/cspell/fixtures/features/typos/code.ts
@@ -1,0 +1,3 @@
+export function remainingOrangges(count: number): number {
+    return count % 42;
+}

--- a/packages/cspell/fixtures/features/typos/cspell.config.yaml
+++ b/packages/cspell/fixtures/features/typos/cspell.config.yaml
@@ -1,7 +1,12 @@
 flagWords:
   - whitelist->allowlist
   - blacklist->denylist
+  - blacklisting->denylisting
+  - blacklists->denylists
+  - blacklist's->denylist's
+  - blacklisted->denylisted
   - rad->cool
   - hte->the
+  - english->English
 ignorePaths:
   - cspell.config.yaml

--- a/packages/cspell/fixtures/features/typos/test.md
+++ b/packages/cspell/fixtures/features/typos/test.md
@@ -5,3 +5,5 @@ It contains some words that will appear in the typos list.
 - blacklist -> denylist
 - whitelist -> allowlist
 - rad -> cool
+
+This is the english file. Things are Blacklisted.

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -1081,12 +1081,13 @@ not-in-any-dictionary - workspace*           ../../cspell-dict.txt"
 exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
 exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 2`] = `
-"log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, backlist, backlists, blacklight, blackfish]
+"log	./fixtures/features/typos/code.ts:1:26 - Unknown word (Orangges) Suggestions: [Oranges, Orangiest, Orangier, orange's, Orange's]
+log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, backlist, backlists, blacklight, blackfish]
 log	./fixtures/features/typos/test.md:6:3 - Forbidden word (whitelist) Suggestions: [allowlist*, whitelists, whitelisted, whitefish, whitest]
 log	./fixtures/features/typos/test.md:7:3 - Forbidden word (rad) Suggestions: [cool*, rda, rads, raid, rand]
 log	./fixtures/features/typos/test.md:9:13 - Forbidden word (english) Suggestions: [English*, englished, english's, englisher, englishes]
 log	./fixtures/features/typos/test.md:9:38 - Forbidden word (Blacklisted) Suggestions: [Denylisted*, Blacklegged, Backlists, Backlist, Lackluster]
-error	CSpell: Files checked: 2, Issues found: 5 in 1 files"
+error	CSpell: Files checked: 3, Issues found: 6 in 2 files"
 `;
 
 exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 3`] = `""`;

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -358,6 +358,7 @@ info	    Glob: coverage/** from ./cspell.json
 info	    Glob: dist/** from ./cspell.json
 info	    Glob: package.json from ./cspell.json
 info	    Glob: .cspell.json from ./cspell.json
+info	    Glob: cspell.json from ./cspell.json
 info	    Glob: .vscode/** from ./cspell.json
 info	    Glob: node_modules/** from command line
 info	

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -1081,10 +1081,12 @@ not-in-any-dictionary - workspace*           ../../cspell-dict.txt"
 exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
 exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 2`] = `
-"log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, blacklists, backlist, blacklist's, blacklisted]
+"log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, backlist, backlists, blacklight, blackfish]
 log	./fixtures/features/typos/test.md:6:3 - Forbidden word (whitelist) Suggestions: [allowlist*, whitelists, whitelisted, whitefish, whitest]
 log	./fixtures/features/typos/test.md:7:3 - Forbidden word (rad) Suggestions: [cool*, rda, rads, raid, rand]
-error	CSpell: Files checked: 2, Issues found: 3 in 1 files"
+log	./fixtures/features/typos/test.md:9:13 - Forbidden word (english) Suggestions: [English*, englished, english's, englisher, englishes]
+log	./fixtures/features/typos/test.md:9:38 - Forbidden word (Blacklisted) Suggestions: [Denylisted*, Blacklegged, Backlists, Backlist, Lackluster]
+error	CSpell: Files checked: 2, Issues found: 5 in 1 files"
 `;
 
 exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 3`] = `""`;

--- a/packages/cspell/src/cli-reporter.ts
+++ b/packages/cspell/src/cli-reporter.ts
@@ -226,7 +226,11 @@ function formatIssue(templateStr: string, issue: ReporterIssue, maxIssueTextWidt
 function formatSuggestions(issue: Issue): string {
     if (issue.suggestionsEx) {
         return issue.suggestionsEx
-            .map((sug) => (sug.isPreferred ? chalk.italic(chalk.bold(sug.word)) + '*' : sug.word))
+            .map((sug) =>
+                sug.isPreferred
+                    ? chalk.italic(chalk.bold(sug.wordAdjustedToMatchCase || sug.word)) + '*'
+                    : sug.wordAdjustedToMatchCase || sug.word
+            )
             .join(', ');
     }
     if (issue.suggestions) {

--- a/packages/cspell/src/lint/lint.ts
+++ b/packages/cspell/src/lint/lint.ts
@@ -108,7 +108,8 @@ export async function runLint(cfg: LintRequest): Promise<RunResult> {
         );
         try {
             const { showSuggestions: generateSuggestions, validateDirectives } = cfg.options;
-            const validateOptions = { generateSuggestions, numSuggestions: 5, validateDirectives };
+            const numSuggestions = configInfo.config.numSuggestions ?? 5;
+            const validateOptions = { generateSuggestions, numSuggestions, validateDirectives };
             const r = await cspell.spellCheckDocument(doc, validateOptions, configInfo.config);
             spellResult = r;
             result.processed = r.checked;


### PR DESCRIPTION
In order to support auto fix in the eslint-cspell-plugin, suggestions need to match the case of the word being replaced.

fixes #4147 