### PR TITLE
fix: Reduce in-doc dictionary creation

### DIFF
--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.test.ts
@@ -25,10 +25,8 @@ describe('Validate CSpellSettingsServer', () => {
         const right = csi({ name: 'Right' });
         expect(mergeSettings(left, right)).toEqual(
             csi({
-                name: 'Left|Right',
-                id: '|',
                 enabledLanguageIds: [],
-                source: { name: 'Left|Right', sources: [left, right] },
+                source: { name: 'merged', sources: [left, right] },
             })
         );
     });
@@ -39,10 +37,8 @@ describe('Validate CSpellSettingsServer', () => {
         expect(mergeSettings(left, enabled)).toEqual(
             csi({
                 enabled: true,
-                name: '|enabledName',
-                id: 'left|enabledId',
                 enabledLanguageIds: [],
-                source: { name: 'left|enabledName', sources: [csi(left), csi(enabled)] },
+                source: { name: 'merged', sources: [csi(left), csi(enabled)] },
             })
         );
     });
@@ -55,10 +51,8 @@ describe('Validate CSpellSettingsServer', () => {
         expect(mergeSettings(left, right)).toEqual(
             csi({
                 enabled: right.enabled,
-                name: '|',
-                id: [left.id, right.id].join('|'),
                 enabledLanguageIds: [],
-                source: { name: 'left|right', sources: [left, right] },
+                source: { name: 'merged', sources: [left, right] },
             })
         );
     });
@@ -69,10 +63,8 @@ describe('Validate CSpellSettingsServer', () => {
         expect(mergeSettings(a, b)).toEqual(
             csi({
                 enabled: false,
-                name: '|',
-                id: '|',
                 enabledLanguageIds: [],
-                source: { name: 'left|right', sources: [csi(a), csi(b)] },
+                source: { name: 'merged', sources: [csi(a), csi(b)] },
             })
         );
     });
@@ -100,13 +92,11 @@ describe('Validate CSpellSettingsServer', () => {
         expect(mergeSettings(left, right)).toEqual(
             csi({
                 enabled: right.enabled,
-                name: '|',
-                id: [left.id, right.id].join('|'),
                 enabledLanguageIds: [],
                 files: left.files?.concat(right.files || []),
                 ignorePaths: left.ignorePaths?.concat(right.ignorePaths || []),
                 overrides: left.overrides?.concat(right.overrides || []),
-                source: { name: 'left|right', sources: [left, right] },
+                source: { name: 'merged', sources: [left, right] },
             })
         );
     });
@@ -136,14 +126,12 @@ describe('Validate CSpellSettingsServer', () => {
         expect(mergeSettings(left, right)).toEqual(
             csi({
                 enabled: right.enabled,
-                name: '|',
-                id: [left.id, right.id].join('|'),
                 version: right.version,
                 enabledLanguageIds: [],
                 files: left.files?.concat(right.files || []),
                 ignorePaths: right.ignorePaths,
                 overrides: right.overrides,
-                source: { name: 'left|right', sources: [left, right] },
+                source: { name: 'merged', sources: [left, right] },
             })
         );
     });

--- a/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/Settings/CSpellSettingsServer.ts
@@ -142,8 +142,6 @@ function merge(
     if (doesLeftHaveRightAncestor(_left, _right)) {
         return _left;
     }
-    const leftId = _left.id || _left.languageId || '';
-    const rightId = _right.id || _right.languageId || '';
 
     const includeRegExpList = takeRightOtherwiseLeft(_left.includeRegExpList, _right.includeRegExpList);
 
@@ -155,8 +153,8 @@ function merge(
         ..._right,
         ...optionals,
         version,
-        id: [leftId, rightId].join('|'),
-        name: [_left.name || '', _right.name || ''].join('|'),
+        id: undefined,
+        name: undefined,
         words: mergeWordsCached(_left.words, _right.words),
         userWords: mergeWordsCached(_left.userWords, _right.userWords),
         flagWords: mergeWordsCached(_left.flagWords, _right.flagWords),
@@ -319,10 +317,8 @@ export function checkFilenameMatchesGlob(filename: string, globs: Glob | Glob[])
 }
 
 function mergeSources(left: CSpellSettingsWSTO, right: CSpellSettingsWSTO): Source {
-    const { source: a = { name: 'left' } } = left;
-    const { source: b = { name: 'right' } } = right;
     return {
-        name: [left.name || a.name, right.name || b.name].join('|'),
+        name: 'merged',
         sources: [left as CSpellSettingsWithSourceTrace, right as CSpellSettingsWithSourceTrace],
     };
 }

--- a/packages/cspell-lib/src/Settings/InDocSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.test.ts
@@ -1,7 +1,10 @@
+import { CSpellSettings, DictionaryDefinitionInline } from '@cspell/cspell-types';
 import * as Text from '../util/text';
 import * as TextRange from '../util/TextRange';
 import { isDefined } from '../util/util';
 import * as InDoc from './InDocSettings';
+
+const dictName = InDoc.internal.staticInDocumentDictionaryName;
 
 const oc = expect.objectContaining;
 const ac = expect.arrayContaining;
@@ -58,6 +61,12 @@ const x = imp.popoutlist;
 // cspell\x3aignore again
 `;
 
+const sampleInDocDict: DictionaryDefinitionInline = {
+    name: dictName,
+    words: ['const'],
+    ignoreWords: ['popoutlist', 'again'],
+};
+
 // cspell:disable
 const sampleTextWithBadRegexp = `
 # cspell\x3AignoreRegExp  "(foobar|foo_baz)"');
@@ -105,13 +114,13 @@ describe('Validate InDocSettings', () => {
         ${'cSpell\x3adisableCompoundWords\ncSpell\x3aenableCompoundWords'} | ${'cSpell\x3adisableCompoundWords\ncSpell\x3aenableCompoundWords'} | ${oc({ allowCompoundWords: true })}
         ${'sampleText'}                                                    | ${sampleText}                                                      | ${oc({ allowCompoundWords: true })}
         ${'sampleCode'}                                                    | ${sampleCode}                                                      | ${oc({ allowCompoundWords: true })}
-        ${'cSpell\x3aword apple'}                                          | ${USE_TEST}                                                        | ${oc({ words: ['apple'] })}
-        ${'/*cSpell\x3aword apple*/'}                                      | ${USE_TEST}                                                        | ${oc({ words: ['apple*/'] })}
-        ${'<!--- cSpell\x3aword apple -->'}                                | ${USE_TEST}                                                        | ${oc({ words: ['apple', '-->'] })}
-        ${'<!--- cSpell\x3aignoreWords apple -->'}                         | ${USE_TEST}                                                        | ${oc({ ignoreWords: ['apple', '-->'] })}
-        ${'<!--- cSpell\x3aforbidWords apple -->'}                         | ${USE_TEST}                                                        | ${oc({ flagWords: ['apple', '-->'] })}
-        ${'<!--- cSpell\x3aflag-words apple -->'}                          | ${USE_TEST}                                                        | ${oc({ flagWords: ['apple', '-->'] })}
-        ${'# cspell\x3aignore auto* *labeler'}                             | ${USE_TEST}                                                        | ${oc({ ignoreWords: ['auto*', '*labeler'] })}
+        ${'cSpell\x3aword apple'}                                          | ${USE_TEST}                                                        | ${oc(inDocDict({ words: ['apple'] }))}
+        ${'/*cSpell\x3aword apple*/'}                                      | ${USE_TEST}                                                        | ${oc(inDocDict({ words: ['apple*/'] }))}
+        ${'<!--- cSpell\x3aword apple -->'}                                | ${USE_TEST}                                                        | ${oc(inDocDict({ words: ['apple', '-->'] }))}
+        ${'<!--- cSpell\x3aignoreWords apple -->'}                         | ${USE_TEST}                                                        | ${oc(inDocDict({ ignoreWords: ['apple', '-->'] }))}
+        ${'<!--- cSpell\x3aforbidWords apple -->'}                         | ${USE_TEST}                                                        | ${oc(inDocDict({ flagWords: ['apple', '-->'] }))}
+        ${'<!--- cSpell\x3aflag-words apple -->'}                          | ${USE_TEST}                                                        | ${oc(inDocDict({ flagWords: ['apple', '-->'] }))}
+        ${'# cspell\x3aignore auto* *labeler'}                             | ${USE_TEST}                                                        | ${oc(inDocDict({ ignoreWords: ['auto*', '*labeler'] }))}
     `('detect compound words setting: $test', ({ test, text, expected }) => {
         expect(InDoc.getInDocumentSettings(text == USE_TEST ? test : text)).toEqual(expected);
         expect([...InDoc.validateInDocumentSettings(text, {})]).toEqual([]);
@@ -120,7 +129,7 @@ describe('Validate InDocSettings', () => {
     test.each`
         test                                      | text                                    | expected
         ${'Empty Doc'}                            | ${''}                                   | ${{ id: 'in-doc-settings' }}
-        ${'sampleTextWithIncompleteInDocSetting'} | ${sampleTextWithIncompleteInDocSetting} | ${oc({ words: ['const'], ignoreWords: ['popoutlist', 'again'], dictionaries: ['php'] })}
+        ${'sampleTextWithIncompleteInDocSetting'} | ${sampleTextWithIncompleteInDocSetting} | ${oc(inDocDict(sampleInDocDict, ['php']))}
         ${'enableCaseSensitive'}                  | ${'// cspell\x3aenableCaseSensitive'}   | ${oc({ caseSensitive: true })}
         ${'disableCaseSensitive'}                 | ${'// cspell\x3adisableCaseSensitive'}  | ${oc({ caseSensitive: false })}
     `('extract setting: $test', ({ text, expected }) => {
@@ -157,7 +166,7 @@ describe('Validate InDocSettings', () => {
 
     test('setting dictionaries for file', () => {
         const settings = InDoc.getInDocumentSettings(sampleCode);
-        expect(settings.dictionaries).toStrictEqual(['lorem-ipsum']);
+        expect(settings.dictionaries).toStrictEqual(['lorem-ipsum', '[in-document-dict]']);
     });
 
     test('bad ignoreRegExp', () => {
@@ -191,6 +200,19 @@ describe('Validate InDocSettings', () => {
         expect(result).toEqual(expected);
     });
 });
+
+function inDocDict(dict: Partial<DictionaryDefinitionInline>, dictionaries: string[] = []): CSpellSettings {
+    const def = {
+        name: dictName,
+        ...dict,
+    } as DictionaryDefinitionInline;
+
+    dictionaries = [...dictionaries, dictName];
+    return {
+        dictionaryDefinitions: [def],
+        dictionaries,
+    };
+}
 
 // cspell:disableCompoundWords
 // cspell:ignore localwords happydays arehere

--- a/packages/cspell-lib/src/Settings/InDocSettings.test.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.test.ts
@@ -1,4 +1,5 @@
-import { CSpellSettings, DictionaryDefinitionInline } from '@cspell/cspell-types';
+import type { CSpellSettings, DictionaryDefinitionInline } from '@cspell/cspell-types';
+
 import * as Text from '../util/text';
 import * as TextRange from '../util/TextRange';
 import { isDefined } from '../util/util';

--- a/packages/cspell-lib/src/Settings/InDocSettings.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.ts
@@ -128,13 +128,16 @@ export function getInDocumentSettings(text: string): CSpellUserSettings {
 
     const dictSettings = dict
         ? { dictionaries: dictionaries.concat(dictName), dictionaryDefinitions: dictionaryDefinitions.concat(dict) }
-        : { dictionaries, dictionaryDefinitions };
+        : clean({
+              dictionaries: dictionaries.length ? dictionaries : undefined,
+              dictionaryDefinitions: dictionaryDefinitions.length ? dictionaryDefinitions : undefined,
+          });
 
     const settings = {
         ...rest,
         ...dictSettings,
     };
-    console.log('InDocSettings: %o', settings);
+    // console.log('InDocSettings: %o', settings);
     return settings;
 }
 

--- a/packages/cspell-lib/src/Settings/InDocSettings.ts
+++ b/packages/cspell-lib/src/Settings/InDocSettings.ts
@@ -1,5 +1,5 @@
 import { opAppend, opFilter, opMap, pipeSync } from '@cspell/cspell-pipe/sync';
-import type { CSpellUserSettings } from '@cspell/cspell-types';
+import type { CSpellUserSettings, DictionaryDefinitionInline } from '@cspell/cspell-types';
 import type { Sequence } from 'gensequence';
 import { genSequence } from 'gensequence';
 
@@ -98,7 +98,7 @@ export interface DirectiveIssue {
 }
 
 export function getInDocumentSettings(text: string): CSpellUserSettings {
-    const settings = getPossibleInDocSettings(text)
+    const collectedSettings = getPossibleInDocSettings(text)
         .concatMap((a) => parseSettingMatch(a))
         .reduce(
             (s, setting) => {
@@ -106,7 +106,35 @@ export function getInDocumentSettings(text: string): CSpellUserSettings {
             },
             { id: 'in-doc-settings' } as CSpellUserSettings
         );
-    // console.log('InDocSettings: %o', settings);
+    const dictName = `[in-document-dict-${nonce()}]`;
+    const {
+        words,
+        flagWords,
+        ignoreWords,
+        suggestWords,
+        dictionaries = [],
+        dictionaryDefinitions = [],
+        ...rest
+    } = collectedSettings;
+    const dict: DictionaryDefinitionInline | undefined =
+        (words || flagWords || ignoreWords || suggestWords) &&
+        clean({
+            name: dictName,
+            words,
+            flagWords,
+            ignoreWords,
+            suggestWords,
+        });
+
+    const dictSettings = dict
+        ? { dictionaries: dictionaries.concat(dictName), dictionaryDefinitions: dictionaryDefinitions.concat(dict) }
+        : { dictionaries, dictionaryDefinitions };
+
+    const settings = {
+        ...rest,
+        ...dictSettings,
+    };
+    console.log('InDocSettings: %o', settings);
     return settings;
 }
 
@@ -134,6 +162,8 @@ export const regExSpellingGuardBlock =
     /(\bc?spell(?:-?checker)?::?)\s*disable(?!-line|-next)\b[\s\S]*?((?:\1\s*enable\b)|$)/gi;
 export const regExSpellingGuardNext = /\bc?spell(?:-?checker)?::?\s*disable-next\b.*\s\s?.*/gi;
 export const regExSpellingGuardLine = /^.*\bc?spell(?:-?checker)?::?\s*disable-line\b.*/gim;
+
+const emptySettings: CSpellUserSettings = Object.freeze({});
 
 const issueMessages = {
     unknownDirective: 'Unknown CSpell directive',
@@ -204,12 +234,12 @@ function parseSettingMatch(matchArray: RegExpMatchArray): CSpellUserSettings[] {
 
 function parseCompoundWords(match: string): CSpellUserSettings {
     const allowCompoundWords = /enable/i.test(match);
-    return { id: 'in-doc-allowCompoundWords', allowCompoundWords };
+    return { allowCompoundWords };
 }
 
 function parseCaseSensitive(match: string): CSpellUserSettings {
     const caseSensitive = /enable/i.test(match);
-    return { id: 'in-doc-caseSensitive', caseSensitive };
+    return { caseSensitive };
 }
 
 function parseWords(match: string): CSpellUserSettings {
@@ -218,23 +248,25 @@ function parseWords(match: string): CSpellUserSettings {
         .split(/[,\s;]+/g)
         .slice(1)
         .filter((a) => !!a);
-    return { id: 'in-doc-words', words };
+    return { words };
 }
 
 function parseLocale(match: string): CSpellUserSettings {
     const parts = match.trim().split(/[\s,]+/);
     const language = parts.slice(1).join(',');
-    return language ? { id: 'in-doc-local', language } : {};
+    return language ? { language } : emptySettings;
 }
 
 function parseIgnoreWords(match: string): CSpellUserSettings {
     const wordsSetting = parseWords(match);
-    return clean({ id: 'in-doc-ignore', ignoreWords: wordsSetting.words });
+    const ignoreWords = wordsSetting.words;
+    return ignoreWords && ignoreWords.length ? { ignoreWords } : emptySettings;
 }
 
 function parseFlagWords(match: string): CSpellUserSettings {
     const wordsSetting = parseWords(match);
-    return clean({ id: 'in-doc-forbid', flagWords: wordsSetting.words });
+    const flagWords = wordsSetting.words;
+    return flagWords && flagWords.length ? { flagWords } : emptySettings;
 }
 
 function parseRegEx(match: string): string[] {
@@ -250,17 +282,17 @@ function parseRegEx(match: string): string[] {
 
 function parseIgnoreRegExp(match: string): CSpellUserSettings {
     const ignoreRegExpList = parseRegEx(match);
-    return { id: 'in-doc-ignoreRegExp', ignoreRegExpList };
+    return { ignoreRegExpList };
 }
 
 function parseIncludeRegExp(match: string): CSpellUserSettings {
     const includeRegExpList = parseRegEx(match);
-    return { id: 'in-doc-includeRegExp', includeRegExpList };
+    return { includeRegExpList };
 }
 
 function parseDictionaries(match: string): CSpellUserSettings {
     const dictionaries = match.split(/[,\s]+/g).slice(1);
-    return { id: 'in-doc-dictionaries', dictionaries };
+    return { dictionaries };
 }
 
 function getPossibleInDocSettings(text: string): Sequence<RegExpExecArray> {
@@ -290,6 +322,16 @@ export function getIgnoreWordsFromDocument(text: string): string[] {
 export function getIgnoreRegExpFromDocument(text: string): (string | RegExp)[] {
     const { ignoreRegExpList = [] } = getInDocumentSettings(text);
     return ignoreRegExpList;
+}
+
+function nonce(length = 6): string {
+    const dict = '01234567890';
+    const digits: string[] = [];
+    for (let i = 0; i < length; ++i) {
+        digits[i] = dict[Math.floor(Math.random() * 10)];
+    }
+
+    return digits.join('');
 }
 
 /**


### PR DESCRIPTION
Do not merge in-doc words with config words to avoid unnecessary large dictionary creation.