### PR TITLE
fix: correct the URI encoding

### DIFF
--- a/packages/cspell-lib/src/lib/util/Uri.test.ts
+++ b/packages/cspell-lib/src/lib/util/Uri.test.ts
@@ -80,6 +80,7 @@ describe('Uri', () => {
         ${uriToFilePath(fromFilePath(__filename))}                                                 | ${eqCI(__filename)}
         ${uriToFilePath(fromFilePath(pTestFixtures('issues/issue-4811/@local?/README.md')))}       | ${normalizeDriveLetter(pTestFixtures('issues/issue-4811/@local?/README.md'))}
         ${uriToFilePath(fromFilePath(pTestFixtures('issues/issue-4811/#local/README.md')))}        | ${normalizeDriveLetter(pTestFixtures('issues/issue-4811/#local/README.md'))}
+        ${uriToFilePath(fromFilePath(pTestFixtures('issues/issue-4811/#+,=&@;?v/README.md')))}     | ${normalizeDriveLetter(pTestFixtures('issues/issue-4811/#+,=&@;?v/README.md'))}
         ${urlFile(pTestFixtures('issues/issue-4811/#local/README.md')).href}                       | ${sc('/%23local/README.md')}
         ${URI.parse(urlFile(pTestFixtures('issues/issue-4811/#local/README.md')).href).toString()} | ${sc('/%23local/README.md')}
         ${URI.file(pTestFixtures('issues/issue-4811/#local/README.md')).toString()}                | ${sc('/%23local/README.md')}

--- a/packages/cspell-lib/src/lib/util/Uri.test.ts
+++ b/packages/cspell-lib/src/lib/util/Uri.test.ts
@@ -73,10 +73,12 @@ describe('Uri', () => {
     test.each`
         uri                                                                                        | expected
         ${toUri('file:///d:/a/src/sample.c').toString()}                                           | ${new URL('file:///d:/a/src/sample.c').toString()}
+        ${toUri('file:///d:/a%20b/%23src/sample@2.c').toString()}                                  | ${new URL('file:///d:/a%20b/%23src/sample@2.c').toString()}
         ${toUri('file:///d:/a/src/sample.c').toString()}                                           | ${'file:///d:/a/src/sample.c'}
         ${toUri('file:///d:/a/src files/sample.c').toString()}                                     | ${new URL('file:///d:/a/src files/sample.c').toString()}
         ${toUri('https://g.com/maps?lat=43.23&lon=-0.5#first').toString()}                         | ${new URL('https://g.com/maps?lat=43.23&lon=-0.5#first').toString()}
         ${uriToFilePath(fromFilePath(__filename))}                                                 | ${eqCI(__filename)}
+        ${uriToFilePath(fromFilePath(pTestFixtures('issues/issue-4811/@local?/README.md')))}       | ${normalizeDriveLetter(pTestFixtures('issues/issue-4811/@local?/README.md'))}
         ${uriToFilePath(fromFilePath(pTestFixtures('issues/issue-4811/#local/README.md')))}        | ${normalizeDriveLetter(pTestFixtures('issues/issue-4811/#local/README.md'))}
         ${urlFile(pTestFixtures('issues/issue-4811/#local/README.md')).href}                       | ${sc('/%23local/README.md')}
         ${URI.parse(urlFile(pTestFixtures('issues/issue-4811/#local/README.md')).href).toString()} | ${sc('/%23local/README.md')}

--- a/packages/cspell-lib/src/lib/util/Uri.ts
+++ b/packages/cspell-lib/src/lib/util/Uri.ts
@@ -107,7 +107,7 @@ class UriImpl extends URI implements UriInstance {
 
     toString(): string {
         // if (this.scheme !== 'stdin') return super.toString(true);
-        const path = (this.path || '').split('/').map(encodeURIComponent).join('/').replace(/%3A/g, ':');
+        const path = encodeURI(this.path || '').replace(/[#?]/g, (c) => `%${c.charCodeAt(0).toString(16)}`);
         const base = `${this.scheme}://${this.authority || ''}${path}`;
         const query = (this.query && `?${this.query}`) || '';
         const fragment = (this.fragment && `#${this.fragment}`) || '';


### PR DESCRIPTION
The uri encoding was overly aggressive. 

This change only has an impact if there are special characters in the path.
Like: `@$&+,=`.