### PR TITLE
fix: eslint-plugin, make sure dictionary settings make it to cspell-lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ out
 
 temp
 tmp
+*.log
 
 # Dependency directories
 

--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -777,9 +777,8 @@
       "type": "string"
     },
     "DictionaryPath": {
-      "description": "A File System Path to a dictionary file.",
-      "markdownDescription": "A File System Path to a dictionary file.",
-      "pattern": "^.*\\.(?:txt|trie)(?:\\.gz)?$",
+      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
+      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
       "type": "string"
     },
     "DictionaryRef": {

--- a/packages/cspell-eslint-plugin/assets/options.schema.json
+++ b/packages/cspell-eslint-plugin/assets/options.schema.json
@@ -69,7 +69,6 @@
               },
               "path": {
                 "description": "Path to the file.",
-                "pattern": "^.*\\.(?:txt|trie)(?:\\.gz)?$",
                 "type": "string"
               },
               "repMap": {
@@ -192,8 +191,7 @@
       "description": "Specify a path to a custom word list file.\n\nexample: ```js customWordListFile: \"./myWords.txt\" ```"
     },
     "debugMode": {
-      "default": false,
-      "description": "Output debug logs",
+      "description": "Output debug logs to `.cspell-eslint-plugin.log` default false",
       "type": "boolean"
     },
     "generateSuggestions": {

--- a/packages/cspell-eslint-plugin/fixtures/issue-4870/.eslintrc.js
+++ b/packages/cspell-eslint-plugin/fixtures/issue-4870/.eslintrc.js
@@ -1,0 +1,35 @@
+module.exports = {
+    env: {
+        browser: true,
+        commonjs: true,
+        es6: true,
+        jest: true,
+        node: true,
+    },
+    extends: ['eslint:recommended', 'plugin:@cspell/recommended'],
+    parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 2018,
+        sourceType: 'module',
+    },
+    plugins: ['@cspell'],
+    root: true,
+    rules: {
+        '@cspell/spellchecker': [
+            'warn',
+            {
+                debugMode: true,
+                autoFix: true,
+                cspell: {
+                    dictionaries: ['business-terminology'],
+                    dictionaryDefinitions: [
+                        {
+                            name: 'business-terminology',
+                            path: './dictionaries/business-terminology.txt',
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+};

--- a/packages/cspell-eslint-plugin/fixtures/issue-4870/cspell.config.yaml
+++ b/packages/cspell-eslint-plugin/fixtures/issue-4870/cspell.config.yaml
@@ -1,0 +1,5 @@
+# dictionaries:
+#   - business-terminology
+# dictionaryDefinitions:
+#   - name: business-terminology
+#     path: ./dictionaries/business-terminology.txt

--- a/packages/cspell-eslint-plugin/fixtures/issue-4870/dictionaries/business-terminology.txt
+++ b/packages/cspell-eslint-plugin/fixtures/issue-4870/dictionaries/business-terminology.txt
@@ -1,0 +1,2 @@
+bestbusiness
+friendz

--- a/packages/cspell-eslint-plugin/fixtures/issue-4870/sample.js
+++ b/packages/cspell-eslint-plugin/fixtures/issue-4870/sample.js
@@ -1,0 +1,1 @@
+console.log('hello bestbusiness and friendz');

--- a/packages/cspell-eslint-plugin/package.json
+++ b/packages/cspell-eslint-plugin/package.json
@@ -17,10 +17,13 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-eslint-plugin#readme",
   "license": "MIT",
   "exports": {
-    "types": "./dist/plugin/index.d.cts",
-    "require": "./dist/plugin/index.cjs",
-    "import": "./dist/plugin/index.cjs",
-    "default": "./dist/plugin/index.cjs"
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/plugin/index.d.cts",
+      "require": "./dist/plugin/index.cjs",
+      "import": "./dist/plugin/index.cjs",
+      "default": "./dist/plugin/index.cjs"
+    }
   },
   "type": "module",
   "main": "dist/plugin/index.cjs",
@@ -38,7 +41,7 @@
     "build": "pnpm build:schema && pnpm build:src",
     "build:src": "tsc -b ./tsconfig.json",
     "build:schema": "ts-json-schema-generator --no-top-ref --expose none --path src/common/options.cts --type Options  -o  ./assets/options.schema.json",
-    "watch": "tsc -p . --watch",
+    "watch": "tsc -b ./tsconfig.json --watch",
     "clean": "shx rm -rf dist temp coverage \"*.tsbuildInfo\"",
     "clean-build": "pnpm run clean && pnpm run build",
     "coverage": "echo coverage",

--- a/packages/cspell-eslint-plugin/src/common/logger.cts
+++ b/packages/cspell-eslint-plugin/src/common/logger.cts
@@ -1,6 +1,6 @@
-import { format } from 'util';
 import fs from 'fs';
 import path from 'path';
+import { format } from 'util';
 
 const debugMode = false;
 

--- a/packages/cspell-eslint-plugin/src/common/logger.cts
+++ b/packages/cspell-eslint-plugin/src/common/logger.cts
@@ -1,0 +1,60 @@
+import { format } from 'util';
+import fs from 'fs';
+import path from 'path';
+
+const debugMode = false;
+
+export interface LoggerOptions {
+    logFile?: string;
+    cwd?: string;
+    /** true - write to file, false - output to console. */
+    logToFile?: boolean;
+    /** enable logging by default? */
+    enabled?: boolean;
+    useAsync?: boolean;
+}
+
+export class Logger {
+    readonly logFile: string;
+    readonly cwd: string;
+    logToFile = true;
+    enabled = true;
+    useAsync = false;
+
+    constructor(readonly options: LoggerOptions) {
+        this.cwd = path.resolve(options.cwd || '.');
+        const logFileBasename = options.logFile || '.cspell-eslint-plugin.log';
+        this.logFile = path.resolve(this.cwd, logFileBasename);
+        this.logToFile = options.logToFile ?? true;
+        this.enabled = options.enabled ?? debugMode;
+        this.useAsync = options.useAsync ?? false;
+    }
+
+    private _log(...p: Parameters<typeof console.log>): void {
+        if (!this.enabled) return;
+        if (!this.logToFile) return console.log(...p);
+        const message = new Date().toISOString() + ' ' + prefixLines(format(...p), '  ') + '\n';
+        this.useAsync
+            ? fs.appendFile(this.logFile, message, (err) => err && console.error(err))
+            : fs.appendFileSync(this.logFile, message);
+        return;
+    }
+
+    log = this._log.bind(this);
+}
+
+let logger: Logger | undefined;
+
+export function getDefaultLogger(): Logger {
+    if (logger) return logger;
+    logger = new Logger({});
+    return logger;
+}
+
+function prefixLines(text: string, prefix: string, startIndex = 1): string {
+    return text
+        .split('\n')
+        .map((line, index) => (index >= startIndex ? prefix + line : line))
+        .map((line) => (line.trim() == '' ? '' : line))
+        .join('\n');
+}

--- a/packages/cspell-eslint-plugin/src/common/options.cts
+++ b/packages/cspell-eslint-plugin/src/common/options.cts
@@ -21,8 +21,8 @@ export interface Options extends Check {
     autoFix: boolean;
 
     /**
-     * Output debug logs
-     * @default false
+     * Output debug logs to `.cspell-eslint-plugin.log`
+     * default false
      */
     debugMode?: boolean;
 }
@@ -46,7 +46,7 @@ export type CSpellOptions = Pick<
     dictionaryDefinitions?: DictionaryDefinition[];
 };
 
-export type RequiredOptions = Required<Options>;
+export type RequiredOptions = Required<Pick<Options, Exclude<keyof Options, 'debugMode'>>> & Pick<Options, 'debugMode'>;
 
 export interface Check {
     /**

--- a/packages/cspell-eslint-plugin/src/plugin/cspell-eslint-plugin.cts
+++ b/packages/cspell-eslint-plugin/src/plugin/cspell-eslint-plugin.cts
@@ -6,6 +6,7 @@ import { createSyncFn } from 'synckit';
 
 import type { Issue, SpellCheckSyncFn } from '../worker/types.cjs';
 import { normalizeOptions } from './defaultCheckOptions.cjs';
+import { getDefaultLogger } from '../common/logger.cjs';
 
 const optionsSchema = JSON.parse(readFileSync(pathJoin(__dirname, '../../assets/options.schema.json'), 'utf8'));
 
@@ -54,20 +55,19 @@ const meta: Rule.RuleMetaData = {
 };
 
 let isDebugMode = false;
-function log(...args: Parameters<typeof console.log>) {
-    if (!isDebugMode) return;
-    console.log(...args);
-}
 
 function nullFix(): null {
     return null;
 }
 
 function create(context: Rule.RuleContext): Rule.RuleListener {
-    const options = normalizeOptions(context.options[0], context.getCwd());
+    const logger = getDefaultLogger();
+    const log = logger.log;
+    const options = normalizeOptions(context.options[0], context.cwd);
     const autoFix = options.autoFix;
-    isDebugMode = options.debugMode || false;
-    isDebugMode && logContext(context);
+    isDebugMode = options.debugMode ?? isDebugMode;
+    logger.enabled = options.debugMode ?? (logger.enabled || isDebugMode);
+    logContext(log, context);
 
     function reportIssue(issue: Issue) {
         const messageId: MessageIds = issue.severity === 'Forbidden' ? 'wordForbidden' : 'wordUnknown';
@@ -75,7 +75,7 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
         const data = {
             word,
         };
-        const code = context.getSourceCode();
+        const code = context.sourceCode;
         const startPos = code.getLocFromIndex(start);
         const endPos = code.getLocFromIndex(end);
         const loc = { start: startPos, end: endPos };
@@ -97,7 +97,7 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
             };
         }
 
-        log('Suggestions: %o', issue.suggestions);
+        // log('Suggestions: %o', issue.suggestions);
 
         const issueSuggestions = issue.suggestions;
         const fixable = issueSuggestions?.filter((sug) => !!sug.isPreferred);
@@ -120,8 +120,15 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
     }
 
     function checkProgram() {
-        const sc = context.getSourceCode();
-        const issues = spellCheck(context.getFilename(), sc.text, sc.ast, options);
+        const sc = context.sourceCode;
+        const { issues, errors } = spellCheck(context.filename, sc.text, sc.ast, options);
+        if (errors && errors.length) {
+            log(
+                'errors: %o',
+                errors.map((e) => e.message),
+            );
+            errors.forEach((error) => console.error('%s', error.message));
+        }
         issues.forEach((issue) => reportIssue(issue));
     }
 
@@ -135,17 +142,15 @@ export const rules: PluginRules = {
     },
 };
 
-function logContext(context: Rule.RuleContext) {
-    log('\n\n************************');
-    // log(context.getSourceCode().text);
-    log(`
-
-id: ${context.id}
-cwd: ${context.getCwd()}
-filename: ${context.getFilename()}
-physicalFilename: ${context.getPhysicalFilename()}
-scope: ${context.getScope().type}
-`);
+function logContext(log: typeof console.log, context: Rule.RuleContext) {
+    log('context: %o', {
+        id: context.id,
+        cwd: context.cwd,
+        filename: context.filename,
+        physicalFilename: context.physicalFilename,
+        scope: context.getScope().type,
+        options: context.options.length === 1 ? context.options[0] : context.options,
+    });
 }
 
 export const configs = {

--- a/packages/cspell-eslint-plugin/src/plugin/cspell-eslint-plugin.cts
+++ b/packages/cspell-eslint-plugin/src/plugin/cspell-eslint-plugin.cts
@@ -4,9 +4,9 @@ import { readFileSync } from 'fs';
 import { join as pathJoin } from 'path';
 import { createSyncFn } from 'synckit';
 
+import { getDefaultLogger } from '../common/logger.cjs';
 import type { Issue, SpellCheckSyncFn } from '../worker/types.cjs';
 import { normalizeOptions } from './defaultCheckOptions.cjs';
-import { getDefaultLogger } from '../common/logger.cjs';
 
 const optionsSchema = JSON.parse(readFileSync(pathJoin(__dirname, '../../assets/options.schema.json'), 'utf8'));
 

--- a/packages/cspell-eslint-plugin/src/plugin/defaultCheckOptions.cts
+++ b/packages/cspell-eslint-plugin/src/plugin/defaultCheckOptions.cts
@@ -20,7 +20,6 @@ export const defaultOptions: RequiredOptions = {
     ...defaultCheckOptions,
     numSuggestions: 8,
     generateSuggestions: true,
-    debugMode: false,
     autoFix: false,
 };
 

--- a/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
+++ b/packages/cspell-eslint-plugin/src/worker/spellCheck.mts
@@ -3,11 +3,11 @@ import type { TSESTree } from '@typescript-eslint/types';
 import assert from 'assert';
 import type { CSpellSettings, TextDocument, ValidationIssue } from 'cspell-lib';
 import {
-    DocumentValidator,
     createTextDocument,
-    refreshDictionaryCache,
+    DocumentValidator,
     extractImportErrors,
     getDictionary,
+    refreshDictionaryCache,
 } from 'cspell-lib';
 import type { Comment, Identifier, ImportSpecifier, Literal, Node, TemplateElement } from 'estree';
 import * as path from 'path';
@@ -454,12 +454,10 @@ async function reportConfigurationErrors(config: CSpellSettings, knownConfigErro
     const errors: Error[] = [];
 
     const importErrors = extractImportErrors(config);
-    let count = 0;
     importErrors.forEach((ref) => {
         const key = ref.error.toString();
         if (knownConfigErrors.has(key)) return;
         knownConfigErrors.add(key);
-        count += 1;
         errors.push(Error('Configuration Error: \n  ' + ref.error.message));
     });
 
@@ -471,7 +469,6 @@ async function reportConfigurationErrors(config: CSpellSettings, knownConfigErro
             const key = msg + error.toString();
             if (knownConfigErrors.has(key)) return;
             knownConfigErrors.add(key);
-            count += 1;
             const errMsg = `${msg}: ${error.message}\n  Source: ${dict.source}`;
             errors.push(Error(errMsg));
         });

--- a/packages/cspell-eslint-plugin/src/worker/types.cts
+++ b/packages/cspell-eslint-plugin/src/worker/types.cts
@@ -29,6 +29,11 @@ export interface Issue {
     nodeType: NodeType;
 }
 
-type SpellCheckFn = (filename: string, text: string, root: Node, options: WorkerOptions) => Promise<Issue[]>;
+export interface SpellCheckResults {
+    issues: Issue[];
+    errors?: Error[];
+}
+
+type SpellCheckFn = (filename: string, text: string, root: Node, options: WorkerOptions) => Promise<SpellCheckResults>;
 
 export type SpellCheckSyncFn = (...p: Parameters<SpellCheckFn>) => Awaited<ReturnType<SpellCheckFn>>;

--- a/packages/cspell-eslint-plugin/src/worker/worker.mjs
+++ b/packages/cspell-eslint-plugin/src/worker/worker.mjs
@@ -6,6 +6,7 @@
 /**
  * @typedef {import('estree').Node} Node
  * @typedef {import('./types.cjs').Issue} Issue
+ * @typedef {import('./types.cjs').SpellCheckResults} SpellCheckResults
  * @typedef {import('../common/options.cjs').WorkerOptions} WorkerOptions
  */
 
@@ -22,7 +23,7 @@ runAsWorker(
      * @param {string} text
      * @param {Node} root
      * @param {WorkerOptions} options
-     * @returns {Promise<Issue[]>} The issues found.
+     * @returns {Promise<SpellCheckResults>} The issues found.
      */
     async (filename, text, root, options) => {
         if (!spellChecker) {

--- a/packages/cspell-gitignore/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell-gitignore/src/__snapshots__/app.test.ts.snap
@@ -25,7 +25,7 @@ exports[`app > app.run [ ' ' ] 1`] = `""`;
 
 exports[`app > app.run [ ' ' ] 2`] = `"Missing files"`;
 
-exports[`app > app.run [ '../node_modules' ] 1`] = `".gitignore:48:node_modules/	../node_modules"`;
+exports[`app > app.run [ '../node_modules' ] 1`] = `".gitignore:49:node_modules/	../node_modules"`;
 
 exports[`app > app.run [ '../node_modules' ] 2`] = `""`;
 

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -777,9 +777,8 @@
       "type": "string"
     },
     "DictionaryPath": {
-      "description": "A File System Path to a dictionary file.",
-      "markdownDescription": "A File System Path to a dictionary file.",
-      "pattern": "^.*\\.(?:txt|trie)(?:\\.gz)?$",
+      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
+      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
       "type": "string"
     },
     "DictionaryRef": {

--- a/packages/cspell-types/src/DictionaryDefinition.ts
+++ b/packages/cspell-types/src/DictionaryDefinition.ts
@@ -223,7 +223,7 @@ export type FsDictionaryPath = string;
 
 /**
  * A File System Path to a dictionary file.
- * @pattern ^.*\.(?:txt|trie)(?:\.gz)?$
+ * Pattern: `^.*\.(?:txt|trie|dic)(?:\.gz)?$`
  */
 export type DictionaryPath = string;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,6 +816,15 @@ importers:
         specifier: 0.19.2
         version: 0.19.2
 
+  test-fixtures/issues/issue-4870:
+    devDependencies:
+      '@cspell/eslint-plugin':
+        specifier: workspace:^
+        version: link:../../../packages/cspell-eslint-plugin
+      eslint:
+        specifier: ^8.50.0
+        version: 8.50.0
+
   test-packages/cspell-dictionary/test-cspell-dictionary:
     dependencies:
       cspell-dictionary:
@@ -4333,7 +4342,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.22.0
       ignore: 5.2.4
@@ -4361,7 +4370,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8253,6 +8262,17 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -9169,7 +9189,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,15 +816,6 @@ importers:
         specifier: 0.19.2
         version: 0.19.2
 
-  test-fixtures/issues/issue-4870:
-    devDependencies:
-      '@cspell/eslint-plugin':
-        specifier: workspace:^
-        version: link:../../../packages/cspell-eslint-plugin
-      eslint:
-        specifier: ^8.50.0
-        version: 8.50.0
-
   test-packages/cspell-dictionary/test-cspell-dictionary:
     dependencies:
       cspell-dictionary:
@@ -4342,7 +4333,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.22.0
       ignore: 5.2.4
@@ -4370,7 +4361,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8262,17 +8253,6 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -9189,7 +9169,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2


### PR DESCRIPTION
fixes: #4870

- resolve the dictionary path based upon the cwd given to eslint
- Add tests for cspell settings.
- support logging to a file.