### PR TITLE
fix: cspell-tools: fix init option output

### DIFF
--- a/packages/cspell-tools/src/compile.test.ts
+++ b/packages/cspell-tools/src/compile.test.ts
@@ -2,7 +2,7 @@ import { writeFile } from 'node:fs/promises';
 
 import { describe, expect, test, vi } from 'vitest';
 
-import { processCompileAction } from './compile.js';
+import { configFileHeader, processCompileAction } from './compile.js';
 
 vi.mock('node:fs/promises', () => ({
     writeFile: vi.fn().mockImplementation(() => Promise.resolve(undefined)),
@@ -22,7 +22,9 @@ describe('compile', () => {
             listFile: ['source-files.txt'],
             init: true,
         };
-        const expected = `\
+        const expected =
+            configFileHeader +
+            `\
 targets:
   - name: public-licenses
     targetDirectory: .
@@ -31,6 +33,35 @@ targets:
     sources:
       - listFile: source-files.txt
     sort: true
+`;
+        await processCompileAction([], options, undefined);
+        expect(mockWriteFile).toHaveBeenLastCalledWith('cspell-tools.config.yaml', expected);
+    });
+
+    test('--init option', async () => {
+        const options = {
+            compress: false,
+            trie3: true,
+            experimental: ['compound'],
+            sort: true,
+            merge: 'nl-nl',
+            output: '.',
+            listFile: ['src\\source-files.txt'],
+            init: true,
+            max_depth: '5',
+        };
+        const expected =
+            configFileHeader +
+            `\
+targets:
+  - name: nl-nl
+    targetDirectory: .
+    compress: false
+    format: trie3
+    sources:
+      - listFile: src/source-files.txt
+    generateNonStrict: true
+maxDepth: 5
 `;
         await processCompileAction([], options, undefined);
         expect(mockWriteFile).toHaveBeenLastCalledWith('cspell-tools.config.yaml', expected);

--- a/packages/cspell-tools/src/compile.ts
+++ b/packages/cspell-tools/src/compile.ts
@@ -15,6 +15,9 @@ getSystemFeatureFlags().register('compound', 'Enable compound dictionary sources
 
 const defaultConfigFile = 'cspell-tools.config.yaml';
 
+export const configFileHeader =
+    '# yaml-language-server: $schema=https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-tools/cspell-tools.config.schema.json\n\n';
+
 export async function processCompileAction(
     src: string[],
     options: CompileCommonAppOptions,
@@ -50,7 +53,7 @@ async function useCompile(src: string[], options: CompileCommonAppOptions): Prom
 }
 
 async function initConfig(request: CompileRequest): Promise<void> {
-    const content = YAML.stringify(request, null, 2);
+    const content = configFileHeader + YAML.stringify(request, null, 2);
     console.log('Writing config file: %s', defaultConfigFile);
     await writeFile(defaultConfigFile, content);
 

--- a/packages/cspell-tools/src/compiler/__snapshots__/createCompileRequest.test.ts.snap
+++ b/packages/cspell-tools/src/compiler/__snapshots__/createCompileRequest.test.ts.snap
@@ -117,3 +117,55 @@ exports[`createCompileRequest > createCompileRequest 7`] = `
   ],
 }
 `;
+
+exports[`createCompileRequest > createCompileRequest 8`] = `
+{
+  "targets": [
+    {
+      "compress": false,
+      "format": "plaintext",
+      "name": "company-words",
+      "sources": [
+        "src/c-words.txt",
+      ],
+      "targetDirectory": ".",
+    },
+  ],
+}
+`;
+
+exports[`createCompileRequest > createCompileRequest 9`] = `
+{
+  "targets": [
+    {
+      "compress": false,
+      "format": "plaintext",
+      "name": "python",
+      "sources": [
+        {
+          "listFile": "src/source-files.txt",
+        },
+      ],
+      "targetDirectory": ".",
+    },
+  ],
+}
+`;
+
+exports[`createCompileRequest > createCompileRequest 10`] = `
+{
+  "targets": [
+    {
+      "compress": false,
+      "format": "plaintext",
+      "name": "python",
+      "sources": [
+        {
+          "filename": "src/python.txt",
+        },
+      ],
+      "targetDirectory": ".",
+    },
+  ],
+}
+`;

--- a/packages/cspell-tools/src/compiler/createCompileRequest.test.ts
+++ b/packages/cspell-tools/src/compiler/createCompileRequest.test.ts
@@ -5,18 +5,21 @@ import { createCompileRequest } from './createCompileRequest.js';
 
 describe('createCompileRequest', () => {
     test.each`
-        source                                 | options
-        ${[]}                                  | ${comp()}
-        ${['src/words.txt']}                   | ${comp()}
-        ${['src/words.txt', 'src/cities.txt']} | ${comp({ output: 'out' })}
-        ${['src/words.txt', 'src/cities.txt']} | ${comp({ output: 'out', merge: 'combo' })}
-        ${[]}                                  | ${comp({ listFile: ['python-sources.txt'] })}
-        ${[]}                                  | ${comp({ listFile: ['python-sources.txt'], output: 'python' })}
-        ${[]}                                  | ${comp({ listFile: ['python-sources.txt'], merge: 'python' })}
+        source                                     | options
+        ${[]}                                      | ${comp()}
+        ${['src/words.txt']}                       | ${comp()}
+        ${['src/words.txt', 'src/cities.txt']}     | ${comp({ output: 'out' })}
+        ${['src/words.txt', 'src/cities.txt']}     | ${comp({ output: 'out', merge: 'combo' })}
+        ${[]}                                      | ${comp({ listFile: ['python-sources.txt'] })}
+        ${[]}                                      | ${comp({ listFile: ['python-sources.txt'], output: 'python' })}
+        ${[]}                                      | ${comp({ listFile: ['python-sources.txt'], merge: 'python' })}
+        ${['src\\c-words.txt']}                    | ${comp({ merge: 'company-words' })}
+        ${[{ listFile: 'src\\source-files.txt' }]} | ${comp({ merge: 'python' })}
+        ${[{ filename: 'src\\python.txt' }]}       | ${comp({ merge: 'python' })}
     `('createCompileRequest', ({ source, options }) => {
         const req = createCompileRequest(source, options);
         // Make sure the test passes on Windows.
-        const reqClean = JSON.parse(JSON.stringify(req, null, 2).replace(/\\\\/g, '/'));
+        const reqClean = JSON.parse(JSON.stringify(req, null, 2) /* .replace(/\\\\/g, '/') */);
         expect(reqClean).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
If the config file was generated on windows, it would not work on Linux.