### PR TITLE
feat: report preferred fixes by default

### DIFF
--- a/packages/cspell/src/app/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/app/__snapshots__/app.test.ts.snap
@@ -518,6 +518,7 @@ exports[`Validate cli > app 'no-args' Expect Error: 'outputHelp' 1`] = `
   "  --relative                   Issues are displayed relative to root.",
   "  --show-context               Show the surrounding text around an issue.",
   "  --show-suggestions           Show spelling suggestions.",
+  "  --no-show-suggestions        Do not show spelling suggestions or fixes.",
   "  --no-must-find-files         Do not error if no files are found.",
   "  --cache                      Use cache to only check changed files.",
   "  --no-cache                   Do not use cache.",
@@ -922,15 +923,43 @@ not-in-any-dictionary - softwareTerms*         .../dict/softwareTerms.txt
 not-in-any-dictionary - workspace*             ../../cspell-dict.txt"
 `;
 
-exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 1`] = `[]`;
+exports[`Validate cli > app 'typos --no-show-suggestions' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
-exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 2`] = `
+exports[`Validate cli > app 'typos --no-show-suggestions' Expect Error: [Function CheckFailed] 2`] = `
+"log	./fixtures/features/typos/code.ts:1:26 - Unknown word (Orangges)
+log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist)
+log	./fixtures/features/typos/test.md:6:3 - Forbidden word (whitelist)
+log	./fixtures/features/typos/test.md:7:3 - Forbidden word (rad)
+log	./fixtures/features/typos/test.md:9:13 - Forbidden word (english)
+log	./fixtures/features/typos/test.md:9:38 - Forbidden word (Blacklisted)
+error	CSpell: Files checked: 3, Issues found: 6 in 2 files"
+`;
+
+exports[`Validate cli > app 'typos --no-show-suggestions' Expect Error: [Function CheckFailed] 3`] = `""`;
+
+exports[`Validate cli > app 'typos --show-suggestions' Expect Error: [Function CheckFailed] 1`] = `[]`;
+
+exports[`Validate cli > app 'typos --show-suggestions' Expect Error: [Function CheckFailed] 2`] = `
 "log	./fixtures/features/typos/code.ts:1:26 - Unknown word (Orangges) Suggestions: [Oranges, Orangiest, Orangier, orange's, Orange's]
 log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, backlist, backlists, blacklight, blackfish]
 log	./fixtures/features/typos/test.md:6:3 - Forbidden word (whitelist) Suggestions: [allowlist*, whitelists, whitelisted, whitefish, whitest]
 log	./fixtures/features/typos/test.md:7:3 - Forbidden word (rad) Suggestions: [cool*, rda, rads, raid, rand]
 log	./fixtures/features/typos/test.md:9:13 - Forbidden word (english) Suggestions: [English*, englished, english's, englisher, englishes]
 log	./fixtures/features/typos/test.md:9:38 - Forbidden word (Blacklisted) Suggestions: [Denylisted*, Blacklegged, Backlists, Backlist, Lackluster]
+error	CSpell: Files checked: 3, Issues found: 6 in 2 files"
+`;
+
+exports[`Validate cli > app 'typos --show-suggestions' Expect Error: [Function CheckFailed] 3`] = `""`;
+
+exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 1`] = `[]`;
+
+exports[`Validate cli > app 'typos' Expect Error: [Function CheckFailed] 2`] = `
+"log	./fixtures/features/typos/code.ts:1:26 - Unknown word (Orangges)
+log	./fixtures/features/typos/test.md:5:3 - Forbidden word (blacklist) fix: (denylist)
+log	./fixtures/features/typos/test.md:6:3 - Forbidden word (whitelist) fix: (allowlist)
+log	./fixtures/features/typos/test.md:7:3 - Forbidden word (rad) fix: (cool)
+log	./fixtures/features/typos/test.md:9:13 - Forbidden word (english) fix: (English)
+log	./fixtures/features/typos/test.md:9:38 - Forbidden word (Blacklisted) fix: (Denylisted)
 error	CSpell: Files checked: 3, Issues found: 6 in 2 files"
 `;
 

--- a/packages/cspell/src/app/app.test.ts
+++ b/packages/cspell/src/app/app.test.ts
@@ -172,7 +172,9 @@ describe('Validate cli', () => {
         ${'issue-2998 --language-id'}                  | ${['-r', pathFix('issue-2998'), '-v', '--language-id=fix', 'fix-words.txt']}              | ${undefined}       | ${true}  | ${false} | ${true}
         ${'Explicit file://'}                          | ${['-r', pathFix('misc'), 'file://star-not.md']}                                          | ${undefined}       | ${true}  | ${false} | ${false}
         ${'Explicit not found file://'}                | ${['-r', pathFix('misc'), 'file://not-fond.md']}                                          | ${app.CheckFailed} | ${true}  | ${false} | ${false}
-        ${'typos'}                                     | ${['-r', pathFix('features/typos'), '--no-progress', '--show-suggestions', '**']}         | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
+        ${'typos'}                                     | ${['-r', pathFix('features/typos'), '--no-progress', '.']}                                | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
+        ${'typos --no-show-suggestions'}               | ${['-r', pathFix('features/typos'), '--no-progress', '--no-show-suggestions', '.']}       | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
+        ${'typos --show-suggestions'}                  | ${['-r', pathFix('features/typos'), '--no-progress', '--show-suggestions', '**']}         | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
         ${'inline suggest'}                            | ${['-r', pathFix('features/inline-suggest'), '--no-progress', '--show-suggestions', '.']} | ${app.CheckFailed} | ${true}  | ${true}  | ${false}
     `('app $msg Expect Error: $errorCheck', async ({ testArgs, errorCheck, eError, eLog, eInfo }: TestCase) => {
         chalk.level = 1;

--- a/packages/cspell/src/app/cli-reporter.test.ts
+++ b/packages/cspell/src/app/cli-reporter.test.ts
@@ -27,7 +27,8 @@ describe('cli-reporter', () => {
         ${genIssue('$col')}    | ${'$row:$col:$text'}                                 | ${'6:23:$col'}
         ${genIssue('$col')}    | ${'$row:$col:$text - $contextFull'}                  | ${'6:23:$col - := $row + $col;'}
         ${genIssue('message')} | ${'$row:$col:$text - $contextFull'}                  | ${'8:36:message - adRowCol,$message,$text,$pa'}
-        ${genIssue('used')}    | ${'$contextLeft:$text:$contextRight - $contextFull'} | ${'rds to be :used: for some  - rds to be used for some '}
+        ${genIssue('used')}    | ${'$contextLeft:$text:$contextRight - $contextFull'} | ${'rds to be :used: for some  - rds to be used for some'}
+        ${genIssue('used')}    | ${'"$contextFull"'}                                  | ${'"rds to be used for some "'}
     `('formatIssue', ({ issue, template, expected }) => {
         expect(formatIssue(template, issue, 200)).toBe(expected);
     });

--- a/packages/cspell/src/app/commandLint.ts
+++ b/packages/cspell/src/app/commandLint.ts
@@ -102,6 +102,11 @@ export function commandLint(prog: Command): Command {
         .option('--relative', 'Issues are displayed relative to root.')
         .option('--show-context', 'Show the surrounding text around an issue.')
         .option('--show-suggestions', 'Show spelling suggestions.')
+        .addOption(
+            new CommanderOption('--no-show-suggestions', 'Do not show spelling suggestions or fixes.').default(
+                undefined
+            )
+        )
         .addOption(new CommanderOption('--must-find-files', 'Error if no files are found.').default(true).hideHelp())
         .option('--no-must-find-files', 'Do not error if no files are found.')
         // The following options are planned features


### PR DESCRIPTION
**Minor Breakage:** the default command line output now includes preferred fixes. This might break CI/CD processes that parse the output. It is better if these systems use a custom reporter.

Use `--no-show-suggestions` to turn of displaying the fixes.
