### PR TITLE
fix: Improve caching of dictionaries

### DIFF
--- a/packages/cspell-io/src/VirtualFS.ts
+++ b/packages/cspell-io/src/VirtualFS.ts
@@ -155,9 +155,8 @@ class CVirtualFS implements VirtualFS {
         if (this.loggingEnabled) {
             const id = event.traceID.toFixed(13).replace(/\d{4}(?=\d)/g, '$&.');
             const msg = event.message ? `\n\t\t${event.message}` : '';
-            this.log(
-                `${event.method}-${event.event}\t ID:${id} ts:${event.ts.toFixed(13)} ${chopUrl(event.url)}${msg}`,
-            );
+            const method = rPad(`${event.method}-${event.event}`, 16);
+            this.log(`${method} ID:${id} ts:${event.ts.toFixed(13)} ${chopUrl(event.url)}${msg}`);
         }
     };
 
@@ -586,7 +585,11 @@ function chopUrl(url: URL | undefined): string {
     const n = parts.indexOf('node_modules');
     if (n > 0) {
         const tail = parts.slice(Math.max(parts.length - 3, n + 1));
-        return parts.slice(0, n + 1).join('/') + '/.../' + tail.join('/');
+        return parts.slice(0, n + 1).join('/') + '/…/' + tail.join('/');
     }
     return href;
+}
+
+function rPad(str: string, len: number, ch = ' '): string {
+    return str + ch.repeat(Math.max(0, len - str.length));
 }

--- a/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
@@ -18,7 +18,7 @@ import type {
     DictionaryFileDefinitionInternalWithSource,
 } from '../Models/CSpellSettingsInternalDef.js';
 import { isDictionaryDefinitionInlineInternal } from '../Models/CSpellSettingsInternalDef.js';
-import { AutoResolveWeakCache, createAutoResolveWeakWeakCache } from '../util/AutoResolve.js';
+import { createAutoResolveWeakWeakCache } from '../util/AutoResolve.js';
 import { resolveRelativeTo } from '../util/resolveFile.js';
 import type { RequireOptional, UnionFields } from '../util/types.js';
 import { toFilePathOrHref } from '../util/url.js';

--- a/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
@@ -18,7 +18,7 @@ import type {
     DictionaryFileDefinitionInternalWithSource,
 } from '../Models/CSpellSettingsInternalDef.js';
 import { isDictionaryDefinitionInlineInternal } from '../Models/CSpellSettingsInternalDef.js';
-import { AutoResolveWeakCache } from '../util/AutoResolve.js';
+import { AutoResolveWeakCache, createAutoResolveWeakWeakCache } from '../util/AutoResolve.js';
 import { resolveRelativeTo } from '../util/resolveFile.js';
 import type { RequireOptional, UnionFields } from '../util/types.js';
 import { toFilePathOrHref } from '../util/url.js';
@@ -81,7 +81,7 @@ export function mapDictDefsToInternal(
     return defs?.map((def) => mapDictDefToInternal(def, pathToSettingsFile));
 }
 
-const internalDefs = new AutoResolveWeakCache<DictionaryDefinition, DictionaryDefinitionInternalWithSource>();
+const internalDefs = createAutoResolveWeakWeakCache<DictionaryDefinition, DictionaryDefinitionInternalWithSource>();
 
 export function mapDictDefToInternal(
     def: DictionaryDefinition,

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
@@ -19,8 +19,8 @@ import type {
 import { isDictionaryDefinitionInlineInternal } from '../../Models/CSpellSettingsInternalDef.js';
 import { AutoResolveWeakCache, AutoResolveWeakWeakCache } from '../../util/AutoResolve.js';
 import { toError } from '../../util/errors.js';
-import { SpellingDictionaryLoadError } from '../SpellingDictionaryError.js';
 import { SimpleCache } from '../../util/simpleCache.js';
+import { SpellingDictionaryLoadError } from '../SpellingDictionaryError.js';
 
 const MAX_AGE = 10000;
 

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
@@ -76,10 +76,14 @@ export class DictionaryLoader {
     private dictionaryCacheByDef = new AutoResolveWeakWeakCache<DictionaryDefinitionInternal, KvPair>();
     private reader: Reader;
     /** The keepAliveCache is to hold onto the most recently loaded dictionaries. */
-    private keepAliveCache = new SimpleCache<DictionaryDefinitionInternal, CacheEntry>(10);
+    private keepAliveCache: SimpleCache<DictionaryDefinitionInternal, CacheEntry>;
 
-    constructor(private fs: VFileSystem) {
+    constructor(
+        private fs: VFileSystem,
+        keepAliveSize = 10,
+    ) {
         this.reader = toReader(fs);
+        this.keepAliveCache = new SimpleCache<DictionaryDefinitionInternal, CacheEntry>(keepAliveSize);
     }
 
     public loadDictionary(def: DictionaryDefinitionInternal): Promise<SpellingDictionary> {

--- a/packages/cspell-lib/src/lib/util/simpleCache.test.ts
+++ b/packages/cspell-lib/src/lib/util/simpleCache.test.ts
@@ -72,6 +72,13 @@ describe('SimpleCache', () => {
         cache.set(b, b);
         // stack: b:b, c:c, hello:there
         expect(cache.get(b)).toBe(b);
+
+        expect(cache.delete(c)).toBe(true);
+
+        expect(cache.delete(b)).toBe(true);
+        expect(cache.delete(b)).toBe(false);
+
+        expect(cache.get(hello)).toBe(there);
     });
 });
 

--- a/packages/cspell-lib/src/lib/util/simpleCache.ts
+++ b/packages/cspell-lib/src/lib/util/simpleCache.ts
@@ -114,6 +114,14 @@ export class SimpleCache<K, T> {
         this._set(key, { v: value });
     }
 
+    delete(key: K): boolean {
+        let deleted = false;
+        for (const c of this.caches()) {
+            deleted = c.delete(key) || deleted;
+        }
+        return deleted;
+    }
+
     private _set(key: K, entry: Box<T>) {
         if (this.L0.has(key)) {
             this.L0.set(key, entry);
@@ -132,9 +140,11 @@ export class SimpleCache<K, T> {
     }
 
     private rotate() {
+        const L2 = this.L2;
         this.L2 = this.L1;
         this.L1 = this.L0;
-        this.L0 = new Map<K, Box<T>>();
+        this.L0 = L2;
+        this.L0.clear();
     }
 }
 

--- a/packages/cspell-strong-weak-map/src/StrongWeakMap.test.ts
+++ b/packages/cspell-strong-weak-map/src/StrongWeakMap.test.ts
@@ -52,7 +52,7 @@ describe('StrongWeakMap', () => {
         init                                    | hold   | expected
         ${[['a', 'a'], ['b', 'b'], ['c', 'c']]} | ${'a'} | ${['a']}
         ${[['a', 'a'], ['b', 'b'], ['c', 'c']]} | ${'b'} | ${['b']}
-    `('Garbage Collection', async ({ init, hold, expected }) => {
+    `('Garbage Collection cleanKeys', async ({ init, hold, expected }) => {
         const map = new StrongWeakMap(safeBoxKeyValues(init));
         const allKeys = keys(map);
         const v = map.get(hold);
@@ -64,7 +64,27 @@ describe('StrongWeakMap', () => {
         await wait(1);
         expect([...map.keys()]).toEqual(allKeys);
         map.cleanKeys();
+        expect([...map.keys()]).toEqual(expected);
+        expect(map.get(hold)).toBe(v);
+    });
+
+    test.each`
+        init                                    | hold   | expected
+        ${[['a', 'a'], ['b', 'b'], ['c', 'c']]} | ${'a'} | ${['a']}
+        ${[['a', 'a'], ['b', 'b'], ['c', 'c']]} | ${'b'} | ${['b']}
+    `('Garbage Collection cleanKeys', async ({ init, hold, expected }) => {
+        const map = new StrongWeakMap(safeBoxKeyValues(init));
+        const allKeys = keys(map);
+        const v = map.get(hold);
+        expect(v).toBeDefined();
+        expect([...map.keys()]).toEqual(allKeys);
+        expect(gc).toBeDefined();
+        await wait(1);
+        gc?.();
+        await wait(1);
+        expect([...map.keys()]).toEqual(allKeys);
         // getting values will clean up keys
+        [...map];
         expect([...map.keys()]).toEqual(expected);
         expect(map.get(hold)).toBe(v);
     });

--- a/packages/cspell-strong-weak-map/src/StrongWeakMap.ts
+++ b/packages/cspell-strong-weak-map/src/StrongWeakMap.ts
@@ -120,7 +120,15 @@ export class StrongWeakMap<K, V extends object> implements Map<K, V> {
      * Removes any keys that reference released objects.
      */
     cleanKeys(): this {
-        [...this];
+        const keysToDel: K[] = [];
+        for (const [key, ref] of this.map.entries()) {
+            if (!ref.deref()) {
+                keysToDel.push(key);
+            }
+        }
+        for (const key of keysToDel) {
+            this.map.delete(key);
+        }
         return this;
     }
 


### PR DESCRIPTION
This change reduces dictionary reload for long running processes.

The dictionary loader uses a WeakMap to keep dictionaries. This is very effective for keeping the memory size down when using the command-line tool. But, it also throws out dictionaries too soon when the spell checker is used as part of a server. To address this, the dictionary loader keep the most recent 10-20 loaded dictionaries in memory.