### PR TITLE
fix: make sure cspell-types are true dependencies

### DIFF
--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -85,6 +85,7 @@
   "homepage": "https://streetsidesoftware.github.io/cspell/",
   "dependencies": {
     "@cspell/cspell-pipe": "workspace:*",
+    "@cspell/cspell-types": "workspace:*",
     "@cspell/dynamic-import": "workspace:*",
     "chalk": "^5.3.0",
     "chalk-template": "^1.1.0",
@@ -106,7 +107,6 @@
   },
   "devDependencies": {
     "@cspell/cspell-json-reporter": "workspace:*",
-    "@cspell/cspell-types": "workspace:*",
     "@types/file-entry-cache": "^5.0.2",
     "@types/glob": "^8.1.0",
     "@types/micromatch": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -207,6 +207,9 @@ importers:
       '@cspell/cspell-pipe':
         specifier: workspace:*
         version: link:../cspell-pipe
+      '@cspell/cspell-types':
+        specifier: workspace:*
+        version: link:../cspell-types
       '@cspell/dynamic-import':
         specifier: workspace:*
         version: link:../dynamic-import
@@ -256,9 +259,6 @@ importers:
       '@cspell/cspell-json-reporter':
         specifier: workspace:*
         version: link:../cspell-json-reporter
-      '@cspell/cspell-types':
-        specifier: workspace:*
-        version: link:../cspell-types
       '@types/file-entry-cache':
         specifier: ^5.0.2
         version: 5.0.2


### PR DESCRIPTION
Related to #4639

This bug creeped in because cspell-types used to be purely types and didn't need to be packaged with cspell.