### PR TITLE
fix: Fix an issue when `words` are `null`

### DIFF
--- a/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.test.ts
@@ -168,13 +168,16 @@ describe('Validate CSpellSettingsServer', () => {
     test.each`
         left                                              | right                                              | expected
         ${{}}                                             | ${{}}                                              | ${csi({})}
+        ${{ words: null }}                                | ${{}}                                              | ${csi({})}
+        ${{}}                                             | ${{ words: null }}                                 | ${csi({})}
         ${{ dictionaries: ['a'] }}                        | ${{ dictionaries: ['b'] }}                         | ${oc(csi({ dictionaries: ['a', 'b'] }))}
         ${{ features: {} }}                               | ${{}}                                              | ${oc(csi({ features: {} }))}
         ${{ features: { 'weighted-suggestions': true } }} | ${{}}                                              | ${oc(csi({ features: { 'weighted-suggestions': true } }))}
         ${{ features: { 'weighted-suggestions': true } }} | ${{ features: { 'weighted-suggestions': false } }} | ${oc(csi({ features: { 'weighted-suggestions': false } }))}
         ${{ features: { 'weighted-suggestions': true } }} | ${{ features: { 'new-feature': true } }}           | ${oc({ features: { 'weighted-suggestions': true, 'new-feature': true } })}
     `('mergeSettings $left with $right', ({ left, right, expected }) => {
-        expect(mergeSettings(left, right)).toEqual(expected);
+        const merged = mergeSettings(left, right);
+        expect(merged).toEqual(expected);
     });
 
     test.each`

--- a/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.ts
@@ -25,10 +25,6 @@ type CSpellSettingsWST = AdvancedCSpellSettingsWithSourceTrace;
 type CSpellSettingsWSTO = OptionalOrUndefined<AdvancedCSpellSettingsWithSourceTrace>;
 type CSpellSettingsI = CSpellSettingsInternal;
 
-function _unique<T>(a: T[]): T[] {
-    return [...new Set(a)];
-}
-
 /**
  * Merges two lists and removes duplicates.  Order is NOT preserved.
  */
@@ -38,11 +34,11 @@ function mergeListUnique<T>(left: undefined, right: T[]): T[];
 function mergeListUnique<T>(left: T[], right: undefined): T[];
 function mergeListUnique<T>(left: T[] | undefined, right: T[] | undefined): T[] | undefined;
 function mergeListUnique<T>(left: T[] | undefined, right: T[] | undefined): T[] | undefined {
-    if (left === undefined) return right;
-    if (right === undefined) return left;
+    if (!Array.isArray(left)) return Array.isArray(right) ? right : undefined;
+    if (!Array.isArray(right)) return left;
     if (!right.length) return left;
     if (!left.length) return right;
-    return _unique([...left, ...right]);
+    return [...new Set([...left, ...right])];
 }
 
 /**
@@ -55,8 +51,8 @@ function mergeList<T>(left: undefined, right: T[]): T[];
 function mergeList<T>(left: T[], right: undefined): T[];
 function mergeList<T>(left: T[] | undefined, right: T[] | undefined): T[] | undefined;
 function mergeList<T>(left: T[] | undefined, right: T[] | undefined): T[] | undefined {
-    if (left === undefined) return right;
-    if (right === undefined) return left;
+    if (!Array.isArray(left)) return Array.isArray(right) ? right : undefined;
+    if (!Array.isArray(right)) return left;
     if (!left.length) return right;
     if (!right.length) return left;
     return left.concat(right);
@@ -82,10 +78,10 @@ function mergeWordsCached(left: undefined, right: string[]): string[];
 function mergeWordsCached(left: string[], right: undefined): string[];
 function mergeWordsCached(left: string[] | undefined, right: string[] | undefined): string[] | undefined;
 function mergeWordsCached(left: string[] | undefined, right: string[] | undefined): string[] | undefined {
-    if (left === undefined) return !right || right.length ? right : emptyWords;
-    if (right === undefined) return !left || left.length ? left : emptyWords;
-    if (!left.length) return !right || right.length ? right : emptyWords;
-    if (!right.length) return !left || left.length ? left : emptyWords;
+    if (!Array.isArray(left) || !left.length) {
+        return Array.isArray(right) ? (right.length ? right : emptyWords) : undefined;
+    }
+    if (!Array.isArray(right) || !right.length) return left;
 
     return _mergeWordsCached(left, right);
 }
@@ -95,8 +91,8 @@ function mergeObjects<T>(left: T, right: undefined): T;
 function mergeObjects<T>(left: T, right: T): T;
 function mergeObjects<T>(left: undefined, right: T): T;
 function mergeObjects<T>(left?: T, right?: T): T | undefined {
-    if (left === undefined) return right;
-    if (right === undefined) return left;
+    if (!left || typeof left !== 'object') return !right || typeof right !== 'object' ? undefined : right;
+    if (!right || typeof right !== 'object') return left;
     return { ...left, ...right };
 }
 

--- a/packages/cspell-lib/src/lib/util/util.ts
+++ b/packages/cspell-lib/src/lib/util/util.ts
@@ -21,7 +21,7 @@ export function unique<T>(src: T[]): T[] {
 }
 
 /**
- * Delete all `undefined` fields from an object.
+ * Delete all `undefined` and `null` fields from an object.
  * @param src - object to be cleaned
  */
 export function clean<T extends object>(src: T): RemoveUndefined<T> {
@@ -29,7 +29,7 @@ export function clean<T extends object>(src: T): RemoveUndefined<T> {
     type keyOfT = keyof T;
     type keysOfT = keyOfT[];
     for (const key of Object.keys(r) as keysOfT) {
-        if (r[key] === undefined) {
+        if (r[key] === undefined || r[key] === null) {
             delete r[key];
         }
     }


### PR DESCRIPTION
`words` and `dictionaries` can become null when editing `.yaml` files and it is saved.

```yaml
words:
dictionaries:
  - def
```