### PR TITLE
docs: Change property name in readme

### DIFF
--- a/packages/cspell-eslint-plugin/README.md
+++ b/packages/cspell-eslint-plugin/README.md
@@ -86,7 +86,7 @@ interface Options {
   /**
    * Some CSpell Settings
    */
-  cSpell?: {
+  cspell?: {
     /** List of words to be considered correct. */
     words?: string[];
     /**


### PR DESCRIPTION
The property must be named `cspell`. If I name it `cSpell` I'm getting following error:

```sh
Oops! Something went wrong! :(

ESLint: 8.46.0

Error: Key "rules": Key "@cspell/spellchecker": 	Value {"words":[],"ignoreWords":[],"flagWords":[],"ignoreRegExpList":[],"includeRegExpList":[],"allowCompoundWords":true,"import":[],"dictionaries":[],"dictionaryDefinitions":[],"enabled":true} should NOT have additional properties.
```

When I name it `cspell` everything is working as expected. Furthermore it it also called `cspell` in your JSON schema: https://github.com/streetsidesoftware/cspell/blob/0c115fedd1050aa67531bc31a9bf81ee0e0c26e0/packages/cspell-eslint-plugin/assets/options.schema.json#L36