### PR TITLE
feat: Add customWords options

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -38,6 +38,7 @@
         "**/.gitignore",
         "**/.vscode/**",
         "**/{cspell.*,cSpell.*,.cspell.*,cspell.config.*}",
+        "**/*.schema.json",
         "**/*.snap",
         "**/*.trie",
         "**/coverage/**",

--- a/packages/cspell-eslint-plugin/README.md
+++ b/packages/cspell-eslint-plugin/README.md
@@ -15,6 +15,7 @@ This plugin is still in active development as part of the CSpell suite of tools 
   ```
 
 - Add to it to `.eslintrc.json`
+
   ```json
   "extends": ["plugin:@cspell/recommended"]
   ```
@@ -82,6 +83,10 @@ interface Options {
    * @default true
    */
   checkComments?: boolean;
+  /**
+   * Spell check allow words
+   */
+  customWords?: string[]
   /**
    * Specify a path to a custom word list file.
    *

--- a/packages/cspell-eslint-plugin/README.md
+++ b/packages/cspell-eslint-plugin/README.md
@@ -84,16 +84,16 @@ interface Options {
    */
   checkComments?: boolean;
   /**
-   * Spell check cspell setting
-   * current support words, ignoreWords, flagWords
+   * CSpell settings
+   *
    * @words - list of words to be always considered correct
-   * 
+   *
    * @ignoreWords - a list of words to be ignored (even if they are in the flagWords)
-   * 
-   * @flagWords - a list of words to be always considered incorrect
-   *  
+   *
+   * @flagWords - a list of words to be always considered incorrect, unless ignored.
+   *
    */
-  cSpell?: { words: string[], ignoreWords: string[], flagWords: string[] }
+  cSpell?: { words?: string[], ignoreWords?: string[], flagWords?: string[] }
   /**
    * Specify a path to a custom word list file.
    *

--- a/packages/cspell-eslint-plugin/README.md
+++ b/packages/cspell-eslint-plugin/README.md
@@ -84,9 +84,16 @@ interface Options {
    */
   checkComments?: boolean;
   /**
-   * Spell check allow words
+   * Spell check cspell setting
+   * current support words, ignoreWords, flagWords
+   * @words - list of words to be always considered correct
+   * 
+   * @ignoreWords - a list of words to be ignored (even if they are in the flagWords)
+   * 
+   * @flagWords - a list of words to be always considered incorrect
+   *  
    */
-  customWords?: string[]
+  cSpell?: { words: string[], ignoreWords: string[], flagWords: string[] }
   /**
    * Specify a path to a custom word list file.
    *

--- a/packages/cspell-eslint-plugin/assets/options.schema.json
+++ b/packages/cspell-eslint-plugin/assets/options.schema.json
@@ -33,6 +33,34 @@
       "description": "Spell check strings",
       "type": "boolean"
     },
+    "cspell": {
+      "additionalProperties": false,
+      "description": "CSpell options to pass to the spell checker.",
+      "properties": {
+        "flagWords": {
+          "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ignoreWords": {
+          "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "words": {
+          "description": "List of words to be considered correct.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "customWordListFile": {
       "anyOf": [
         {

--- a/packages/cspell-eslint-plugin/cspell.config.yaml
+++ b/packages/cspell-eslint-plugin/cspell.config.yaml
@@ -1,5 +1,6 @@
 ignorePaths:
   - cspell*.{yaml,json}
+  - assets/options.schema.json
 ignoreWords:
   - todos
   - bluelist

--- a/packages/cspell-eslint-plugin/package.json
+++ b/packages/cspell-eslint-plugin/package.json
@@ -66,6 +66,7 @@
     "ts-json-schema-generator": "^1.2.0"
   },
   "dependencies": {
+    "@cspell/cspell-types": "workspace:*",
     "cspell-lib": "workspace:*",
     "estree-walker": "^3.0.3",
     "synckit": "^0.8.5"

--- a/packages/cspell-eslint-plugin/src/common/options.ts
+++ b/packages/cspell-eslint-plugin/src/common/options.ts
@@ -74,7 +74,7 @@ export interface Check {
      */
     checkComments?: boolean;
     /**
-     * Spell check allow words
+     * CSpell options to pass to the spell checker.
      */
     cspell?: Pick<CSpellSettings, 'words' | 'ignoreWords' | 'flagWords'>;
     /**

--- a/packages/cspell-eslint-plugin/src/common/options.ts
+++ b/packages/cspell-eslint-plugin/src/common/options.ts
@@ -1,3 +1,5 @@
+import type { CSpellSettings } from '@cspell/cspell-types';
+
 export interface Options extends Check {
     /**
      * Number of spelling suggestions to make.
@@ -74,7 +76,7 @@ export interface Check {
     /**
      * Spell check allow words
      */
-    customWords?: string[];
+    cspell?: Pick<CSpellSettings, 'words' | 'ignoreWords' | 'flagWords'>;
     /**
      * Specify a path to a custom word list file.
      *

--- a/packages/cspell-eslint-plugin/src/common/options.ts
+++ b/packages/cspell-eslint-plugin/src/common/options.ts
@@ -72,6 +72,10 @@ export interface Check {
      */
     checkComments?: boolean;
     /**
+     * Spell check allow words
+     */
+    customWords?: string[];
+    /**
      * Specify a path to a custom word list file.
      *
      * example:

--- a/packages/cspell-eslint-plugin/src/plugin/defaultCheckOptions.ts
+++ b/packages/cspell-eslint-plugin/src/plugin/defaultCheckOptions.ts
@@ -6,7 +6,11 @@ export const defaultCheckOptions: Required<Check> = {
     checkJSXText: true,
     checkStrings: true,
     checkStringTemplates: true,
-    customWords: [],
+    cspell: {
+        words: [],
+        flagWords: [],
+        ignoreWords: [],
+    },
     customWordListFile: undefined,
     ignoreImportProperties: true,
     ignoreImports: true,

--- a/packages/cspell-eslint-plugin/src/plugin/defaultCheckOptions.ts
+++ b/packages/cspell-eslint-plugin/src/plugin/defaultCheckOptions.ts
@@ -6,6 +6,7 @@ export const defaultCheckOptions: Required<Check> = {
     checkJSXText: true,
     checkStrings: true,
     checkStringTemplates: true,
+    customWords: [],
     customWordListFile: undefined,
     ignoreImportProperties: true,
     ignoreImports: true,

--- a/packages/cspell-eslint-plugin/src/plugin/index.test.ts
+++ b/packages/cspell-eslint-plugin/src/plugin/index.test.ts
@@ -49,6 +49,11 @@ ruleTester.run('cspell', Rule.rules.spellchecker, {
                 flagWords: [],
             },
         }),
+        readFix('with-errors/sampleESM.mjs', {
+            cspell: {
+                ignoreWords: ['Guuide', 'Gallaxy', 'BADD', 'functionn', 'coool'],
+            },
+        }),
     ],
     invalid: [
         // cspell:ignore Guuide Gallaxy BADD functionn coool
@@ -57,6 +62,7 @@ ruleTester.run('cspell', Rule.rules.spellchecker, {
             'Unknown word: "Gallaxy"',
             'Unknown word: "BADD"',
             'Unknown word: "functionn"',
+            'Unknown word: "coool"',
             'Unknown word: "coool"',
         ]),
         readInvalid(

--- a/packages/cspell-eslint-plugin/src/plugin/index.test.ts
+++ b/packages/cspell-eslint-plugin/src/plugin/index.test.ts
@@ -42,6 +42,9 @@ ruleTester.run('cspell', Rule.rules.spellchecker, {
         readSample('sampleESM.mjs'),
         readFix('with-errors/strings.ts', { checkStrings: false, checkStringTemplates: false }),
         readFix('with-errors/imports.ts'),
+        readFix('with-errors/sampleESM.mjs', {
+            customWords: ['Guuide', 'Gallaxy', 'BADD', 'functionn', 'coool'],
+        }),
     ],
     invalid: [
         // cspell:ignore Guuide Gallaxy BADD functionn coool
@@ -50,7 +53,6 @@ ruleTester.run('cspell', Rule.rules.spellchecker, {
             'Unknown word: "Gallaxy"',
             'Unknown word: "BADD"',
             'Unknown word: "functionn"',
-            'Unknown word: "coool"',
             'Unknown word: "coool"',
         ]),
         readInvalid(

--- a/packages/cspell-eslint-plugin/src/plugin/index.test.ts
+++ b/packages/cspell-eslint-plugin/src/plugin/index.test.ts
@@ -43,7 +43,11 @@ ruleTester.run('cspell', Rule.rules.spellchecker, {
         readFix('with-errors/strings.ts', { checkStrings: false, checkStringTemplates: false }),
         readFix('with-errors/imports.ts'),
         readFix('with-errors/sampleESM.mjs', {
-            customWords: ['Guuide', 'Gallaxy', 'BADD', 'functionn', 'coool'],
+            cspell: {
+                words: ['Guuide', 'Gallaxy', 'BADD', 'functionn', 'coool'],
+                ignoreWords: [],
+                flagWords: [],
+            },
         }),
     ],
     invalid: [

--- a/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
+++ b/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
@@ -318,14 +318,14 @@ const docValCache = new WeakMap<TextDocument, DocumentValidator>();
 
 function getDocValidator(filename: string, text: string, options: WorkerOptions): DocumentValidator {
     const doc = getTextDocument(filename, text);
+    const settings = calcInitialSettings(options);
     const cachedValidator = docValCache.get(doc);
-    if (cachedValidator) {
+    if (cachedValidator && deepEqual(cachedValidator.settings, settings)) {
         refreshDictionaryCache(0);
         cachedValidator.updateDocumentText(text);
         return cachedValidator;
     }
 
-    const settings = calcInitialSettings(options);
     isDebugMode = options.debugMode || false;
     const validator = new DocumentValidator(doc, options, settings);
     docValCache.set(doc, validator);
@@ -393,4 +393,17 @@ function normalizeSuggestions(suggestions: Suggestions, nodeType: NodeType): Sug
         }
         return s;
     });
+}
+
+/**
+ * Deep Equal check.
+ * Note: There are faster methods, but this is called once per file, so speed is not a concern.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+    try {
+        assert.deepStrictEqual(a, b);
+        return true;
+    } catch (e) {
+        return false;
+    }
 }

--- a/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
+++ b/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
@@ -333,31 +333,29 @@ function getDocValidator(filename: string, text: string, options: WorkerOptions)
 }
 
 function calcInitialSettings(options: WorkerOptions): CSpellSettings {
-    const { customWordListFile, customWords, cwd } = options;
+    const { customWordListFile, cspell, cwd } = options;
+
+    const settings: CSpellSettings = {
+        ...defaultSettings,
+        words: cspell?.words || [],
+        ignoreWords: cspell?.ignoreWords || [],
+        flagWords: cspell?.flagWords || [],
+    };
 
     if (customWordListFile) {
         const filePath = isCustomWordListFile(customWordListFile) ? customWordListFile.path : customWordListFile;
         const dictFile = path.resolve(cwd, filePath);
 
-        const settings: CSpellSettings = {
-            ...defaultSettings,
+        const customWordListSettings = {
+            ...settings,
             dictionaryDefinitions: [{ name: 'eslint-plugin-custom-words', path: dictFile }],
             dictionaries: ['eslint-plugin-custom-words'],
         };
 
-        return settings;
+        return customWordListSettings;
     }
 
-    if (customWords && customWords.length > 0) {
-        const settings: CSpellSettings = {
-            ...defaultSettings,
-            userWords: customWords,
-        };
-
-        return settings;
-    }
-
-    return defaultSettings;
+    return settings;
 }
 
 function getTextDocument(filename: string, content: string): TextDocument {

--- a/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
+++ b/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
@@ -333,19 +333,31 @@ function getDocValidator(filename: string, text: string, options: WorkerOptions)
 }
 
 function calcInitialSettings(options: WorkerOptions): CSpellSettings {
-    const { customWordListFile, cwd } = options;
-    if (!customWordListFile) return defaultSettings;
+    const { customWordListFile, customWords, cwd } = options;
 
-    const filePath = isCustomWordListFile(customWordListFile) ? customWordListFile.path : customWordListFile;
-    const dictFile = path.resolve(cwd, filePath);
+    if (customWordListFile) {
+        const filePath = isCustomWordListFile(customWordListFile) ? customWordListFile.path : customWordListFile;
+        const dictFile = path.resolve(cwd, filePath);
 
-    const settings: CSpellSettings = {
-        ...defaultSettings,
-        dictionaryDefinitions: [{ name: 'eslint-plugin-custom-words', path: dictFile }],
-        dictionaries: ['eslint-plugin-custom-words'],
-    };
+        const settings: CSpellSettings = {
+            ...defaultSettings,
+            dictionaryDefinitions: [{ name: 'eslint-plugin-custom-words', path: dictFile }],
+            dictionaries: ['eslint-plugin-custom-words'],
+        };
 
-    return settings;
+        return settings;
+    }
+
+    if (customWords && customWords.length > 0) {
+        const settings: CSpellSettings = {
+            ...defaultSettings,
+            userWords: customWords,
+        };
+
+        return settings;
+    }
+
+    return defaultSettings;
 }
 
 function getTextDocument(filename: string, content: string): TextDocument {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -471,6 +471,9 @@ importers:
 
   packages/cspell-eslint-plugin:
     dependencies:
+      '@cspell/cspell-types':
+        specifier: workspace:*
+        version: link:../cspell-types
       cspell-lib:
         specifier: workspace:*
         version: link:../cspell-lib


### PR DESCRIPTION
hello. In addition to the file path option, an option has been added to make the eslint spell checker work normally even when word lists are entered.

If this option is added, it seems that the spell checker option can be applied immediately without having to create and read the file.