### PR TITLE
fix: Fix and issue with `.trie` builder

### DIFF
--- a/packages/cspell-dictionary/src/util/simpleCache.test.ts
+++ b/packages/cspell-dictionary/src/util/simpleCache.test.ts
@@ -23,7 +23,7 @@ describe('AutoCache', () => {
             expect(r).toBe(v);
             expect(cache.has(v)).toBe(true);
         }
-        expect(mock.mock.calls.reduce((a, v) => a.concat(v), <unknown[]>[])).toEqual(expected);
+        expect(mock.mock.calls.flatMap((a) => a)).toEqual(expected);
     });
 });
 
@@ -150,6 +150,6 @@ describe('AutoWeakCache', () => {
             expect(r).toBe(v);
             expect(cache.has(v)).toBe(true);
         }
-        expect(mock.mock.calls.reduce((a, v) => a.concat(v), <unknown[]>[])).toEqual(expected);
+        expect(mock.mock.calls.flatMap((a) => a)).toEqual(expected);
     });
 });

--- a/packages/cspell-lib/src/lib/wordListHelper.ts
+++ b/packages/cspell-lib/src/lib/wordListHelper.ts
@@ -25,7 +25,7 @@ export function splitLine(line: string): string[] {
 }
 
 export function splitCodeWords(words: string[]): string[] {
-    return words.map(Text.splitCamelCaseWord).reduce((a, b) => a.concat(b), []);
+    return words.map(Text.splitCamelCaseWord).flatMap((a) => a);
 }
 
 export function splitLineIntoCodeWords(line: string): IterableIterator<string> {

--- a/packages/cspell-tools/src/compiler/compile.ts
+++ b/packages/cspell-tools/src/compiler/compile.ts
@@ -119,6 +119,8 @@ async function processFiles(action: ActionFn, filesToProcess: FileToProcess[], m
             logWithTimestamp('Done processing %s', rel(ftp.src));
         }),
         // opMap((a) => (console.warn(a), a))
+        logProgress(),
+        // opTake(27000000),
     );
     await action(words, dst);
     logWithTimestamp('Done "%s"', rel(dst));
@@ -207,4 +209,20 @@ async function readFileSource(fileSource: FileSource, sourceOptions: CompileSour
 
 function normalizeTargetName(name: string) {
     return name.replace(/((\.txt|\.dic|\.aff|\.trie)(\.gz)?)?$/, '').replace(/[^\p{L}\p{M}.\w\\/-]/gu, '_');
+}
+
+function logProgress<T>(freq = 100000): (iter: Iterable<T>) => Iterable<T> {
+    function* logProgress<T>(iter: Iterable<T>): Iterable<T> {
+        const _freq = freq;
+        let count = 0;
+        for (const v of iter) {
+            ++count;
+            if (!(count % _freq)) {
+                logWithTimestamp('Progress: Words Processed - %s', count.toLocaleString());
+            }
+            yield v;
+        }
+    }
+
+    return logProgress;
 }

--- a/packages/cspell-trie-lib/api/api.d.ts
+++ b/packages/cspell-trie-lib/api/api.d.ts
@@ -664,8 +664,10 @@ declare class TrieBuilder {
     private lastPath;
     private tails;
     trieOptions: TrieInfo;
+    private numWords;
+    private _debug_lastWordsInserted;
+    private _debug_mode;
     constructor(words?: Iterable<string>, trieOptions?: PartialTrieInfo);
-    private set _root(value);
     private get _root();
     private signature;
     private _canBeCached;
@@ -683,6 +685,13 @@ declare class TrieBuilder {
      */
     reset(): void;
     build(consolidateSuffixes?: boolean): Trie;
+    private debugStack;
+    private debNodeInfo;
+    private logDebug;
+    private runDebug;
+    private copyIfFrozen;
+    private createNodeFrozen;
+    private createNode;
 }
 
 declare function insert(text: string, root?: TrieNode): TrieNode;

--- a/packages/cspell-trie-lib/src/lib/TrieBuilder.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBuilder.ts
@@ -1,10 +1,24 @@
 import { consolidate } from './consolidate.js';
 import type { PartialTrieOptions, TrieOptions } from './trie.js';
 import { Trie } from './trie.js';
-import { createTrieRoot, createTrieRootFromList, trieNodeToRoot } from './TrieNode/trie-util.js';
+import { checkCircular, createTrieRootFromList, trieNodeToRoot } from './TrieNode/trie-util.js';
 import type { TrieNode, TrieRoot } from './TrieNode/TrieNode.js';
 import { mergeOptionalWithDefaults } from './utils/mergeOptionalWithDefaults.js';
 import { SecondChanceCache } from './utils/secondChanceCache.js';
+
+type ChildMap = Record<string, TrieNodeEx>;
+
+interface TrieNodeEx extends TrieNode {
+    id: number;
+    c?: ChildMap | undefined;
+}
+
+const SymbolFrozenNode = Symbol();
+
+interface TrieNodeExFrozen extends TrieNodeEx {
+    [SymbolFrozenNode]?: true;
+    c?: Record<string, TrieNodeExFrozen> | undefined;
+}
 
 /**
  * Builds an optimized Trie from a Iterable<string>. It attempts to reduce the size of the trie
@@ -30,7 +44,7 @@ interface PathNode {
     /** a single character */
     s: string;
     /** the corresponding child node after adding s */
-    n: TrieNode;
+    n: TrieNodeEx;
 }
 
 // cspell:words sigs
@@ -40,19 +54,25 @@ const MAX_CACHE_SIZE = 1000000;
 
 export class TrieBuilder {
     private count = 0;
-    private readonly signatures = new SecondChanceCache<string, TrieNode>(MAX_NUM_SIGS);
-    private readonly cached = new SecondChanceCache<TrieNode, number>(MAX_CACHE_SIZE);
-    private readonly transforms = new SecondChanceCache<TrieNode, Map<string, TrieNode>>(MAX_TRANSFORMS);
-    private _eow: TrieNode = Object.freeze({ f: 1 });
+    private readonly signatures = new SecondChanceCache<string, TrieNodeEx>(MAX_NUM_SIGS);
+    private readonly cached = new SecondChanceCache<TrieNodeEx, number>(MAX_CACHE_SIZE);
+    private readonly transforms = new SecondChanceCache<TrieNodeEx, Map<string, TrieNodeEx>>(MAX_TRANSFORMS);
+    private _eow: TrieNodeEx;
     /** position 0 of lastPath is always the root */
-    private lastPath: PathNode[] = [{ s: '', n: { f: undefined, c: undefined } }];
-    private tails = new Map([['', this._eow]]);
+    private lastPath: PathNode[] = [{ s: '', n: { id: 0, f: undefined, c: undefined } }];
+    private tails = new Map<string, TrieNodeEx>();
     public trieOptions: TrieOptions;
+    private numWords = 0;
+    private _debug_lastWordsInserted: string[] = [];
+    // private _debug_mode = true;
+    private _debug_mode = false;
 
     constructor(words?: Iterable<string>, trieOptions?: PartialTrieOptions) {
+        this._eow = this.createNodeFrozen(1);
+        this.tails.set('', this._eow);
         this._canBeCached(this._eow); // this line is just for coverage reasons
         this.signatures.set(this.signature(this._eow), this._eow);
-        this.cached.set(this._eow, this.count++);
+        this.cached.set(this._eow, this._eow.id ?? ++this.count);
         this.trieOptions = Object.freeze(mergeOptionalWithDefaults(trieOptions));
 
         if (words) {
@@ -60,21 +80,20 @@ export class TrieBuilder {
         }
     }
 
-    private set _root(n: TrieRoot) {
-        this.lastPath[0].n = n;
-    }
-
     private get _root(): TrieRoot {
         return trieNodeToRoot(this.lastPath[0].n, this.trieOptions);
     }
 
-    private signature(n: TrieNode): string {
+    private signature(n: TrieNodeEx): string {
         const isWord = n.f ? '*' : '';
-        const ref = n.c ? JSON.stringify(Object.entries(n.c).map(([k, n]) => [k, this.cached.get(n)])) : '';
-        return isWord + ref;
+        const entries = n.c ? Object.entries(n.c) : undefined;
+        const c = entries ? entries.map(([k, n]) => [k, this.cached.get(n)]) : undefined;
+        const ref = c ? JSON.stringify(c) : '';
+        const sig = isWord + ref;
+        return sig;
     }
 
-    private _canBeCached(n: TrieNode): boolean {
+    private _canBeCached(n: TrieNodeEx): boolean {
         if (!n.c) return true;
         for (const v of Object.values(n.c)) {
             if (!this.cached.has(v)) return false;
@@ -82,28 +101,29 @@ export class TrieBuilder {
         return true;
     }
 
-    private tryCacheFrozen(n: TrieNode) {
+    private tryCacheFrozen(n: TrieNodeEx) {
+        assertFrozen(n);
         if (this.cached.has(n)) {
             return n;
         }
-        this.cached.set(n, this.count++);
+        this.cached.set(n, n.id ?? ++this.count);
         return n;
     }
 
-    private freeze(n: TrieNode) {
+    private freeze(n: TrieNodeEx): TrieNodeExFrozen {
         if (Object.isFrozen(n)) return n;
         // istanbul ignore else
         if (n.c) {
             const c = Object.entries(n.c)
                 .sort((a, b) => (a[0] < b[0] ? -1 : 1))
-                .map(([k, n]) => [k, this.freeze(n)] as [string, TrieNode]);
+                .map(([k, n]) => [k, this.freeze(n)] as [string, TrieNodeExFrozen]);
             n.c = Object.fromEntries(c);
             Object.freeze(n.c);
         }
         return Object.freeze(n);
     }
 
-    private tryToCache(n: TrieNode): TrieNode {
+    private tryToCache(n: TrieNodeEx): TrieNodeEx {
         if (!this._canBeCached(n)) {
             return n;
         }
@@ -116,14 +136,15 @@ export class TrieBuilder {
         return n;
     }
 
-    private storeTransform(src: TrieNode, s: string, result: TrieNode) {
+    private storeTransform(src: TrieNodeEx, s: string, result: TrieNodeEx) {
         if (!Object.isFrozen(result) || !Object.isFrozen(src)) return;
-        const t = this.transforms.get(src) ?? new Map<string, TrieNode>();
+        this.logDebug('storeTransform', () => ({ s, src: this.debNodeInfo(src), result: this.debNodeInfo(result) }));
+        const t = this.transforms.get(src) ?? new Map<string, TrieNodeEx>();
         t.set(s, result);
         this.transforms.set(src, t);
     }
 
-    private addChild(node: TrieNode, head: string, child: TrieNode): TrieNode {
+    private addChild(node: TrieNodeEx, head: string, child: TrieNodeEx): TrieNodeEx {
         if (node.c?.[head] !== child) {
             let c = node.c || Object.create(null);
             if (Object.isFrozen(c)) {
@@ -131,7 +152,7 @@ export class TrieBuilder {
             }
             c[head] = child;
             if (Object.isFrozen(node)) {
-                node = { ...node, c };
+                node = this.createNode(node.f, c);
             } else {
                 node.c = c;
             }
@@ -139,23 +160,30 @@ export class TrieBuilder {
         return Object.isFrozen(child) ? this.tryToCache(node) : node;
     }
 
-    private buildTail(s: string): TrieNode {
+    private buildTail(s: string): TrieNodeEx {
         const v = this.tails.get(s);
         if (v) return v;
         const head = s[0];
         const tail = s.slice(1);
         const t = this.tails.get(tail);
         const c = t || this.buildTail(tail);
-        const n = this.addChild({ f: undefined, c: undefined }, head, c);
+        const n = this.addChild(this.createNode(), head, c);
         if (!t) {
             return n;
         }
-        const cachedNode = this.tryCacheFrozen(Object.freeze(n));
+        const cachedNode = this.tryCacheFrozen(this.freeze(n));
         this.tails.set(s, cachedNode);
+        // console.warn('tail: %s', s);
         return cachedNode;
     }
 
-    private _insert(node: TrieNode, s: string, d: number): TrieNode {
+    private _insert(node: TrieNodeEx, s: string, d: number): TrieNodeEx {
+        this.logDebug('_insert', () => ({
+            n: this.debNodeInfo(node),
+            s,
+            d,
+            w: this.lastPath.map((a) => a.s).join(''),
+        }));
         const orig = node;
         if (Object.isFrozen(node)) {
             const n = this.transforms.get(node)?.get(s);
@@ -167,7 +195,7 @@ export class TrieBuilder {
             if (!node.c) {
                 return this._eow;
             } else {
-                node = copyIfFrozen(node);
+                node = this.copyIfFrozen(node);
                 node.f = this._eow.f;
                 return node;
             }
@@ -183,6 +211,25 @@ export class TrieBuilder {
     }
 
     insertWord(word: string): void {
+        // this._debug_mode ||= this.numWords >= 26123525;
+        this.logDebug('insertWord', word);
+        this._debug_lastWordsInserted[this.numWords & 0xf] = word;
+        this.numWords++;
+        // if (!(this.numWords % 100000) /*|| this.numWords > 26123530 */) {
+        //     console.warn('check circular at: %o', this.numWords);
+        //     const check = checkCircular(this._root);
+        //     if (check.isCircular) {
+        //         const prevWord = this.lastPath.map((a) => a.s).join('|');
+        //         const prevWords = this._debug_lastWordsInserted.map(
+        //             (w, i) => this._debug_lastWordsInserted[(this.numWords + i) & 0xf],
+        //         );
+        //         const { word, pos, stack } = check.ref;
+        //         console.error('Circular before %o\ncheck: %o', this.numWords, { word, pos, prevWord, prevWords });
+        //         console.error('Stack: %o', this.debugStack(stack));
+        //         throw new Error('Circular');
+        //     }
+        // }
+
         let d = 1;
         for (const s of word.split('')) {
             const p = this.lastPath[d];
@@ -221,24 +268,77 @@ export class TrieBuilder {
      * Resets the builder
      */
     reset(): void {
-        this._root = createTrieRoot(this.trieOptions);
+        this.lastPath = [{ s: '', n: { id: 0, f: undefined, c: undefined } }];
         this.cached.clear();
         this.signatures.clear();
         this.signatures.set(this.signature(this._eow), this._eow);
         this.count = 0;
-        this.cached.set(this._eow, this.count++);
+        this.cached.set(this._eow, this._eow.id ?? ++this.count);
     }
 
     build(consolidateSuffixes = false): Trie {
         const root = this._root;
         // Reset the builder to prevent updating the trie in the background.
         this.reset();
+        const check = checkCircular(this._root);
+
+        if (check.isCircular) {
+            const { word, pos } = check.ref;
+            console.error('Circular Reference %o', { word, pos });
+            throw new Error('Trie: Circular Reference');
+        }
+
         return new Trie(consolidateSuffixes ? consolidate(root) : root);
+    }
+
+    private debugStack(stack: TrieNodeEx[]) {
+        return stack.map((n) => this.debNodeInfo(n));
+    }
+
+    private debNodeInfo(node: TrieNodeEx) {
+        const id = node.id ?? '?';
+        const cid = this.cached.get(node) ?? '?';
+        const f = node.f || 0;
+        const c = node.c
+            ? Object.fromEntries(
+                  Object.entries(node.c).map(([k, n]) => [k, { id: (<TrieNodeEx>n).id, r: this.cached.get(n) }]),
+              )
+            : undefined;
+        const L = Object.isFrozen(node);
+        return { id, cid, f, c, L };
+    }
+
+    private logDebug(methodName: string, contentOrFunction: unknown | (() => void)) {
+        this.runDebug(() => {
+            const content = typeof contentOrFunction === 'function' ? contentOrFunction() : contentOrFunction;
+            console.warn('%s: %o', methodName, content);
+        });
+    }
+
+    private runDebug(method: () => void) {
+        if (this._debug_mode) {
+            method();
+        }
+    }
+
+    private copyIfFrozen(n: TrieNodeEx): TrieNodeEx {
+        if (!Object.isFrozen(n)) return n;
+        const c = n.c ? Object.assign(Object.create(null), n.c) : undefined;
+        return this.createNode(n.f, c);
+    }
+
+    private createNodeFrozen(f?: number | undefined, c?: ChildMap | undefined): TrieNodeExFrozen {
+        return this.freeze(this.createNode(f, c));
+    }
+
+    private createNode(f?: number | undefined, c?: ChildMap | undefined): TrieNodeEx {
+        return { id: ++this.count, f, c };
     }
 }
 
-function copyIfFrozen(n: TrieNode): TrieNode {
-    if (!Object.isFrozen(n)) return n;
-    const c = n.c ? Object.assign(Object.create(null), n.c) : undefined;
-    return { f: n.f, c };
+function assertFrozen(n: TrieNodeEx): asserts n is TrieNodeExFrozen {
+    if (!('id' in n)) {
+        console.warn('%o', n);
+    }
+    if (!Object.isFrozen(n) || !('id' in n)) throw Error('Must be TrieNodeExFrozen');
 }

--- a/packages/cspell-trie-lib/src/lib/TrieNode/trie-util.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/trie-util.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import { mergeDefaults } from '../utils/mergeDefaults.js';
 import {
+    checkCircular,
     countNodes,
     countWords,
     createTrieRootFromList,
@@ -10,6 +11,8 @@ import {
     isCircular,
     iteratorTrieWords,
 } from './trie-util.js';
+
+const oc = expect.objectContaining;
 
 describe('Validate Util Functions', () => {
     test('createTriFromList', () => {
@@ -48,6 +51,17 @@ describe('Validate Util Functions', () => {
         const n = findNode(trie, 'samp');
         n && n.c && (n.c['x'] = trie);
         expect(isCircular(trie)).toBe(true);
+    });
+
+    test('checkCircular', () => {
+        const trie = createTrieRootFromList(words);
+        expect(isCircular(trie)).toBe(false);
+        const cir = findNode(trie, 'sp');
+        const n = findNode(trie, 'space');
+        n && n.c && (n.c['s'] = cir || trie);
+        const { ref } = checkCircular(trie);
+        if (ref) ref.stack = [];
+        expect(ref).toEqual(oc({ word: 'spaces', pos: 2 }));
     });
 
     test('countWords', () => {

--- a/packages/cspell-trie-lib/src/lib/consolidate.ts
+++ b/packages/cspell-trie-lib/src/lib/consolidate.ts
@@ -1,4 +1,4 @@
-import { trieNodeToRoot } from './TrieNode/trie-util.js';
+import { isCircular, trieNodeToRoot } from './TrieNode/trie-util.js';
 import type { TrieNode, TrieRoot } from './TrieNode/TrieNode.js';
 import { FLAG_WORD } from './TrieNode/TrieNode.js';
 
@@ -11,6 +11,10 @@ export function consolidate(root: TrieRoot): TrieRoot {
     const signatures = new Map<string, TrieNode>();
     const cached = new Map<TrieNode, number>();
     const knownMap = new Map<TrieNode, TrieNode>();
+
+    if (isCircular(root)) {
+        throw new Error('Trie is circular.');
+    }
 
     function signature(n: TrieNode): string {
         const isWord = n.f ? '*' : '';
@@ -75,7 +79,7 @@ export function consolidate(root: TrieRoot): TrieRoot {
         if (n.c) {
             const children = Object.entries(n.c)
                 .sort((a, b) => (a[0] < b[0] ? -1 : 1))
-                .map((c) => [c[0], process(c[1])] as [string, TrieNode]);
+                .map(([k, n]) => [k, process(n)] as [string, TrieNode]);
             n.c = Object.fromEntries(children);
         }
         const sig = signature(n);

--- a/packages/cspell-trie-lib/src/lib/utils/secondChanceCache.test.ts
+++ b/packages/cspell-trie-lib/src/lib/utils/secondChanceCache.test.ts
@@ -23,10 +23,12 @@ describe('Validate SecondChanceCache', () => {
         cache.set('f', ++cnt);
         expect(cache.size).toBe(6);
         expect(cache.get('b')).toBe(2);
-        expect(cache.size).toBe(4);
-        expect(cache.size0).toBe(1);
-        expect(cache.size1).toBe(3);
+        expect(cache.size).toBe(6);
+        expect(cache.size0).toBe(4);
+        expect(cache.size1).toBe(2);
         expect(cache.toArray()).toEqual([
+            ['a', 1],
+            ['c', 3],
             ['d', 4],
             ['e', 5],
             ['f', 6],
@@ -34,15 +36,17 @@ describe('Validate SecondChanceCache', () => {
         ]);
         cache.set('g', ++cnt);
         expect(cache.size).toBe(5);
-        expect(cache.size0).toBe(2);
+        expect(cache.size0).toBe(1);
+        expect(cache.size1).toBe(4);
         expect(cache.has('a')).toBe(false);
         expect(cache.get('a')).toBe(undefined);
         expect(cache.has('f')).toBe(true);
-        expect(cache.size0).toBe(3);
-        expect(cache.size1).toBe(2);
+        expect(cache.size).toBe(5);
+        expect(cache.size0).toBe(2);
+        expect(cache.size1).toBe(3);
         expect(cache.get('f')).toBe(6);
-        expect(cache.size0).toBe(3);
-        expect(cache.size1).toBe(2);
+        expect(cache.size0).toBe(2);
+        expect(cache.size1).toBe(3);
         expect(cache.clear()).toBe(cache);
         expect(cache.size).toBe(0);
     });

--- a/packages/cspell-trie-lib/src/lib/utils/secondChanceCache.ts
+++ b/packages/cspell-trie-lib/src/lib/utils/secondChanceCache.ts
@@ -53,7 +53,7 @@ export class SecondChanceCache<Key, Value> {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const v = this.map1.get(key)!;
             this.map1.delete(key);
-            this.set(key, v);
+            this.map0.set(key, v);
             return v;
         }
         return undefined;

--- a/packages/cspell-trie-lib/src/lib/utils/secondChanceCache.ts
+++ b/packages/cspell-trie-lib/src/lib/utils/secondChanceCache.ts
@@ -1,11 +1,8 @@
 export class SecondChanceCache<Key, Value> {
-    private map0: Map<Key, Value>;
-    private map1: Map<Key, Value>;
+    private map0 = new Map<Key, Value>();
+    private map1 = new Map<Key, Value>();
 
-    constructor(readonly maxL0Size: number) {
-        this.map0 = new Map<Key, Value>();
-        this.map1 = new Map<Key, Value>();
-    }
+    constructor(readonly maxL0Size: number) {}
 
     public has(key: Key) {
         if (this.map0.has(key)) return true;
@@ -24,7 +21,7 @@ export class SecondChanceCache<Key, Value> {
     public set(key: Key, value: Value): this {
         if (this.map0.size >= this.maxL0Size && !this.map0.has(key)) {
             this.map1 = this.map0;
-            this.map0 = new Map<Key, Value>();
+            this.map0 = new Map();
         }
         this.map0.set(key, value);
         return this;

--- a/packages/cspell/src/app/application.test.ts
+++ b/packages/cspell/src/app/application.test.ts
@@ -171,7 +171,7 @@ describe('Validate the Application', () => {
 
 async function trace(words: string[], options: TraceOptions) {
     const results = await asyncIterableToArray(App.trace(words, options));
-    return results.reduce((a, r) => a.concat(r), []);
+    return results.flatMap((a) => a);
 }
 
 describe('Validate createInit', () => {

--- a/packages/hunspell-reader/src/aff.ts
+++ b/packages/hunspell-reader/src/aff.ts
@@ -91,10 +91,8 @@ export class Aff {
             .map(({ id }) => id);
         const combinableSfx = this.joinRules(combinableRules);
         const r = affixRules
-            .map((affix) => this.applyAffixToWord(affix, affWord, combinableSfx))
-            .reduce((a, b) => a.concat(b), [])
-            .map((affWord) => this.applyRulesToWord(affWord, remainingDepth - 1))
-            .reduce((a, b) => a.concat(b), []);
+            .flatMap((affix) => this.applyAffixToWord(affix, affWord, combinableSfx))
+            .flatMap((affWord) => this.applyRulesToWord(affWord, remainingDepth - 1));
         return r;
     }
 
@@ -105,8 +103,7 @@ export class Aff {
         const matchingSubstitutions = [...affix.substitutionSets.values()].filter((sub) => sub.match.test(word));
         const partialAffWord = { ...affWord, flags, rules: combineRules };
         return matchingSubstitutions
-            .map((sub) => sub.substitutions)
-            .reduce((a, b) => a.concat(b), [])
+            .flatMap((sub) => sub.substitutions)
             .filter((sub) => sub.remove === '0' || sub.replace.test(word))
             .map((sub) => this.substitute(affix, partialAffWord, sub))
             .map((affWord) => logAffWord(affWord, 'applyAffixToWord'));


### PR DESCRIPTION
On large dictionaries it was possible for the Trie builder to create circular tries.
