### PR TITLE
fix: cspell-tools - support excluding words

### DIFF
--- a/packages/cspell-tools/fixtures/build-exclude/cspell-tools.config.yaml
+++ b/packages/cspell-tools/fixtures/build-exclude/cspell-tools.config.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=./../../cspell-tools.config.schema.json
+
+targets:
+  - name: colors
+    targetDirectory: ../../temp/builds/build-exclude
+    sources:
+      - filename: src/words.txt
+        split: true
+      - ../dicts/colors.txt
+    format: plaintext

--- a/packages/cspell-tools/fixtures/build-exclude/src/exclude.txt
+++ b/packages/cspell-tools/fixtures/build-exclude/src/exclude.txt
@@ -1,0 +1,5 @@
+# Words to exclucde
+green
+purple
+London
+paris

--- a/packages/cspell-tools/fixtures/build-exclude/src/words.txt
+++ b/packages/cspell-tools/fixtures/build-exclude/src/words.txt
@@ -1,0 +1,4 @@
+apple
+banana
+apple‌banana
+grape

--- a/packages/cspell-tools/src/__snapshots__/build.test.ts.snap
+++ b/packages/cspell-tools/src/__snapshots__/build.test.ts.snap
@@ -131,6 +131,27 @@ strawberry
 "
 `;
 
+exports[`build action > build 6 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+apple
+banana
+black
+blue
+cyan
+grape
+green
+magenta
+orange
+pink
+purple
+red
+white
+yellow
+"
+`;
+
 exports[`build action > build multi 0 1`] = `
 "
 # cspell-tools: keep-case no-split

--- a/packages/cspell-tools/src/build.test.ts
+++ b/packages/cspell-tools/src/build.test.ts
@@ -27,6 +27,7 @@ describe('build action', () => {
         ${f('build-source-list')}        | ${undefined}                                              | ${tBuilds('build-source-list/source-list.txt')}
         ${'.'}                           | ${f('build-combo/cspell-tools.config.yaml')}              | ${'color-cities-code.txt'}
         ${f('build-split-source')}       | ${undefined}                                              | ${tBuilds('build-split-source/split-colors.txt')}
+        ${f('build-exclude')}            | ${undefined}                                              | ${tBuilds('build-exclude/colors.txt')}
     `('build %#', async ({ sourceRoot, config, target }) => {
         await expect(build(undefined, { config, root: t(sourceRoot), cwd: t() })).resolves.toBeUndefined();
         const content = await readTextFile(t(target));

--- a/packages/cspell-tools/src/compiler/CompileOptions.ts
+++ b/packages/cspell-tools/src/compiler/CompileOptions.ts
@@ -9,4 +9,11 @@ export interface CompileOptions {
      * Generate lower case / accent free versions of words.
      */
     generateNonStrict: boolean;
+
+    /**
+     * Optional filter function to filter out words.
+     * @param word the word to test
+     * @returns `true` to keep the word, `false` to exclude it.
+     */
+    filter?: (word: string) => boolean;
 }

--- a/packages/cspell-tools/src/compiler/__snapshots__/compile.test.ts.snap
+++ b/packages/cspell-tools/src/compiler/__snapshots__/compile.test.ts.snap
@@ -305,3 +305,33 @@ Error+
 msg
 "
 `;
+
+exports[`compile > compile filtered 'dicts/cities.txt', excludeWordsFrom: [ 'build-exclude/src/exclude.txt' ] 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+Los Angeles
+Mexico City
+New Amsterdam
+New Delhi
+New York
+Paris
+San Francisco
+"
+`;
+
+exports[`compile > compile filtered 'dicts/colors.txt', excludeWordsFrom: [ 'build-exclude/src/exclude.txt' ] 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+black
+blue
+cyan
+magenta
+orange
+pink
+red
+white
+yellow
+"
+`;

--- a/packages/cspell-tools/src/compiler/wordListParser.ts
+++ b/packages/cspell-tools/src/compiler/wordListParser.ts
@@ -17,6 +17,7 @@ export function normalizeTargetWords(options: CompileOptions): Operator<string> 
         lineParser,
         options.sort ? createInlineBufferedSort(10000) : undefined,
         opFilter<string>(uniqueFilter(10000)),
+        options.filter ? opFilter<string>(options.filter) : undefined,
     ].filter(isDefined);
     return opCombine(...operations);
 }

--- a/packages/cspell-tools/src/config/config.ts
+++ b/packages/cspell-tools/src/config/config.ts
@@ -100,7 +100,7 @@ export interface Target extends CompileTargetOptions {
      * Words from the sources that are found in `excludeWordsFrom` files
      * will not be added to the dictionary.
      *
-     * @version TBD
+     * @version 8.3.2
      */
     excludeWordsFrom?: FilePath[] | undefined;
 

--- a/packages/cspell-tools/src/test/TestHelper.ts
+++ b/packages/cspell-tools/src/test/TestHelper.ts
@@ -12,7 +12,9 @@ const tempDirBase = path.join(packageRoot, 'temp');
 const repoSamples = path.join(repoRoot, 'packages/Samples');
 
 export interface TestHelper {
+    /** path to `.../cspell/package/cspell-tools/` */
     readonly packageRoot: string;
+    /** path to `...cspell/` */
     readonly repoRoot: string;
     readonly tempDir: string;
 


### PR DESCRIPTION
When compiling a word list, support excluding words based upon another word list.

This helps reduce the size of a dictionary.