### PR TITLE
update homepage for cspell-grammar

### DIFF
--- a/packages/cspell-grammar/package.json
+++ b/packages/cspell-grammar/package.json
@@ -7,7 +7,7 @@
     "grammar"
   ],
   "author": "Jason Dent <jason@streetsidesoftware.nl>",
-  "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-gitignore#readme",
+  "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-grammar#readme",
   "license": "MIT",
   "bin": {
     "cspell-grammar": "bin.mjs"


### PR DESCRIPTION
Previously the 'homepage' in `package.json` for cspell-grammar erroneously pointed to the README for cspell-gitignore