### PR TITLE
feat: Support loading remote configuration.

### DIFF
--- a/packages/cspell-io/src/VirtualFS/redirectProvider.ts
+++ b/packages/cspell-io/src/VirtualFS/redirectProvider.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import { renameFileReference, renameFileResource, urlOrReferenceToUrl } from '../common/index.js';
 import type { DirEntry, FileReference, FileResource } from '../models/index.js';
-import type { VFileSystemProvider, FSCapabilityFlags, VProviderFileSystem } from '../VirtualFS.js';
+import type { FSCapabilityFlags, VFileSystemProvider, VProviderFileSystem } from '../VirtualFS.js';
 import { fsCapabilities, VFSErrorUnsupportedRequest } from '../VirtualFS.js';
 
 type UrlOrReference = URL | FileReference;

--- a/packages/cspell-io/src/VirtualFs.test.ts
+++ b/packages/cspell-io/src/VirtualFs.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CFileResource } from './common/index.js';
 import { toFileURL, urlBasename } from './node/file/url.js';
 import { pathToSample as ps } from './test/test.helper.js';
-import type { VFileSystemProvider, VProviderFileSystem, VirtualFS } from './VirtualFS.js';
+import type { VFileSystemProvider, VirtualFS, VProviderFileSystem } from './VirtualFS.js';
 import { createVirtualFS, FSCapabilityFlags, getDefaultVirtualFs, VFSErrorUnsupportedRequest } from './VirtualFS.js';
 
 const sc = expect.stringContaining;

--- a/packages/cspell-io/src/VirtualFs.test.ts
+++ b/packages/cspell-io/src/VirtualFs.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CFileResource } from './common/index.js';
 import { toFileURL, urlBasename } from './node/file/url.js';
 import { pathToSample as ps } from './test/test.helper.js';
-import type { FileSystemProvider, ProviderFileSystem, VirtualFS } from './VirtualFS.js';
+import type { VFileSystemProvider, VProviderFileSystem, VirtualFS } from './VirtualFS.js';
 import { createVirtualFS, FSCapabilityFlags, getDefaultVirtualFs, VFSErrorUnsupportedRequest } from './VirtualFS.js';
 
 const sc = expect.stringContaining;
@@ -241,8 +241,8 @@ describe('VirtualFs', () => {
     });
 });
 
-function mockFileSystem(): ProviderFileSystem {
-    const p: ProviderFileSystem = {
+function mockFileSystem(): VProviderFileSystem {
+    const p: VProviderFileSystem = {
         providerInfo: { name: 'mockFileSystemProvider' },
         capabilities: FSCapabilityFlags.Stat | FSCapabilityFlags.ReadWrite | FSCapabilityFlags.ReadDir,
         stat: vi.fn(),
@@ -255,8 +255,8 @@ function mockFileSystem(): ProviderFileSystem {
     return p;
 }
 
-function mockFileSystemProvider(): FileSystemProvider {
-    const p: FileSystemProvider = {
+function mockFileSystemProvider(): VFileSystemProvider {
+    const p: VFileSystemProvider = {
         name: 'mockFileSystemProvider',
         getFileSystem: vi.fn(),
         dispose: vi.fn(),

--- a/packages/cspell-io/src/index.ts
+++ b/packages/cspell-io/src/index.ts
@@ -16,6 +16,6 @@ export type { BufferEncoding, TextEncoding } from './models/BufferEncoding.js';
 export type { Stats } from './models/Stats.js';
 export { encodeDataUrl, toDataUrl } from './node/dataUrl.js';
 export { isFileURL, isUrlLike, toFileURL, toURL, urlBasename, urlDirname } from './node/file/url.js';
-export type { FileSystem, FileSystemProvider, VfsDirEntry, VfsStat, VirtualFS } from './VirtualFS.js';
+export type { VFileSystem as VFileSystem, VFileSystemProvider, VfsDirEntry, VfsStat, VirtualFS } from './VirtualFS.js';
 export { createVirtualFS, FSCapabilityFlags, getDefaultVirtualFs } from './VirtualFS.js';
 export { createRedirectProvider } from './VirtualFS/redirectProvider.js';

--- a/packages/cspell-io/src/node/file/url.ts
+++ b/packages/cspell-io/src/node/file/url.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'url';
 
 const isZippedRegExp = /\.gz($|[?#])/i;
 
-const isURLRegExp = /^(\w{2,64}:\/\/|data:)/i;
+const isURLRegExp = /^([\w-]{2,64}:\/\/|data:)/i;
 const isWindowsPath = /^[a-z]:[\\/]/i;
 const supportedProtocols: Record<string, true | undefined> = { 'file:': true, 'http:': true, 'https:': true };
 

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -5,8 +5,8 @@ import { WeightMap } from 'cspell-trie-lib';
 export { CompoundWordsMethod } from 'cspell-trie-lib';
 import { CSpellConfigFile } from 'cspell-config-lib';
 import * as cspell_io from 'cspell-io';
-import { FileSystem } from 'cspell-io';
-export { FSCapabilityFlags, FileSystemProvider, VirtualFS, asyncIterableToArray, readFileText as readFile, readFileTextSync as readFileSync, writeToFile, writeToFileIterable, writeToFileIterableP } from 'cspell-io';
+import { VFileSystem } from 'cspell-io';
+export { FSCapabilityFlags, VFileSystemProvider, VirtualFS, asyncIterableToArray, readFileText as readFile, readFileTextSync as readFileSync, writeToFile, writeToFileIterable, writeToFileIterableP } from 'cspell-io';
 import { SuggestOptions, SuggestionResult, CachingDictionary, SpellingDictionaryCollection } from 'cspell-dictionary';
 export { SpellingDictionary, SpellingDictionaryCollection, SuggestOptions, SuggestionCollector, SuggestionResult, createSpellingDictionary, createCollection as createSpellingDictionaryCollection } from 'cspell-dictionary';
 
@@ -409,6 +409,24 @@ declare const ENV_CSPELL_GLOB_ROOT = "CSPELL_GLOB_ROOT";
 
 declare function getVirtualFS(): cspell_io.VirtualFS;
 
+interface ResolveFileResult {
+    /**
+     * Absolute path or URL to the file.
+     */
+    filename: string;
+    relativeTo: string | undefined;
+    found: boolean;
+    /**
+     * A warning message if the file was found, but there was a problem.
+     */
+    warning?: string;
+    /**
+     * The method used to resolve the file.
+     */
+    method: string;
+}
+declare function resolveFile(filename: string | URL, relativeTo: string | URL, fs?: VFileSystem): Promise<ResolveFileResult>;
+
 type LoaderResult = URL | undefined;
 
 type PnPSettingsOptional = OptionalOrUndefined<PnPSettings>;
@@ -459,7 +477,7 @@ interface IConfigLoader {
     getStats(): Readonly<Record<string, Readonly<Record<string, number>>>>;
 }
 declare function loadPnP(pnpSettings: PnPSettingsOptional, searchFrom: URL): Promise<LoaderResult>;
-declare function createConfigLoader(vfs?: FileSystem): IConfigLoader;
+declare function createConfigLoader(fs?: VFileSystem): IConfigLoader;
 
 declare const defaultConfigFilenames: readonly string[];
 
@@ -958,30 +976,6 @@ declare function setLogger(logger: Logger): Logger;
  * @returns the current logger.
  */
 declare function getLogger(): Logger;
-
-interface ResolveFileResult {
-    /**
-     * Absolute path or URL to the file.
-     */
-    filename: string;
-    relativeTo: string | undefined;
-    found: boolean;
-    /**
-     * A warning message if the file was found, but there was a problem.
-     */
-    warning?: string;
-    /**
-     * The method used to resolve the file.
-     */
-    method: string;
-}
-/**
- * Resolve filename to absolute paths.
- * It tries to look for local files as well as node_modules
- * @param filename an absolute path, relative path, `~` path, or a node_module.
- * @param relativeTo absolute path
- */
-declare function resolveFile(filename: string, relativeTo: string | URL): ResolveFileResult;
 
 /**
  * Clear the cached files and other cached data.

--- a/packages/cspell-lib/samples/README.md
+++ b/packages/cspell-lib/samples/README.md
@@ -1,0 +1,5 @@
+# Samples
+
+This is a folder containing testings samples / fixtures.
+
+Changing files in this directory might cause tests to break.

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
@@ -336,6 +336,13 @@ describe('Validate search/load config files', () => {
         clearCachedSettingsFiles();
     });
 
+    function resolveError(filename: string): ImportFileRefWithError {
+        return {
+            filename,
+            error: new Error(`Failed to resolve file: "${filename}"`),
+        };
+    }
+
     function readError(filename: string): ImportFileRefWithError {
         return {
             filename,
@@ -434,8 +441,8 @@ describe('Validate search/load config files', () => {
 
     test.each`
         file                                          | expectedConfig
-        ${samplesSrc}                                 | ${cfg(readError(samplesSrc))}
-        ${s('bug-fixes')}                             | ${cfg(readError(s('bug-fixes')))}
+        ${samplesSrc}                                 | ${cfg(resolveError(samplesSrc))}
+        ${s('bug-fixes')}                             | ${cfg(resolveError(s('bug-fixes')))}
         ${s('linked/cspell.config.js')}               | ${cfg(s('linked/cspell.config.js'))}
         ${s('dot-config/.config/cspell.config.yaml')} | ${cfg(s('dot-config/.config/cspell.config.yaml'), { name: 'Nested in .config', globRoot: s('dot-config') })}
         ${s('js-config/cspell.config.js')}            | ${cfg(s('js-config/cspell.config.js'))}
@@ -614,7 +621,7 @@ describe('Validate search/load config files', () => {
     });
 });
 
-describe.only('ConfigLoader with VirtualFS', () => {
+describe('ConfigLoader with VirtualFS', () => {
     const publicURL = new URL('vscode-fs://github/streetsidesoftware/public-samples/');
 
     function pURL(path: string): URL {

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
@@ -1,5 +1,6 @@
 import type { CSpellSettingsWithSourceTrace, CSpellUserSettings, ImportFileRef } from '@cspell/cspell-types';
 import { CSpellConfigFile, CSpellConfigFileInMemory } from 'cspell-config-lib';
+import { createRedirectProvider, createVirtualFS } from 'cspell-io';
 import * as path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -19,7 +20,8 @@ import { currentSettingsFileVersion, ENV_CSPELL_GLOB_ROOT } from '../../constant
 import type { ImportFileRefWithError } from '../../CSpellSettingsServer.js';
 import { extractDependencies, getSources, mergeSettings } from '../../CSpellSettingsServer.js';
 import { _defaultSettings, getDefaultBundledSettingsAsync } from '../../DefaultSettings.js';
-import { __testing__ as __configLoader_testing__, loadPnP } from './configLoader.js';
+import { __testing__ as __configLoader_testing__, createConfigLoader, loadPnP } from './configLoader.js';
+import { configToRawSettings } from './configToRawSettings.js';
 import {
     clearCachedSettingsFiles,
     getCachedFileSize,
@@ -341,32 +343,6 @@ describe('Validate search/load config files', () => {
         };
     }
 
-    function cfg(
-        filename: string | ImportFileRefWithError,
-        values: CSpellSettingsWithSourceTrace = {},
-    ): CSpellSettingsWithSourceTrace {
-        const __importRef = importFileRef(filename);
-        return {
-            __importRef,
-            ...values,
-        };
-    }
-
-    /**
-     * Create an ImportFileRef that has an `error` field.
-     */
-    function importFileRef(filenameOrRef: string | ImportFileRef | ImportFileRefWithError): ImportFileRef {
-        const { filename, error } = iRef(filenameOrRef);
-        return { filename, error };
-    }
-
-    /**
-     * Create an ImportFileRef with an optional `error` field.
-     */
-    function iRef(filenameOrRef: string | ImportFileRef | ImportFileRefWithError): ImportFileRef {
-        return typeof filenameOrRef === 'string' ? { filename: filenameOrRef } : filenameOrRef;
-    }
-
     function s(filename: string): string {
         return rSample(filename);
     }
@@ -638,6 +614,72 @@ describe('Validate search/load config files', () => {
     });
 });
 
+describe.only('ConfigLoader with VirtualFS', () => {
+    const publicURL = new URL('vscode-fs://github/streetsidesoftware/public-samples/');
+
+    function pURL(path: string): URL {
+        return new URL(path, publicURL);
+    }
+
+    test.each`
+        file                                       | expectedConfig
+        ${'dot-config/.config/cspell.config.yaml'} | ${cf(pURL('dot-config/.config/cspell.config.yaml'), { name: 'Nested in .config' })}
+        ${'yaml-config/cspell.yaml'}               | ${cf(pURL('yaml-config/cspell.yaml'), { id: 'Yaml Example Config' })}
+    `('ReadRawSettings from $file', async ({ file, expectedConfig }) => {
+        const vfs = createVirtualFS();
+        const redirectProvider = createRedirectProvider('test', publicURL, sURL('./'));
+        vfs.registerFileSystemProvider(redirectProvider);
+
+        const fileURL = pURL(file);
+
+        // Make sure we can read the file without using the loader.
+        const rawFilePrivate = await vfs.fs.readFile(sURL(file));
+        expect(rawFilePrivate.url.href).toBe(sURL(file).href);
+
+        const rawFile = await vfs.fs.readFile(fileURL);
+        expect(rawFile.url.href).toBe(fileURL.href);
+
+        // Use the loader
+        const loader = createConfigLoader(vfs.fs);
+        const cfg = await loader.readConfigFile(fileURL, publicURL);
+        expect(cfg).not.instanceOf(Error);
+        assert(!(cfg instanceof Error));
+        const searchResult = configToRawSettings(cfg);
+        expect(searchResult.__importRef?.filename).toEqual(toFilePathOrHref(expectedConfig.url));
+        expect(searchResult).toEqual(oc(expectedConfig.settings));
+    });
+
+    test.each`
+        file                       | expectedConfig                                                         | expectedImportErrors
+        ${'README.md'}             | ${cfg(pURL('.cspell.json'), {})}                                       | ${[]}
+        ${'bug-fixes/bug345.ts'}   | ${cfg(pURL('bug-fixes/cspell.json'), {})}                              | ${[]}
+        ${'linked/file.txt'}       | ${cfg(pURL('linked/cspell.config.js'), { __importRef: undefined })}    | ${[]}
+        ${'yaml-config/README.md'} | ${cfg(pURL('yaml-config/cspell.yaml'), { id: 'Yaml Example Config' })} | ${['cspell-imports.json']}
+    `('Search check from $file', async ({ file, expectedConfig, expectedImportErrors }) => {
+        const vfs = createVirtualFS();
+        const redirectProvider = createRedirectProvider('test', publicURL, sURL('./'));
+        vfs.registerFileSystemProvider(redirectProvider);
+
+        const fileURL = pURL(file);
+        const loader = createConfigLoader(vfs.fs);
+
+        const searchResult = await loader.searchForConfig(fileURL);
+        expect(searchResult?.__importRef).toEqual(
+            expectedConfig.__importRef ? expect.objectContaining(expectedConfig.__importRef) : undefined,
+        );
+        // expect(searchResult).toEqual(expect.objectContaining(expectedConfig));
+        const errors = extractImportErrors(searchResult || {});
+        expect(errors).toHaveLength(expectedImportErrors.length);
+        expect(errors).toEqual(
+            expect.arrayContaining(
+                (expectedImportErrors as string[]).map((filename) =>
+                    expect.objectContaining({ filename: expect.stringContaining(filename) }),
+                ),
+            ),
+        );
+    });
+});
+
 function u(url: string | URL, ref?: string | URL): URL {
     return new URL(url, ref);
 }
@@ -766,4 +808,31 @@ function cUrl(url: string | URL, replaceWith: Partial<UriComponents>): URL {
     const uri = URI.parse(toFileUrl(url).href).with(replaceWith);
 
     return new URL(uri.toString());
+}
+
+function cfg(
+    filename: string | ImportFileRefWithError | URL,
+    values: CSpellSettingsWithSourceTrace | { __importRef?: undefined } = {},
+): CSpellSettingsWithSourceTrace {
+    const __importRef = importFileRef(filename);
+    return {
+        __importRef,
+        ...values,
+    } as CSpellSettingsWithSourceTrace;
+}
+
+/**
+ * Create an ImportFileRef that has an `error` field.
+ */
+function importFileRef(filenameOrRef: string | ImportFileRef | ImportFileRefWithError | URL): ImportFileRef {
+    const { filename, error } = iRef(filenameOrRef);
+    return { filename, error };
+}
+
+/**
+ * Create an ImportFileRef with an optional `error` field.
+ */
+function iRef(filenameOrRef: string | ImportFileRef | ImportFileRefWithError | URL): ImportFileRef {
+    filenameOrRef = filenameOrRef instanceof URL ? toFilePathOrHref(filenameOrRef) : filenameOrRef;
+    return typeof filenameOrRef === 'string' ? { filename: filenameOrRef } : filenameOrRef;
 }

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultConfigLoader.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultConfigLoader.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+
+import { getDefaultConfigLoader } from './defaultConfigLoader.js';
+
+describe('defaultConfigLoader', () => {
+    test('getDefaultConfigLoader', () => {
+        expect(getDefaultConfigLoader()).toEqual(expect.any(Object));
+    });
+});

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultConfigLoader.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultConfigLoader.ts
@@ -1,7 +1,6 @@
 import type { CSpellConfigFile } from 'cspell-config-lib';
 
 import { toError } from '../../../util/errors.js';
-import type { ResolveFileResult } from '../../../util/resolveFile.js';
 import { toFileUrl } from '../../../util/url.js';
 import type { IConfigLoader } from './configLoader.js';
 import { getDefaultConfigLoaderInternal } from './configLoader.js';

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultConfigLoader.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultConfigLoader.ts
@@ -1,6 +1,7 @@
 import type { CSpellConfigFile } from 'cspell-config-lib';
 
 import { toError } from '../../../util/errors.js';
+import type { ResolveFileResult } from '../../../util/resolveFile.js';
 import { toFileUrl } from '../../../util/url.js';
 import type { IConfigLoader } from './configLoader.js';
 import { getDefaultConfigLoaderInternal } from './configLoader.js';

--- a/packages/cspell-lib/src/lib/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DefaultSettings.ts
@@ -14,7 +14,7 @@ import * as RegPat from './RegExpPatterns.js';
 const defaultConfigFileModuleRef = '@cspell/cspell-bundled-dicts/cspell-default.json';
 
 // Do not use require.resolve because webpack will mess it up.
-const defaultConfigFile = resolveConfigModule(defaultConfigFileModuleRef);
+const defaultConfigFile = () => resolveConfigModule(defaultConfigFileModuleRef);
 
 const regExpSpellCheckerDisable = [
     new PatternRegExp(RegPat.regExSpellingGuardBlock),
@@ -145,8 +145,8 @@ export const _defaultSettings: Readonly<CSpellSettingsInternal> = Object.freeze(
     }),
 );
 
-function resolveConfigModule(configModuleName: string) {
-    return resolveFile(configModuleName, srcDirectory).filename;
+async function resolveConfigModule(configModuleName: string) {
+    return (await resolveFile(configModuleName, srcDirectory)).filename;
 }
 
 function normalizePattern(pat: RegExpPatternDefinition): RegExpPatternDefinition {
@@ -177,7 +177,8 @@ class DefaultSettingsLoader {
         if (this.pending) return this.pending;
 
         this.pending = (async () => {
-            const jsonSettings = await readSettings(defaultConfigFile);
+            const defaultConfigLocation = await defaultConfigFile();
+            const jsonSettings = await readSettings(defaultConfigLocation);
             this.settings = mergeSettings(_defaultSettings, jsonSettings);
             if (jsonSettings.name !== undefined) {
                 this.settings.name = jsonSettings.name;

--- a/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
@@ -19,7 +19,7 @@ import type {
 } from '../Models/CSpellSettingsInternalDef.js';
 import { isDictionaryDefinitionInlineInternal } from '../Models/CSpellSettingsInternalDef.js';
 import { AutoResolveWeakCache } from '../util/AutoResolve.js';
-import { resolveFile } from '../util/resolveFile.js';
+import { resolveFile } from '../util/resolveFileLegacy.js';
 import type { RequireOptional, UnionFields } from '../util/types.js';
 import { clean } from '../util/util.js';
 import type { DictionaryReferenceCollection } from './DictionaryReferenceCollection.js';

--- a/packages/cspell-lib/src/lib/fileSystem.ts
+++ b/packages/cspell-lib/src/lib/fileSystem.ts
@@ -1,8 +1,8 @@
-import type { CSpellIO, FileSystemProvider } from 'cspell-io';
+import type { CSpellIO, VFileSystemProvider } from 'cspell-io';
 import { getDefaultCSpellIO, getDefaultVirtualFs } from 'cspell-io';
 
-export type { FileSystemProvider, VfsDirEntry, VirtualFS } from 'cspell-io';
-export { createTextFileResource, FileSystem, FSCapabilityFlags } from 'cspell-io';
+export type { VFileSystemProvider, VfsDirEntry, VirtualFS } from 'cspell-io';
+export { createTextFileResource, FSCapabilityFlags, VFileSystem } from 'cspell-io';
 
 export function getCSpellIO(): CSpellIO {
     return getDefaultCSpellIO();
@@ -12,7 +12,11 @@ export function getVirtualFS() {
     return getDefaultVirtualFs();
 }
 
-export function registerCSpell(fsp: FileSystemProvider) {
+export function getFileSystem() {
+    return getVirtualFS().fs;
+}
+
+export function registerCSpell(fsp: VFileSystemProvider) {
     const vfs = getVirtualFS();
     vfs.registerFileSystemProvider(fsp);
 }

--- a/packages/cspell-lib/src/lib/index.ts
+++ b/packages/cspell-lib/src/lib/index.ts
@@ -100,7 +100,7 @@ export {
 export { Link, Text };
 export { ExclusionHelper };
 export { clearCachedFiles, clearCaches } from './clearCachedFiles.js';
-export type { FileSystemProvider, VirtualFS } from './fileSystem.js';
+export type { VFileSystemProvider, VirtualFS } from './fileSystem.js';
 export { FSCapabilityFlags, getVirtualFS } from './fileSystem.js';
 export { getDictionary } from './getDictionary.js';
 export type { PerfTimer } from './perf/index.js';

--- a/packages/cspell-lib/src/lib/util/findUpFromUrl.ts
+++ b/packages/cspell-lib/src/lib/util/findUpFromUrl.ts
@@ -1,9 +1,9 @@
-import type { FileSystem } from '../fileSystem.js';
+import type { VFileSystem } from '../fileSystem.js';
 import { getVirtualFS } from '../fileSystem.js';
 
 type EntryType = 'file' | 'directory' | '!file' | '!directory';
 
-export type FindUpFileSystem = Pick<FileSystem, 'stat'>;
+export type FindUpFileSystem = Pick<VFileSystem, 'stat'>;
 
 export interface FindUpURLOptions {
     type?: EntryType;

--- a/packages/cspell-lib/src/lib/util/resolveFile.ts
+++ b/packages/cspell-lib/src/lib/util/resolveFile.ts
@@ -1,8 +1,9 @@
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 
 import { resolveGlobal } from '@cspell/cspell-resolver';
 import { importResolveModuleName } from '@cspell/dynamic-import';
-import * as fs from 'fs';
+import type { VFileSystem } from 'cspell-io';
 import * as os from 'os';
 import * as path from 'path';
 import resolveFrom from 'resolve-from';
@@ -16,8 +17,10 @@ import {
     isURLLike,
     resolveFileWithURL,
     toFilePathOrHref,
+    toFileUrl,
     toURL,
 } from './url.js';
+import { getFileSystem } from '../fileSystem.js';
 
 export interface ResolveFileResult {
     /**
@@ -38,204 +41,232 @@ export interface ResolveFileResult {
 
 const regExpStartsWidthNodeModules = /^node_modules[/\\]/;
 
-/**
- * Resolve filename to absolute paths.
- * It tries to look for local files as well as node_modules
- * @param filename an absolute path, relative path, `~` path, or a node_module.
- * @param relativeTo absolute path
- */
-export function resolveFile(filename: string, relativeTo: string | URL): ResolveFileResult {
-    const result = _resolveFile(filename, relativeTo);
-    const match = filename.match(regExpStartsWidthNodeModules);
+export class FileResolver {
+    constructor(private fs: VFileSystem) {}
 
-    if (match) {
-        result.warning ??= `Import of '${filename}' should not start with '${match[0]}' in '${toFilePathOrHref(
-            relativeTo,
-        )}'. Use '${filename.replace(regExpStartsWidthNodeModules, '')}' or a relative path instead.`;
-    }
-
-    return result;
-}
-
-export function _resolveFile(filename: string, relativeTo: string | URL): ResolveFileResult {
-    filename = filename.replace(/^~/, os.homedir());
-    const steps: { filename: string; fn: (f: string, r: string | URL) => ResolveFileResult | undefined }[] = [
-        { filename, fn: tryUrl },
-        { filename, fn: tryCreateRequire },
-        { filename, fn: tryNodeRequireResolve },
-        { filename, fn: tryImportResolve },
-        { filename, fn: tryResolveExists },
-        { filename, fn: tryNodeResolveDefaultPaths },
-        { filename, fn: tryResolveFrom },
-        { filename, fn: tryResolveGlobal },
-        { filename, fn: tryLegacyResolve },
-    ];
-
-    for (const step of steps) {
-        const r = step.fn(step.filename, relativeTo);
-        if (r?.found) return r;
-    }
-
-    const result = tryUrl(filename, relativeTo) || {
-        filename: isRelative(filename) ? joinWith(filename, relativeTo) : filename.toString(),
-        relativeTo: relativeTo.toString(),
-        found: false,
-        method: 'not found',
-    };
-
-    return result;
-}
-
-/**
- * Check to see if it is a URL.
- * Note: URLs are absolute!
- * If relativeTo is a non-file URL, then it will try to resolve the filename relative to it.
- * @param filename - url string
- * @returns ResolveFileResult
- */
-function tryUrl(filename: string, relativeToURL: string | URL): ResolveFileResult | undefined {
-    if (isURLLike(filename)) {
-        if (isFileURL(filename)) {
-            const file = fileURLToPath(filename);
+    /**
+     * Resolve filename to absolute paths.
+     * It tries to look for local files as well as node_modules
+     * @param filename an absolute path, relative path, `~` path, or a node_module.
+     * @param relativeTo absolute path
+     */
+    async resolveFile(filename: string | URL, relativeTo: string | URL): Promise<ResolveFileResult> {
+        if (filename instanceof URL) {
             return {
-                filename: file,
+                filename: toFilePathOrHref(filename),
+                relativeTo: relativeTo.toString(),
+                found: await this.doesExist(filename),
+                method: 'url',
+            };
+        }
+        const result = await this._resolveFile(filename, relativeTo);
+        const match = filename.match(regExpStartsWidthNodeModules);
+
+        if (match) {
+            result.warning ??= `Import of '${filename}' should not start with '${match[0]}' in '${toFilePathOrHref(
+                relativeTo,
+            )}'. Use '${filename.replace(regExpStartsWidthNodeModules, '')}' or a relative path instead.`;
+        }
+
+        return result;
+    }
+
+    async _resolveFile(filename: string, relativeTo: string | URL): Promise<ResolveFileResult> {
+        filename = filename.replace(/^~/, os.homedir());
+        const steps: {
+            filename: string;
+            fn: (f: string, r: string | URL) => Promise<ResolveFileResult | undefined> | ResolveFileResult | undefined;
+        }[] = [
+            { filename, fn: this.tryUrl },
+            { filename, fn: this.tryCreateRequire },
+            { filename, fn: this.tryNodeRequireResolve },
+            { filename, fn: this.tryImportResolve },
+            { filename, fn: this.tryResolveExists },
+            { filename, fn: this.tryNodeResolveDefaultPaths },
+            { filename, fn: this.tryResolveFrom },
+            { filename, fn: this.tryResolveGlobal },
+            { filename, fn: this.tryLegacyResolve },
+        ];
+
+        for (const step of steps) {
+            const r = await step.fn(step.filename, relativeTo);
+            if (r?.found) return r;
+        }
+
+        const result = (await this.tryUrl(filename, relativeTo)) || {
+            filename: isRelative(filename) ? joinWith(filename, relativeTo) : filename.toString(),
+            relativeTo: relativeTo.toString(),
+            found: false,
+            method: 'not found',
+        };
+
+        return result;
+    }
+
+    private async doesExist(file: URL): Promise<boolean> {
+        try {
+            const s = await this.fs.stat(file);
+            return s.isFile() || s.isUnknown();
+        } catch (error) {
+            return false;
+        }
+    }
+
+    /**
+     * Check to see if it is a URL.
+     * Note: URLs are absolute!
+     * If relativeTo is a non-file URL, then it will try to resolve the filename relative to it.
+     * @param filename - url string
+     * @returns ResolveFileResult
+     */
+    tryUrl = async (filename: string, relativeToURL: string | URL): Promise<ResolveFileResult | undefined> => {
+        if (isURLLike(filename)) {
+            const fileURL = toURL(filename);
+            return {
+                filename: toFilePathOrHref(fileURL),
                 relativeTo: undefined,
-                found: fs.existsSync(file),
+                found: await this.doesExist(fileURL),
                 method: 'tryUrl',
             };
         }
-        return { filename: filename.toString(), relativeTo: undefined, found: true, method: 'tryUrl' };
-    }
 
-    if (isURLLike(relativeToURL) && !isDataURL(relativeToURL)) {
-        const relToURL = toURL(relativeToURL);
-        const isRelToAFile = isFileURL(relToURL);
-        const url = resolveFileWithURL(filename, relToURL);
-        return {
-            filename: toFilePathOrHref(url),
-            relativeTo: toFilePathOrHref(relToURL),
-            found: !isRelToAFile || fs.existsSync(url),
-            method: 'tryUrl',
-        };
-    }
+        if (isURLLike(relativeToURL) && !isDataURL(relativeToURL)) {
+            const relToURL = toURL(relativeToURL);
+            const url = resolveFileWithURL(filename, relToURL);
+            return {
+                filename: toFilePathOrHref(url),
+                relativeTo: toFilePathOrHref(relToURL),
+                found: await this.doesExist(url),
+                method: 'tryUrl',
+            };
+        }
 
-    return undefined;
-}
-
-function tryCreateRequire(filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined {
-    if (filename instanceof URL) return undefined;
-    const require = createRequire(relativeTo);
-    try {
-        const r = require.resolve(filename);
-        return { filename: r, relativeTo: relativeTo.toString(), found: true, method: 'tryCreateRequire' };
-    } catch (_) {
         return undefined;
-    }
-}
+    };
 
-function tryNodeResolveDefaultPaths(filename: string): ResolveFileResult | undefined {
-    try {
-        const r = require.resolve(filename);
-        return { filename: r, relativeTo: undefined, found: true, method: 'tryNodeResolveDefaultPaths' };
-    } catch (_) {
-        return undefined;
-    }
-}
+    tryCreateRequire = (filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined => {
+        if (filename instanceof URL) return undefined;
+        const rel = !isURLLike(relativeTo) || isFileURL(relativeTo) ? relativeTo : pathToFileURL('./');
+        const require = createRequire(rel);
+        try {
+            const r = require.resolve(filename);
+            return { filename: r, relativeTo: rel.toString(), found: true, method: 'tryCreateRequire' };
+        } catch (_) {
+            return undefined;
+        }
+    };
 
-function tryNodeRequireResolve(filenameOrURL: string, relativeTo: string | URL): ResolveFileResult | undefined {
-    const filename = fileURLOrPathToPath(filenameOrURL);
-    const relativeToPath = pathFromRelativeTo(relativeTo);
-    const home = os.homedir();
-    function calcPaths(p: string) {
-        const paths = [p];
-        // Do not progress towards the root if it is a relative filename.
-        if (isRelative(filename)) {
+    tryNodeResolveDefaultPaths = (filename: string): ResolveFileResult | undefined => {
+        try {
+            const r = require.resolve(filename);
+            return { filename: r, relativeTo: undefined, found: true, method: 'tryNodeResolveDefaultPaths' };
+        } catch (_) {
+            return undefined;
+        }
+    };
+
+    tryNodeRequireResolve = (filenameOrURL: string, relativeTo: string | URL): ResolveFileResult | undefined => {
+        if (isURLLike(relativeTo) && !isFileURL(relativeTo)) return undefined;
+
+        const filename = fileURLOrPathToPath(filenameOrURL);
+        const relativeToPath = pathFromRelativeTo(relativeTo);
+        const home = os.homedir();
+        function calcPaths(p: string) {
+            const paths = [p];
+            // Do not progress towards the root if it is a relative filename.
+            if (isRelative(filename)) {
+                return paths;
+            }
+            for (; p && path.dirname(p) !== p && p !== home; p = path.dirname(p)) {
+                paths.push(p);
+            }
             return paths;
         }
-        for (; p && path.dirname(p) !== p && p !== home; p = path.dirname(p)) {
-            paths.push(p);
+        const paths = calcPaths(path.resolve(relativeToPath));
+        try {
+            const r = require.resolve(filename, { paths });
+            return { filename: r, relativeTo: relativeToPath, found: true, method: 'tryNodeRequireResolve' };
+        } catch (_) {
+            return undefined;
         }
-        return paths;
-    }
-    const paths = calcPaths(path.resolve(relativeToPath));
-    try {
-        const r = require.resolve(filename, { paths });
-        return { filename: r, relativeTo: relativeToPath, found: true, method: 'tryNodeRequireResolve' };
-    } catch (_) {
-        return undefined;
-    }
-}
-
-function tryImportResolve(filename: string, relativeTo: string | URL): ResolveFileResult | undefined {
-    try {
-        const paths = isRelative(filename) ? [relativeTo] : [relativeTo, srcDirectory];
-        const resolved = fileURLToPath(importResolveModuleName(filename, paths));
-        return { filename: resolved, relativeTo: relativeTo.toString(), found: true, method: 'tryImportResolve' };
-    } catch (_) {
-        return undefined;
-    }
-}
-
-function tryResolveGlobal(filename: string): ResolveFileResult | undefined {
-    const r = resolveGlobal(filename);
-    return (r && { filename: r, relativeTo: undefined, found: true, method: 'tryResolveGlobal' }) || undefined;
-}
-
-function tryResolveExists(filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined {
-    if (filename instanceof URL || isURLLike(filename) || (isURLLike(relativeTo) && !isFileURL(relativeTo))) {
-        return undefined;
-    }
-
-    relativeTo = pathFromRelativeTo(relativeTo);
-
-    const toTry = [{ filename }, { filename: path.resolve(relativeTo, filename), relativeTo }];
-    for (const { filename, relativeTo } of toTry) {
-        const found = path.isAbsolute(filename) && fs.existsSync(filename);
-        if (found) return { filename, relativeTo: relativeTo?.toString(), found, method: 'tryResolveExists' };
-    }
-    filename = path.resolve(filename);
-    return {
-        filename,
-        relativeTo: path.resolve('.'),
-        found: fs.existsSync(filename),
-        method: 'tryResolveExists',
     };
-}
 
-function tryResolveFrom(filename: string, relativeTo: string | URL): ResolveFileResult | undefined {
-    if (relativeTo instanceof URL) return undefined;
-    try {
-        return {
-            filename: resolveFrom(pathFromRelativeTo(relativeTo), filename),
-            relativeTo,
-            found: true,
-            method: 'tryResolveFrom',
-        };
-    } catch (error) {
-        // Failed to resolve a relative module request
-        return undefined;
-    }
-}
-
-function tryLegacyResolve(filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined {
-    if (filename instanceof URL || isURLLike(filename) || (isURLLike(relativeTo) && !isFileURL(relativeTo))) {
-        return undefined;
-    }
-
-    const relativeToPath = isURLLike(relativeTo) ? fileURLToPath(new URL('./', relativeTo)) : relativeTo.toString();
-
-    const match = filename.match(regExpStartsWidthNodeModules);
-
-    if (match) {
-        const fixedFilename = filename.replace(regExpStartsWidthNodeModules, '');
-        const found = tryImportResolve(fixedFilename, relativeToPath) || tryResolveFrom(fixedFilename, relativeToPath);
-        if (found?.found) {
-            found.method = 'tryLegacyResolve';
-            return found;
+    tryImportResolve = (filename: string, relativeTo: string | URL): ResolveFileResult | undefined => {
+        try {
+            const paths = isRelative(filename) ? [relativeTo] : [relativeTo, srcDirectory];
+            const resolved = fileURLToPath(importResolveModuleName(filename, paths));
+            return { filename: resolved, relativeTo: relativeTo.toString(), found: true, method: 'tryImportResolve' };
+        } catch (_) {
+            return undefined;
         }
-    }
+    };
 
-    return undefined;
+    tryResolveGlobal = (filename: string): ResolveFileResult | undefined => {
+        const r = resolveGlobal(filename);
+        return (r && { filename: r, relativeTo: undefined, found: true, method: 'tryResolveGlobal' }) || undefined;
+    };
+
+    tryResolveExists = async (
+        filename: string | URL,
+        relativeTo: string | URL,
+    ): Promise<ResolveFileResult | undefined> => {
+        if (filename instanceof URL || isURLLike(filename) || (isURLLike(relativeTo) && !isFileURL(relativeTo))) {
+            return undefined;
+        }
+
+        relativeTo = pathFromRelativeTo(relativeTo);
+
+        const toTry = [{ filename }, { filename: path.resolve(relativeTo, filename), relativeTo }];
+        for (const { filename, relativeTo } of toTry) {
+            const found = path.isAbsolute(filename) && (await this.doesExist(toFileUrl(filename)));
+            if (found) return { filename, relativeTo: relativeTo?.toString(), found, method: 'tryResolveExists' };
+        }
+        filename = path.resolve(filename);
+        return {
+            filename,
+            relativeTo: path.resolve('.'),
+            found: await this.doesExist(toFileUrl(filename)),
+            method: 'tryResolveExists',
+        };
+    };
+
+    tryResolveFrom = (filename: string, relativeTo: string | URL): ResolveFileResult | undefined => {
+        if (relativeTo instanceof URL) return undefined;
+        try {
+            return {
+                filename: resolveFrom(pathFromRelativeTo(relativeTo), filename),
+                relativeTo,
+                found: true,
+                method: 'tryResolveFrom',
+            };
+        } catch (error) {
+            // Failed to resolve a relative module request
+            return undefined;
+        }
+    };
+
+    tryLegacyResolve = (filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined => {
+        if (filename instanceof URL || isURLLike(filename) || (isURLLike(relativeTo) && !isFileURL(relativeTo))) {
+            return undefined;
+        }
+
+        const relativeToPath = isURLLike(relativeTo) ? fileURLToPath(new URL('./', relativeTo)) : relativeTo.toString();
+
+        const match = filename.match(regExpStartsWidthNodeModules);
+
+        if (match) {
+            const fixedFilename = filename.replace(regExpStartsWidthNodeModules, '');
+            const found =
+                this.tryImportResolve(fixedFilename, relativeToPath) ||
+                this.tryResolveFrom(fixedFilename, relativeToPath);
+            if (found?.found) {
+                found.method = 'tryLegacyResolve';
+                return found;
+            }
+        }
+
+        return undefined;
+    };
 }
 
 function isRelative(filename: string | URL): boolean {
@@ -258,16 +289,22 @@ function pathFromRelativeTo(relativeTo: string | URL): string {
     return relativeTo instanceof URL || isURLLike(relativeTo) ? fileURLToPath(new URL('./', relativeTo)) : relativeTo;
 }
 
-export const __testing__ = {
-    isRelative,
-    isFileURL,
-    isURLLike,
-    fileURLOrPathToPath,
-    tryResolveFrom,
-    tryResolveExists,
-    tryResolveGlobal,
-    tryImportResolve,
-    tryNodeRequireResolve,
-    tryNodeResolveDefaultPaths,
-    tryUrl,
-};
+const loaderCache = new WeakMap<VFileSystem, FileResolver>();
+
+export function createFileResolver(fs: VFileSystem): FileResolver {
+    let loader = loaderCache.get(fs);
+    if (!loader) {
+        loader = new FileResolver(fs);
+        loaderCache.set(fs, loader);
+    }
+    return loader;
+}
+
+export async function resolveFile(
+    filename: string | URL,
+    relativeTo: string | URL,
+    fs: VFileSystem = getFileSystem(),
+): Promise<ResolveFileResult> {
+    const resolver = createFileResolver(fs);
+    return resolver.resolveFile(filename, relativeTo);
+}

--- a/packages/cspell-lib/src/lib/util/resolveFile.ts
+++ b/packages/cspell-lib/src/lib/util/resolveFile.ts
@@ -10,6 +10,7 @@ import resolveFrom from 'resolve-from';
 import { fileURLToPath } from 'url';
 
 import { srcDirectory } from '../../lib-cjs/pkg-info.cjs';
+import { getFileSystem } from '../fileSystem.js';
 import {
     fileURLOrPathToPath,
     isDataURL,
@@ -20,7 +21,6 @@ import {
     toFileUrl,
     toURL,
 } from './url.js';
-import { getFileSystem } from '../fileSystem.js';
 
 export interface ResolveFileResult {
     /**

--- a/packages/cspell-lib/src/lib/util/resolveFileLegacy.ts
+++ b/packages/cspell-lib/src/lib/util/resolveFileLegacy.ts
@@ -1,0 +1,273 @@
+import { createRequire } from 'node:module';
+
+import { resolveGlobal } from '@cspell/cspell-resolver';
+import { importResolveModuleName } from '@cspell/dynamic-import';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import resolveFrom from 'resolve-from';
+import { fileURLToPath } from 'url';
+
+import { srcDirectory } from '../../lib-cjs/pkg-info.cjs';
+import {
+    fileURLOrPathToPath,
+    isDataURL,
+    isFileURL,
+    isURLLike,
+    resolveFileWithURL,
+    toFilePathOrHref,
+    toURL,
+} from './url.js';
+
+export interface ResolveFileResult {
+    /**
+     * Absolute path or URL to the file.
+     */
+    filename: string;
+    relativeTo: string | undefined;
+    found: boolean;
+    /**
+     * A warning message if the file was found, but there was a problem.
+     */
+    warning?: string;
+    /**
+     * The method used to resolve the file.
+     */
+    method: string;
+}
+
+const regExpStartsWidthNodeModules = /^node_modules[/\\]/;
+
+/**
+ * Resolve filename to absolute paths.
+ * It tries to look for local files as well as node_modules
+ * @param filename an absolute path, relative path, `~` path, or a node_module.
+ * @param relativeTo absolute path
+ */
+export function resolveFile(filename: string, relativeTo: string | URL): ResolveFileResult {
+    const result = _resolveFile(filename, relativeTo);
+    const match = filename.match(regExpStartsWidthNodeModules);
+
+    if (match) {
+        result.warning ??= `Import of '${filename}' should not start with '${match[0]}' in '${toFilePathOrHref(
+            relativeTo,
+        )}'. Use '${filename.replace(regExpStartsWidthNodeModules, '')}' or a relative path instead.`;
+    }
+
+    return result;
+}
+
+function _resolveFile(filename: string, relativeTo: string | URL): ResolveFileResult {
+    filename = filename.replace(/^~/, os.homedir());
+    const steps: { filename: string; fn: (f: string, r: string | URL) => ResolveFileResult | undefined }[] = [
+        { filename, fn: tryUrl },
+        { filename, fn: tryCreateRequire },
+        { filename, fn: tryNodeRequireResolve },
+        { filename, fn: tryImportResolve },
+        { filename, fn: tryResolveExists },
+        { filename, fn: tryNodeResolveDefaultPaths },
+        { filename, fn: tryResolveFrom },
+        { filename, fn: tryResolveGlobal },
+        { filename, fn: tryLegacyResolve },
+    ];
+
+    for (const step of steps) {
+        const r = step.fn(step.filename, relativeTo);
+        if (r?.found) return r;
+    }
+
+    const result = tryUrl(filename, relativeTo) || {
+        filename: isRelative(filename) ? joinWith(filename, relativeTo) : filename.toString(),
+        relativeTo: relativeTo.toString(),
+        found: false,
+        method: 'not found',
+    };
+
+    return result;
+}
+
+/**
+ * Check to see if it is a URL.
+ * Note: URLs are absolute!
+ * If relativeTo is a non-file URL, then it will try to resolve the filename relative to it.
+ * @param filename - url string
+ * @returns ResolveFileResult
+ */
+function tryUrl(filename: string, relativeToURL: string | URL): ResolveFileResult | undefined {
+    if (isURLLike(filename)) {
+        if (isFileURL(filename)) {
+            const file = fileURLToPath(filename);
+            return {
+                filename: file,
+                relativeTo: undefined,
+                found: fs.existsSync(file),
+                method: 'tryUrl',
+            };
+        }
+        return { filename: filename.toString(), relativeTo: undefined, found: true, method: 'tryUrl' };
+    }
+
+    if (isURLLike(relativeToURL) && !isDataURL(relativeToURL)) {
+        const relToURL = toURL(relativeToURL);
+        const isRelToAFile = isFileURL(relToURL);
+        const url = resolveFileWithURL(filename, relToURL);
+        return {
+            filename: toFilePathOrHref(url),
+            relativeTo: toFilePathOrHref(relToURL),
+            found: !isRelToAFile || fs.existsSync(url),
+            method: 'tryUrl',
+        };
+    }
+
+    return undefined;
+}
+
+function tryCreateRequire(filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined {
+    if (filename instanceof URL) return undefined;
+    const require = createRequire(relativeTo);
+    try {
+        const r = require.resolve(filename);
+        return { filename: r, relativeTo: relativeTo.toString(), found: true, method: 'tryCreateRequire' };
+    } catch (_) {
+        return undefined;
+    }
+}
+
+function tryNodeResolveDefaultPaths(filename: string): ResolveFileResult | undefined {
+    try {
+        const r = require.resolve(filename);
+        return { filename: r, relativeTo: undefined, found: true, method: 'tryNodeResolveDefaultPaths' };
+    } catch (_) {
+        return undefined;
+    }
+}
+
+function tryNodeRequireResolve(filenameOrURL: string, relativeTo: string | URL): ResolveFileResult | undefined {
+    const filename = fileURLOrPathToPath(filenameOrURL);
+    const relativeToPath = pathFromRelativeTo(relativeTo);
+    const home = os.homedir();
+    function calcPaths(p: string) {
+        const paths = [p];
+        // Do not progress towards the root if it is a relative filename.
+        if (isRelative(filename)) {
+            return paths;
+        }
+        for (; p && path.dirname(p) !== p && p !== home; p = path.dirname(p)) {
+            paths.push(p);
+        }
+        return paths;
+    }
+    const paths = calcPaths(path.resolve(relativeToPath));
+    try {
+        const r = require.resolve(filename, { paths });
+        return { filename: r, relativeTo: relativeToPath, found: true, method: 'tryNodeRequireResolve' };
+    } catch (_) {
+        return undefined;
+    }
+}
+
+function tryImportResolve(filename: string, relativeTo: string | URL): ResolveFileResult | undefined {
+    try {
+        const paths = isRelative(filename) ? [relativeTo] : [relativeTo, srcDirectory];
+        const resolved = fileURLToPath(importResolveModuleName(filename, paths));
+        return { filename: resolved, relativeTo: relativeTo.toString(), found: true, method: 'tryImportResolve' };
+    } catch (_) {
+        return undefined;
+    }
+}
+
+function tryResolveGlobal(filename: string): ResolveFileResult | undefined {
+    const r = resolveGlobal(filename);
+    return (r && { filename: r, relativeTo: undefined, found: true, method: 'tryResolveGlobal' }) || undefined;
+}
+
+function tryResolveExists(filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined {
+    if (filename instanceof URL || isURLLike(filename) || (isURLLike(relativeTo) && !isFileURL(relativeTo))) {
+        return undefined;
+    }
+
+    relativeTo = pathFromRelativeTo(relativeTo);
+
+    const toTry = [{ filename }, { filename: path.resolve(relativeTo, filename), relativeTo }];
+    for (const { filename, relativeTo } of toTry) {
+        const found = path.isAbsolute(filename) && fs.existsSync(filename);
+        if (found) return { filename, relativeTo: relativeTo?.toString(), found, method: 'tryResolveExists' };
+    }
+    filename = path.resolve(filename);
+    return {
+        filename,
+        relativeTo: path.resolve('.'),
+        found: fs.existsSync(filename),
+        method: 'tryResolveExists',
+    };
+}
+
+function tryResolveFrom(filename: string, relativeTo: string | URL): ResolveFileResult | undefined {
+    if (relativeTo instanceof URL) return undefined;
+    try {
+        return {
+            filename: resolveFrom(pathFromRelativeTo(relativeTo), filename),
+            relativeTo,
+            found: true,
+            method: 'tryResolveFrom',
+        };
+    } catch (error) {
+        // Failed to resolve a relative module request
+        return undefined;
+    }
+}
+
+function tryLegacyResolve(filename: string | URL, relativeTo: string | URL): ResolveFileResult | undefined {
+    if (filename instanceof URL || isURLLike(filename) || (isURLLike(relativeTo) && !isFileURL(relativeTo))) {
+        return undefined;
+    }
+
+    const relativeToPath = isURLLike(relativeTo) ? fileURLToPath(new URL('./', relativeTo)) : relativeTo.toString();
+
+    const match = filename.match(regExpStartsWidthNodeModules);
+
+    if (match) {
+        const fixedFilename = filename.replace(regExpStartsWidthNodeModules, '');
+        const found = tryImportResolve(fixedFilename, relativeToPath) || tryResolveFrom(fixedFilename, relativeToPath);
+        if (found?.found) {
+            found.method = 'tryLegacyResolve';
+            return found;
+        }
+    }
+
+    return undefined;
+}
+
+function isRelative(filename: string | URL): boolean {
+    if (filename instanceof URL) return false;
+    if (isURLLike(filename)) return false;
+    if (filename.startsWith('./')) return true;
+    if (filename.startsWith('../')) return true;
+    if (filename.startsWith('.' + path.sep)) return true;
+    if (filename.startsWith('..' + path.sep)) return true;
+    return false;
+}
+
+function joinWith(filename: string, relativeTo: string | URL): string {
+    return relativeTo instanceof URL || isURLLike(relativeTo)
+        ? toFilePathOrHref(new URL(filename, relativeTo))
+        : path.resolve(relativeTo, filename);
+}
+
+function pathFromRelativeTo(relativeTo: string | URL): string {
+    return relativeTo instanceof URL || isURLLike(relativeTo) ? fileURLToPath(new URL('./', relativeTo)) : relativeTo;
+}
+
+export const __testing__ = {
+    isRelative,
+    isFileURL,
+    isURLLike,
+    fileURLOrPathToPath,
+    tryResolveFrom,
+    tryResolveExists,
+    tryResolveGlobal,
+    tryImportResolve,
+    tryNodeRequireResolve,
+    tryNodeResolveDefaultPaths,
+    tryUrl,
+};


### PR DESCRIPTION
This PR is to add support for reading cspell configuration over `https` or a virtual file system used by VSCode.

It is not possible to load JavaScript files remotely until it is supported by NodeJS.