### PR TITLE
feat: Support words containing `.`

### DIFF
--- a/packages/cspell-lib/src/lib/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-lib/src/lib/__snapshots__/index.test.ts.snap
@@ -109,7 +109,7 @@ exports[`Validate the cspell API > Verify API exports 1`] = `
   "Text": {
     "__testing__": {
       "regExWords": /\\\\p\\{L\\}\\\\p\\{M\\}\\?\\(\\?:\\(\\?:\\\\\\\\\\?\\['’\\]\\)\\?\\\\p\\{L\\}\\\\p\\{M\\}\\?\\)\\*/gu,
-      "regExWordsAndDigits": /\\(\\?:\\\\d\\+\\)\\?\\[\\\\p\\{L\\}\\\\p\\{M\\}_'’-\\]\\(\\?:\\(\\?:\\\\\\\\\\?\\['’\\]\\)\\?\\[\\\\p\\{L\\}\\\\p\\{M\\}\\\\w'’\\.-\\]\\)\\*/gu,
+      "regExWordsAndDigits": /\\[\\\\p\\{L\\}\\\\w'’\`\\.\\+-\\]\\(\\?:\\(\\?:\\\\\\\\\\(\\?=\\['\\]\\)\\)\\?\\[\\\\p\\{L\\}\\\\p\\{M\\}\\\\w'’\`\\.\\+-\\]\\)\\*/gu,
     },
     "calculateTextDocumentOffsets": [Function],
     "camelToSnake": [Function],

--- a/packages/cspell-lib/src/lib/trace.test.ts
+++ b/packages/cspell-lib/src/lib/trace.test.ts
@@ -5,7 +5,7 @@ import { getDefaultSettings, mergeSettings } from './Settings/index.js';
 import type { TraceResult } from './trace.js';
 import { traceWords } from './trace.js';
 
-const timeout = 10000;
+const timeout = 20000;
 
 describe('Verify trace', () => {
     test(

--- a/packages/cspell-lib/src/lib/util/__snapshots__/wordSplitter.test.ts.snap
+++ b/packages/cspell-lib/src/lib/util/__snapshots__/wordSplitter.test.ts.snap
@@ -99,3 +99,162 @@ exports[`Validate wordSplitter > Extract all possible word breaks to 'well-educa
   "well-educated",
 ]
 `;
+
+exports[`Validate wordSplitter > split \`'+flow.tensor'\` in doc 1`] = `
+Map {
+  "flow" => 1,
+  "flow." => 1,
+  "tensor" => 1,
+  ".tensor" => 1,
+  "flow.tensor" => 1,
+  "+flow" => 1,
+  "+flow." => 1,
+  "+flow.tensor" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'\\'twas the night'\` in doc 1`] = `
+Map {
+  "twas" => 1,
+  "'twas" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'-torch.tensor+64'\` in doc 1`] = `
+Map {
+  "torch" => 1,
+  "tensor" => 1,
+  "tensor+" => 1,
+  "tensor+64" => 1,
+  "torch." => 1,
+  ".tensor" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'0.7e1-count+56'\` in doc 1`] = `
+Map {
+  "count" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'64-bit'\` in doc 1`] = `
+Map {
+  "bit" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'64bit'\` in doc 1`] = `
+Map {
+  "bit" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'128-bit'\` in doc 1`] = `
+Map {
+  "bit" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'256-sha'\` in doc 1`] = `
+Map {
+  "sha" => 1,
+  "-sha" => 1,
+  "256-sha" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'REFACTOR\\'d'\` in doc 1`] = `
+Map {
+  "REFACTOR" => 1,
+  "REFACTOR'" => 1,
+  "REFACTOR'd" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'begin+end29'\` in doc 1`] = `
+Map {
+  "begin" => 1,
+  "end" => 1,
+  "end29" => 1,
+  "begin+" => 1,
+  "+end" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'dogs\\''\` in doc 1`] = `
+Map {
+  "dogs" => 1,
+  "dogs'" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'êphoneStatic'\` in doc 1`] = `
+Map {
+  "êphone" => 1,
+  "Static" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'geschäft'\` in doc 1`] = `
+Map {
+  "geschäft" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'îphoneStatic'\` in doc 1`] = `
+Map {
+  "îphone" => 1,
+  "Static" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'n\\'cpp'\` in doc 1`] = `
+Map {
+  "cpp" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'n\\'log'\` in doc 1`] = `
+Map {
+  "log" => 1,
+  "log'" => 1,
+  "'log" => 1,
+  "'log'" => 1,
+  "n" => 1,
+  "n'" => 1,
+  "n'log" => 1,
+  "n'log'" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'nstatic'\` in doc 1`] = `
+Map {
+  "static" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'planets’'\` in doc 1`] = `
+Map {
+  "planets" => 1,
+  "planets’" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'static'\` in doc 1`] = `
+Map {
+  "static" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'techo'\` in doc 1`] = `
+Map {
+  "echo" => 1,
+}
+`;
+
+exports[`Validate wordSplitter > split \`'î\\'cpp'\` in doc 1`] = `
+Map {
+  "î" => 1,
+  "cpp" => 1,
+}
+`;

--- a/packages/cspell-lib/src/lib/util/text.test.ts
+++ b/packages/cspell-lib/src/lib/util/text.test.ts
@@ -23,14 +23,17 @@ describe('Util Text', () => {
         expect(Text.stringToRegExp(pattern)).toEqual(expected);
     });
 
-    test('splits words', () => {
-        expect(splitCamelCaseWord('hello')).toEqual(['hello']);
-        expect(splitCamelCaseWord('helloThere')).toEqual(['hello', 'There']);
-        expect(splitCamelCaseWord('HelloThere')).toEqual(['Hello', 'There']);
-        expect(splitCamelCaseWord('BigÁpple')).toEqual(['Big', 'Ápple']);
-        expect(splitCamelCaseWord('ASCIIToUTF16')).toEqual(['ASCII', 'To', 'UTF16']);
-        expect(splitCamelCaseWord('URLsAndDBAs')).toEqual(['Urls', 'And', 'Dbas']);
-        expect(splitCamelCaseWord('WALKingRUNning')).toEqual(['Walking', 'Running']);
+    test.each`
+        word                | expected
+        ${'hello'}          | ${'hello'.split('|')}
+        ${'helloThere'}     | ${['hello', 'There']}
+        ${'HelloThere'}     | ${['Hello', 'There']}
+        ${'BigÁpple'}       | ${['Big', 'Ápple']}
+        ${'ASCIIToUTF16'}   | ${['ASCII', 'To', 'UTF16']}
+        ${'URLsAndDBAs'}    | ${['Urls', 'And', 'Dbas']}
+        ${'WALKingRUNning'} | ${['Walking', 'Running']}
+    `('splitCamelCaseWord $word', ({ word, expected }) => {
+        expect(splitCamelCaseWord(word)).toEqual(expected);
     });
 
     test('extract word from text', () => {
@@ -328,7 +331,7 @@ describe('Validate individual regexp', () => {
         testName                 | regexp                 | text                           | expectedResult
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${''}                          | ${[]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${" x = 'Don\\'t'"}            | ${['x', 1, "'Don\\'t'", 5]}
-        ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'12345'}                     | ${[]}
+        ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'12345'}                     | ${['12345', 0]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'12345a'}                    | ${['12345a', 0]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'geschäft'}                  | ${['geschäft', 0]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'geschäft'.normalize('NFD')} | ${['geschäft'.normalize('NFD'), 0]}
@@ -336,6 +339,7 @@ describe('Validate individual regexp', () => {
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'b12345a'}                   | ${['b12345a', 0]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'b12_345a'}                  | ${['b12_345a', 0]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'well-educated'}             | ${['well-educated', 0]}
+        ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'.test.each.name `twas'}     | ${['.test.each.name', 0, '`twas', 16]}
         ${'regExWordsAndDigits'} | ${regExWordsAndDigits} | ${'DB\\Driver\\Manager'}       | ${['DB', 0, 'Driver', 3, 'Manager', 10]}
     `('$testName `$text`', ({ regexp, text, expectedResult }: RegExpTestCase) => {
         const r = match(regexp, text);

--- a/packages/cspell-lib/src/lib/util/textRegex.test.ts
+++ b/packages/cspell-lib/src/lib/util/textRegex.test.ts
@@ -7,9 +7,11 @@ import {
     regExDanglingQuote,
     regExFirstUpper,
     regExMatchRegExParts,
+    regExNumericLiteral,
     regExSplitWords,
     regExSplitWords2,
     regExTrailingEndings,
+    regExWordsAndDigits,
     stringToRegExp,
 } from './textRegex.js';
 
@@ -138,6 +140,39 @@ describe('Validate textRegex', () => {
     `('regExMatchRegExParts "$value"', ({ value, expected }) => {
         const r = value.match(regExMatchRegExParts);
         expect(r ? [...r] : r).toEqual(expected);
+    });
+
+    test.each`
+        value        | expected
+        ${''}        | ${null}
+        ${'-22'}     | ${['-22']}
+        ${'-.e6'}    | ${null}
+        ${'-1.e6'}   | ${['-1.e6']}
+        ${'-1.e-6'}  | ${['-1.e-6']}
+        ${'.1e-6'}   | ${['.1e-6']}
+        ${'.1e10'}   | ${['.1e10']}
+        ${'.1e+10'}  | ${['.1e+10']}
+        ${'+.1e+10'} | ${['+.1e+10']}
+    `('regExNumericLiteral "$value"', ({ value, expected }) => {
+        const r = value.match(regExNumericLiteral);
+        expect(r ? [...r] : r).toEqual(expected);
+    });
+
+    test.each`
+        value                | expected
+        ${''}                | ${null}
+        ${',happy birthday'} | ${['happy', 1]}
+        ${'-22'}             | ${['-22', 0]}
+        ${'-.e6'}            | ${['-.e6', 0]}
+        ${'-1.e6'}           | ${['-1.e6', 0]}
+        ${'-1.e-6'}          | ${['-1.e-6', 0]}
+        ${'.1e-6'}           | ${['.1e-6', 0]}
+        ${'.1e10'}           | ${['.1e10', 0]}
+        ${'.1e+10'}          | ${['.1e+10', 0]}
+        ${'+.1e+10'}         | ${['+.1e+10', 0]}
+    `('regExWordsAndDigits "$value"', ({ value, expected }) => {
+        const r = new RegExp(regExWordsAndDigits).exec(value);
+        expect(r ? [...r, r.index] : r).toEqual(expected);
     });
 
     const examplePattern = `/

--- a/packages/cspell-lib/src/lib/util/textRegex.ts
+++ b/packages/cspell-lib/src/lib/util/textRegex.ts
@@ -4,12 +4,13 @@ export const regExUpperSOrIng = /([\p{Lu}\p{M}]+\\?['’]?(?:s|ing|ies|es|ings|e
 export const regExSplitWords = /(\p{Ll}\p{M}?)(\p{Lu})/gu;
 export const regExSplitWords2 = /(\p{Lu}\p{M}?)(\p{Lu}\p{M}?\p{Ll})/gu;
 export const regExWords = /\p{L}\p{M}?(?:(?:\\?['’])?\p{L}\p{M}?)*/gu;
-export const regExWordsAndDigits = /(?:\d+)?[\p{L}\p{M}_'’-](?:(?:\\?['’])?[\p{L}\p{M}\w'’.-])*/gu;
+// Words can be made of letters, numbers, period, underscore, dash, plus, and single quote
+export const regExWordsAndDigits = /[\p{L}\w'’`.+-](?:(?:\\(?=[']))?[\p{L}\p{M}\w'’`.+-])*/gu;
 export const regExIgnoreCharacters = /[\p{sc=Hiragana}\p{sc=Han}\p{sc=Katakana}\u30A0-\u30FF\p{sc=Hangul}]/gu;
 export const regExFirstUpper = /^\p{Lu}\p{M}?\p{Ll}+$/u;
 export const regExAllUpper = /^(?:\p{Lu}\p{M}?)+$/u;
 export const regExAllLower = /^(?:\p{Ll}\p{M}?)+$/u;
-export const regExPossibleWordBreaks = /[-_’'.]/g;
+export const regExPossibleWordBreaks = /[-+_’'`.\s]/g;
 export const regExMatchRegExParts = /^\s*\/([\s\S]*?)\/([gimuxy]*)\s*$/;
 export const regExAccents = /\p{M}/gu;
 export const regExEscapeCharacters = /(?<=\\)[anrvtbf]/gi;
@@ -17,6 +18,7 @@ export const regExEscapeCharacters = /(?<=\\)[anrvtbf]/gi;
 export const regExDanglingQuote = /(?<=(?:^|(?!\p{M})\P{L})(?:\p{L}\p{M}?)?)[']/gu;
 /** Match tailing endings after CAPS words */
 export const regExTrailingEndings = /(?<=(?:\p{Lu}\p{M}?){2})['’]?(?:s|d|ings?|ies|e[ds]?|ning|th|nth)(?!\p{Ll})/gu;
+export const regExNumericLiteral = /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?$/;
 
 export function stringToRegExp(pattern: string | RegExp, defaultFlags = 'gimu', forceFlags = 'g'): RegExp | undefined {
     if (pattern instanceof RegExp) {

--- a/packages/cspell-lib/src/lib/util/wordSplitter.ts
+++ b/packages/cspell-lib/src/lib/util/wordSplitter.ts
@@ -5,6 +5,7 @@ import { escapeRegEx } from './regexHelper.js';
 import {
     regExDanglingQuote,
     regExEscapeCharacters,
+    regExNumericLiteral,
     regExPossibleWordBreaks,
     regExSplitWords,
     regExSplitWords2,
@@ -52,6 +53,8 @@ export function split(
     const lineOffset = line.offset;
     const requested = new Map<number, boolean>();
 
+    const regExpIgnoreSegment = /^[-.+\d_eE'`\\\s]+$/;
+
     if (!relWordToSplit.text) {
         const text = rebaseTextOffset(relWordToSplit);
         return {
@@ -89,6 +92,10 @@ export function split(
     }
 
     function has(word: TextOffset): boolean {
+        if (regExpIgnoreSegment.test(word.text)) {
+            return true;
+        }
+
         const i = word.offset;
         const j = word.text.length;
         let v = i + (j << 20);
@@ -131,6 +138,11 @@ function findNextWordText({ text, offset }: TextOffset): TextOffset {
             text: '',
             offset: offset + text.length,
         };
+    }
+
+    // Skip numeric literals.
+    if (regExNumericLiteral.test(m[0])) {
+        return findNextWordText({ text, offset: offset + m[0].length });
     }
 
     return {
@@ -451,4 +463,5 @@ function mergeSortedBreaks(...maps: SortedBreaks[]): SortedBreaks {
 
 export const __testing__ = {
     generateWordBreaks,
+    findNextWordText,
 };


### PR DESCRIPTION
Support words starting with `.` or digits.

It is now possible to match against the following types of words

dictionary:
- `.descvec`
- `99.9krock`


