### PR TITLE
fix: Set `"sideEffects": false` in package.json

### DIFF
--- a/packages/cspell-bundled-dicts/package.json
+++ b/packages/cspell-bundled-dicts/package.json
@@ -5,6 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": false,
   "main": "cspell-default.json",
   "files": [
     "cspell-default.json",

--- a/packages/cspell-config-lib/package.json
+++ b/packages/cspell-config-lib/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-config#readme",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/cspell-dictionary/package.json
+++ b/packages/cspell-dictionary/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.0",
   "description": "A spelling dictionary library useful for checking words and getting suggestions.",
   "type": "module",
+  "sideEffects": false,
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {

--- a/packages/cspell-eslint-plugin/package.json
+++ b/packages/cspell-eslint-plugin/package.json
@@ -26,6 +26,7 @@
     }
   },
   "type": "module",
+  "sideEffects": false,
   "main": "dist/plugin/index.cjs",
   "types": "dist/plugin/index.d.cts",
   "files": [

--- a/packages/cspell-gitignore/package.json
+++ b/packages/cspell-gitignore/package.json
@@ -14,6 +14,7 @@
     "cspell-gitignore": "bin.mjs"
   },
   "type": "module",
+  "sideEffects": false,
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {

--- a/packages/cspell-glob/package.json
+++ b/packages/cspell-glob/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-glob#readme",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/cspell-grammar/package.json
+++ b/packages/cspell-grammar/package.json
@@ -13,6 +13,7 @@
     "cspell-grammar": "bin.mjs"
   },
   "type": "module",
+  "sideEffects": false,
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {

--- a/packages/cspell-io/package.json
+++ b/packages/cspell-io/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.0",
   "description": "A library of useful I/O functions used across various cspell tools.",
   "type": "module",
+  "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/cspell-json-reporter/package.json
+++ b/packages/cspell-json-reporter/package.json
@@ -9,6 +9,7 @@
   },
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-json-reporter#readme",
   "type": "module",
+  "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/cspell-lib/package.json
+++ b/packages/cspell-lib/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.0",
   "description": "A library of useful functions used across various cspell tools.",
   "type": "module",
+  "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/cspell-pipe/package.json
+++ b/packages/cspell-pipe/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-pipe#readme",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "directories": {

--- a/packages/cspell-resolver/package.json
+++ b/packages/cspell-resolver/package.json
@@ -13,6 +13,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-resolver#readme",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/cspell-service-bus/package.json
+++ b/packages/cspell-service-bus/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-service-bus#readme",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {

--- a/packages/cspell-strong-weak-map/package.json
+++ b/packages/cspell-strong-weak-map/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell-strong-weak-map#readme",
   "license": "MIT",
   "type": "module",
+  "sideEffects": false,
   "module": "dist/esm/index.js",
   "exports": {
     ".": {

--- a/packages/cspell-tools/package.json
+++ b/packages/cspell-tools/package.json
@@ -6,6 +6,7 @@
     "access": "public"
   },
   "type": "module",
+  "sideEffects": false,
   "bin": {
     "cspell-tools-cli": "bin.mjs"
   },

--- a/packages/cspell-trie-lib/package.json
+++ b/packages/cspell-trie-lib/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.0",
   "description": "Trie Data Structure to support cspell.",
   "type": "module",
+  "sideEffects": false,
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {

--- a/packages/cspell-trie/package.json
+++ b/packages/cspell-trie/package.json
@@ -3,6 +3,7 @@
   "version": "8.1.0",
   "description": "Trie Data Structure reader for cspell",
   "type": "module",
+  "sideEffects": false,
   "bin": {
     "cspell-trie": "bin.js"
   },

--- a/packages/cspell-types/package.json
+++ b/packages/cspell-types/package.json
@@ -6,6 +6,7 @@
   "version": "8.1.0",
   "description": "Types for cspell and cspell-lib",
   "type": "commonjs",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -8,6 +8,7 @@
     "cspell-esm": "bin.mjs"
   },
   "type": "module",
+  "sideEffects": false,
   "types": "dist/esm/index.d.mts",
   "module": "dist/esm/index.mjs",
   "exports": {

--- a/packages/dynamic-import/package.json
+++ b/packages/dynamic-import/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/streetsidesoftware/cspell/tree/main/packages/dynamic-import#readme",
   "license": "MIT",
   "type": "commonjs",
+  "sideEffects": false,
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/cjs/index.d.ts",

--- a/packages/hunspell-reader/package.json
+++ b/packages/hunspell-reader/package.json
@@ -4,6 +4,7 @@
   "description": "A library for reading Hunspell Dictionary Files",
   "bin": "bin.js",
   "type": "module",
+  "sideEffects": false,
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Since CSpell does not change any global state, try to encourage tree-shaking.