### PR TITLE
feat: Add untrusted mode to the config loader

### DIFF
--- a/packages/cspell-config-lib/src/CSpellConfigFileReaderWriter.ts
+++ b/packages/cspell-config-lib/src/CSpellConfigFileReaderWriter.ts
@@ -1,3 +1,5 @@
+import { extname } from 'node:path/posix';
+
 import type { CSpellConfigFile, ICSpellConfigFile } from './CSpellConfigFile.js';
 import type { FileLoaderMiddleware } from './FileLoader.js';
 import type { IO } from './IO.js';
@@ -13,6 +15,17 @@ export interface CSpellConfigFileReaderWriter {
     readConfig(uri: URL | string): Promise<CSpellConfigFile>;
     writeConfig(configFile: CSpellConfigFile): Promise<TextFileRef>;
     clearCachedFiles(): void;
+    setUntrustedExtensions(ext: readonly string[]): this;
+    setTrustedUrls(urls: readonly (URL | string)[]): this;
+    /**
+     * Untrusted extensions are extensions that are not trusted to be loaded from a file system.
+     * Extension are case insensitive and should include the leading dot.
+     */
+    readonly untrustedExtensions: string[];
+    /**
+     * Urls starting with these urls are trusted to be loaded from a file system.
+     */
+    readonly trustedUrls: URL[];
 }
 
 export class CSpellConfigFileReaderWriterImpl implements CSpellConfigFileReaderWriter {
@@ -27,7 +40,30 @@ export class CSpellConfigFileReaderWriterImpl implements CSpellConfigFileReaderW
         readonly loaders: FileLoaderMiddleware[],
     ) {}
 
+    private _untrustedExtensions = new Set<string>();
+    private _trustedUrls: string[] = [];
+
+    /**
+     * Untrusted extensions are extensions that are not trusted to be loaded from a file system.
+     * Extension are case insensitive and should include the leading dot.
+     */
+    get untrustedExtensions(): string[] {
+        return [...this._untrustedExtensions];
+    }
+
+    /**
+     * Urls starting with these urls are trusted to be loaded from a file system.
+     */
+    get trustedUrls(): URL[] {
+        return [...this._trustedUrls].map((url) => new URL(url));
+    }
+
     readConfig(uri: URL | string): Promise<CSpellConfigFile> {
+        const url = new URL(uri);
+        if (!isTrusted(url, this._trustedUrls, this._untrustedExtensions)) {
+            return Promise.reject(new UntrustedUrlError(url));
+        }
+
         const loader = getLoader(this.loaders);
         return loader({ url: toURL(uri), context: { deserialize: this.getDeserializer(), io: this.io } });
     }
@@ -48,9 +84,37 @@ export class CSpellConfigFileReaderWriterImpl implements CSpellConfigFileReaderW
         return { url: configFile.url };
     }
 
+    setUntrustedExtensions(ext: readonly string[]): this {
+        this._untrustedExtensions.clear();
+        ext.forEach((e) => this._untrustedExtensions.add(e.toLowerCase()));
+        return this;
+    }
+
+    setTrustedUrls(urls: readonly (URL | string)[]): this {
+        this._trustedUrls = [...new Set([...urls.map((url) => new URL(url).href)])].sort();
+        return this;
+    }
+
     clearCachedFiles(): void {
         for (const loader of this.loaders) {
             loader.reset?.();
         }
+    }
+}
+
+function isTrusted(url: URL, trustedUrls: string[], untrustedExtensions: Set<string>): boolean {
+    const path = url.pathname;
+    const ext = extname(path).toLowerCase();
+
+    if (!untrustedExtensions.has(ext)) return true;
+
+    const href = url.href;
+
+    return trustedUrls.some((trustedUrl) => href.startsWith(trustedUrl));
+}
+
+export class UntrustedUrlError extends Error {
+    constructor(url: URL) {
+        super(`Untrusted URL: "${url.href}"`);
     }
 }

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -453,6 +453,7 @@ interface IConfigLoader {
      * @returns the resulting settings
      */
     searchForConfig(searchFrom: URL | string | undefined, pnpSettings?: PnPSettingsOptional): Promise<CSpellSettingsI | undefined>;
+    resolveConfigFileLocation(filenameOrURL: string | URL, relativeTo?: string | URL): Promise<URL | undefined>;
     getGlobalSettingsAsync(): Promise<CSpellSettingsI>;
     /**
      * The loader caches configuration files for performance. This method clears the cache.
@@ -475,6 +476,8 @@ interface IConfigLoader {
      */
     dispose(): void;
     getStats(): Readonly<Record<string, Readonly<Record<string, number>>>>;
+    readonly isTrusted: boolean;
+    setIsTrusted(isTrusted: boolean): void;
 }
 declare function loadPnP(pnpSettings: PnPSettingsOptional, searchFrom: URL): Promise<LoaderResult>;
 declare function createConfigLoader(fs?: VFileSystem): IConfigLoader;

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
@@ -11,12 +11,13 @@ import {
     pathPackageSamples,
     pathPackageSamplesURL,
     pathRepoRoot,
+    pathRepoRootURL,
     pathRepoTestFixtures,
     pathRepoTestFixturesURL,
 } from '../../../../test-util/test.locations.cjs';
 import { logError, logWarning } from '../../../util/logger.js';
 import { resolveFileWithURL, toFilePathOrHref, toFileUrl } from '../../../util/url.js';
-import { currentSettingsFileVersion, ENV_CSPELL_GLOB_ROOT } from '../../constants.js';
+import { currentSettingsFileVersion, defaultConfigFileModuleRef, ENV_CSPELL_GLOB_ROOT } from '../../constants.js';
 import type { ImportFileRefWithError } from '../../CSpellSettingsServer.js';
 import { extractDependencies, getSources, mergeSettings } from '../../CSpellSettingsServer.js';
 import { _defaultSettings, getDefaultBundledSettingsAsync } from '../../DefaultSettings.js';
@@ -623,9 +624,10 @@ describe('Validate search/load config files', () => {
 
 describe('ConfigLoader with VirtualFS', () => {
     const publicURL = new URL('vscode-fs://github/streetsidesoftware/public-samples/');
+    const publicFileURL = new URL('file:///public-samples/');
 
-    function pURL(path: string): URL {
-        return new URL(path, publicURL);
+    function pURL(path: string, rel = publicURL): URL {
+        return new URL(path, rel);
     }
 
     test.each`
@@ -657,11 +659,12 @@ describe('ConfigLoader with VirtualFS', () => {
     });
 
     test.each`
-        file                       | expectedConfig                                                         | expectedImportErrors
-        ${'README.md'}             | ${cfg(pURL('.cspell.json'), {})}                                       | ${[]}
-        ${'bug-fixes/bug345.ts'}   | ${cfg(pURL('bug-fixes/cspell.json'), {})}                              | ${[]}
-        ${'linked/file.txt'}       | ${cfg(pURL('linked/cspell.config.js'), { __importRef: undefined })}    | ${[]}
-        ${'yaml-config/README.md'} | ${cfg(pURL('yaml-config/cspell.yaml'), { id: 'Yaml Example Config' })} | ${['cspell-imports.json']}
+        file                                    | expectedConfig                                                                   | expectedImportErrors
+        ${'README.md'}                          | ${cfg(pURL('.cspell.json'), {})}                                                 | ${[]}
+        ${'bug-fixes/bug345.ts'}                | ${cfg(pURL('bug-fixes/cspell.json'), {})}                                        | ${[]}
+        ${uh('linked/file.txt', publicFileURL)} | ${cfg(uh('linked/cspell.config.js', publicFileURL), { __importRef: undefined })} | ${[]}
+        ${'linked/file.txt'}                    | ${cfg(pURL('.cspell.json') /* .js not loaded */, {})}                            | ${[]}
+        ${'yaml-config/README.md'}              | ${cfg(pURL('yaml-config/cspell.yaml'), { id: 'Yaml Example Config' })}           | ${['cspell-imports.json']}
     `('Search check from $file', async ({ file, expectedConfig, expectedImportErrors }) => {
         const vfs = createVirtualFS();
         const redirectProvider = createRedirectProvider('test', publicURL, sURL('./'));
@@ -684,6 +687,82 @@ describe('ConfigLoader with VirtualFS', () => {
                 ),
             ),
         );
+    });
+
+    test.each`
+        file                       | expectedConfig                                                                     | expectedImportErrors
+        ${'README.md'}             | ${cfg(u('.cspell.json', publicFileURL), {})}                                       | ${[]}
+        ${'bug-fixes/bug345.ts'}   | ${cfg(u('bug-fixes/cspell.json', publicFileURL), {})}                              | ${[]}
+        ${'linked/file.txt'}       | ${cfg(u('.cspell.json', publicFileURL) /* not trusted == .js not loaded */, {})}   | ${[]}
+        ${'yaml-config/README.md'} | ${cfg(u('yaml-config/cspell.yaml', publicFileURL), { id: 'Yaml Example Config' })} | ${['cspell-imports.json']}
+    `('Search untrusted $file', async ({ file, expectedConfig, expectedImportErrors }) => {
+        const vfs = createVirtualFS();
+        const redirectProvider = createRedirectProvider('test', publicFileURL, sURL('./'));
+        vfs.registerFileSystemProvider(redirectProvider);
+
+        const fileURL = u(file, publicFileURL);
+        const loader = createConfigLoader(vfs.fs);
+        loader.setIsTrusted(false);
+
+        const searchResult = await loader.searchForConfig(fileURL);
+        expect(searchResult?.__importRef).toEqual(
+            expectedConfig.__importRef ? expect.objectContaining(expectedConfig.__importRef) : undefined,
+        );
+        // expect(searchResult).toEqual(expect.objectContaining(expectedConfig));
+        const errors = extractImportErrors(searchResult || {});
+        expect(errors).toHaveLength(expectedImportErrors.length);
+        expect(errors).toEqual(
+            expect.arrayContaining(
+                (expectedImportErrors as string[]).map((filename) =>
+                    expect.objectContaining({ filename: expect.stringContaining(filename) }),
+                ),
+            ),
+        );
+    });
+
+    test.each`
+        file                          | expectedConfig
+        ${'./.cspell.json'}           | ${cf(u('.cspell.json', publicFileURL), {})}
+        ${'./bug-fixes/cspell.json'}  | ${cf(u('bug-fixes/cspell.json', publicFileURL), {})}
+        ${defaultConfigFileModuleRef} | ${cf(u('packages/cspell-bundled-dicts/cspell-default.json', pathRepoRootURL), {})}
+    `('Search resolve untrusted $file', async ({ file, expectedConfig }) => {
+        const vfs = createVirtualFS();
+        const redirectProvider = createRedirectProvider('test', publicFileURL, sURL('./'));
+        vfs.registerFileSystemProvider(redirectProvider);
+        const loader = createConfigLoader(vfs.fs);
+        loader.setIsTrusted(false);
+
+        const location = await loader.resolveConfigFileLocation(file, publicFileURL);
+
+        const configFile = await loader.readConfigFile(file, publicFileURL);
+
+        expect(configFile).not.toBeInstanceOf(Error);
+        assert(!(configFile instanceof Error));
+        expect(configFile.url.href).toBe(location?.href);
+        expect(configFile.url.href).toBe(expectedConfig.url.href);
+
+        const config = await loader.mergeConfigFileWithImports(configFile);
+        expect(config).toBeDefined();
+        const errors = extractImportErrors(config);
+        expect(errors).toHaveLength(0);
+    });
+
+    test.each`
+        file
+        ${'./linked/cspell.config.js'}
+    `('Error reading untrusted $file', async ({ file }) => {
+        const vfs = createVirtualFS();
+        const redirectProvider = createRedirectProvider('test', publicFileURL, sURL('./'));
+        vfs.registerFileSystemProvider(redirectProvider);
+        const loader = createConfigLoader(vfs.fs);
+        loader.setIsTrusted(false);
+
+        const location = await loader.resolveConfigFileLocation(file, publicFileURL);
+        const configFile = await loader.readConfigFile(file, publicFileURL);
+
+        expect(configFile).toBeInstanceOf(Error);
+        assert(configFile instanceof Error);
+        expect(configFile.cause).toEqual(Error(`Untrusted URL: "${location?.href}"`));
     });
 });
 

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.test.ts
@@ -624,7 +624,7 @@ describe('Validate search/load config files', () => {
 
 describe('ConfigLoader with VirtualFS', () => {
     const publicURL = new URL('vscode-fs://github/streetsidesoftware/public-samples/');
-    const publicFileURL = new URL('file:///public-samples/');
+    const publicFileURL = new URL('public-sample/', pathToFileURL(path.resolve('/')));
 
     function pURL(path: string, rel = publicURL): URL {
         return new URL(path, rel);

--- a/packages/cspell-lib/src/lib/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DefaultSettings.ts
@@ -6,12 +6,11 @@ import type { CSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef
 import { createCSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef.js';
 import { PatternRegExp } from '../Models/PatternRegExp.js';
 import { resolveFile } from '../util/resolveFile.js';
+import { defaultConfigFileModuleRef } from './constants.js';
 import { readSettings } from './Controller/configLoader/index.js';
 import { mergeSettings } from './CSpellSettingsServer.js';
 import * as LanguageSettings from './LanguageSettings.js';
 import * as RegPat from './RegExpPatterns.js';
-
-const defaultConfigFileModuleRef = '@cspell/cspell-bundled-dicts/cspell-default.json';
 
 // Do not use require.resolve because webpack will mess it up.
 const defaultConfigFile = () => resolveConfigModule(defaultConfigFileModuleRef);

--- a/packages/cspell-lib/src/lib/Settings/constants.ts
+++ b/packages/cspell-lib/src/lib/Settings/constants.ts
@@ -2,3 +2,4 @@ export const configSettingsFileVersion0_1 = '0.1';
 export const configSettingsFileVersion0_2 = '0.2';
 export const currentSettingsFileVersion = configSettingsFileVersion0_2;
 export const ENV_CSPELL_GLOB_ROOT = 'CSPELL_GLOB_ROOT';
+export const defaultConfigFileModuleRef = '@cspell/cspell-bundled-dicts/cspell-default.json';


### PR DESCRIPTION
There are times it is necessary to prevent loading JavaScript based configuration.

It is now possible to switch the config loader into untrusted mode. In this mode, the loader will not load JavaScript files outside of the CSpell configuration.

This is to support: [Workspace Trust Extension Guide | Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)