### PR TITLE
feat: Support sharing cache between windows and linux

### DIFF
--- a/packages/cspell/fixtures/features/cached/cspell.json
+++ b/packages/cspell/fixtures/features/cached/cspell.json
@@ -3,7 +3,8 @@
     "version": "0.2",
     "cache": {
         "useCache": true,
-        "cacheLocation": ".cspellcache"
+        "cacheLocation": ".cspellcache",
+        "cacheFormat": "legacy"
     },
     "files": ["*.md"]
 }

--- a/packages/cspell/src/app/application.test.ts
+++ b/packages/cspell/src/app/application.test.ts
@@ -237,10 +237,16 @@ describe('Linter File Caching', () => {
     }
 
     const NoCache: LinterOptions = { cache: false };
-    const Config: LinterOptions = {};
-    const WithCache: LinterOptions = { cache: true, cacheStrategy: 'metadata' };
-    const WithCacheReset: LinterOptions = { cache: true, cacheStrategy: 'metadata', cacheReset: true };
-    const CacheContent: LinterOptions = { cache: true, cacheStrategy: 'content' };
+    const Config: LinterOptions = { cacheFormat: 'legacy' };
+    const WithCache: LinterOptions = { cache: true, cacheStrategy: 'metadata', cacheFormat: 'legacy' };
+    // const WithCacheUniversal: LinterOptions = { cache: true, cacheStrategy: 'metadata' };
+    const WithCacheReset: LinterOptions = {
+        cache: true,
+        cacheStrategy: 'metadata',
+        cacheReset: true,
+        cacheFormat: 'legacy',
+    };
+    const CacheContent: LinterOptions = { cache: true, cacheStrategy: 'content', cacheFormat: 'legacy' };
 
     test.each`
         runs                                                                                                                           | root            | comment
@@ -257,13 +263,16 @@ describe('Linter File Caching', () => {
         const cacheLocation = tempLocation('.cspellcache');
         await fs.rm(cacheLocation, { recursive: true }).catch(() => undefined);
 
+        let r = 0;
+
         for (const run of runs) {
+            ++r;
             const { fileGlobs, options, expected } = run;
             const useOptions = { ...options, cacheLocation };
             useOptions.root = root;
             const result = await App.lint(fileGlobs, useOptions, reporter);
             expect(reporter.errors).toEqual([]);
-            expect(result).toEqual(oc(expected));
+            expect(result, `run #${r}`).toEqual(oc(expected));
         }
     });
 });

--- a/packages/cspell/src/app/util/cache/createCache.test.ts
+++ b/packages/cspell/src/app/util/cache/createCache.test.ts
@@ -86,7 +86,7 @@ function cco(
     useCache = false,
     cacheLocation = '.cspellcache',
     cacheStrategy: CreateCacheSettings['cacheStrategy'] = 'metadata',
-    cacheFormat: CreateCacheSettings['cacheFormat'] = 'legacy',
+    cacheFormat: CreateCacheSettings['cacheFormat'] = 'universal',
 ): CreateCacheSettings {
     if (cacheLocation) {
         cacheLocation = path.resolve(process.cwd(), cacheLocation);

--- a/packages/cspell/src/app/util/cache/createCache.ts
+++ b/packages/cspell/src/app/util/cache/createCache.ts
@@ -53,7 +53,7 @@ export async function calcCacheSettings(
     );
 
     const cacheStrategy = cacheOptions.cacheStrategy ?? cs.cacheStrategy ?? 'metadata';
-    const cacheFormat = cacheOptions.cacheFormat ?? cs.cacheFormat ?? 'legacy';
+    const cacheFormat = cacheOptions.cacheFormat ?? cs.cacheFormat ?? 'universal';
     const optionals: Partial<CreateCacheSettings> = {};
     if (cacheOptions.cacheReset) {
         optionals.reset = true;

--- a/packages/cspell/src/app/util/cache/fileEntryCache.ts
+++ b/packages/cspell/src/app/util/cache/fileEntryCache.ts
@@ -60,7 +60,7 @@ export function createFromFile(pathToCache: string, useCheckSum: boolean, useRel
     return cacheWrapper;
 
     function resolveFile(cwd: string, file: string): string {
-        if (!useRelative) return file;
+        if (!useRelative) return normalizePath(file);
         const r = path.relative(relDir, path.resolve(cwd, file));
         return normalizePath(r);
     }

--- a/packages/cspell/src/app/util/cache/fileEntryCache.ts
+++ b/packages/cspell/src/app/util/cache/fileEntryCache.ts
@@ -83,8 +83,6 @@ export function createFromFile(pathToCache: string, useCheckSum: boolean, useRel
 }
 
 export function normalizePath(filePath: string): string {
-    return filePath;
-
-    // if (path.sep !== '\\') return filePath;
-    // return filePath.replace(/\\/g, '/');
+    if (path.sep === '/') return filePath;
+    return filePath.split(path.sep).join('/');
 }


### PR DESCRIPTION
fixes: #5246

- Defaults to the `universal` format instead of legacy.
- Path separators are converted to `/` before being stored.