### PR TITLE
doc: fix typo in 'programming'

### DIFF
--- a/docs/configuration/document-settings.md
+++ b/docs/configuration/document-settings.md
@@ -104,7 +104,7 @@ const companyName = 'woorxs sweeetbeat';
 
 ### Enable / Disable compound words
 
-In some programing language it is common to glue words together.
+In some programming language it is common to glue words together.
 
 ```c
 // cSpell:enableCompoundWords

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -417,7 +417,7 @@ const companyName = 'woorxs sweeetbeat';
 
 ### Enable / Disable compound words
 
-In some programing language it is common to glue words together.
+In some programming language it is common to glue words together.
 
 ```c
 // cspell:enableCompoundWords


### PR DESCRIPTION
This word is normally spelled with two `m`.