### PR TITLE
fix: `--no-exit-code` will allow running even if there are config errors

### DIFF
--- a/packages/cspell/src/app/lint/lint.ts
+++ b/packages/cspell/src/app/lint/lint.ts
@@ -441,7 +441,7 @@ export async function runLint(cfg: LintRequest): Promise<RunResult> {
         reporter.info(`Config Files Found:\n    ${configInfo.source}\n`, MessageTypes.Info);
 
         const configErrors = await countConfigErrors(configInfo);
-        if (configErrors) return runResult({ errors: configErrors });
+        if (configErrors && cfg.options.exitCode !== false) return runResult({ errors: configErrors });
 
         // Get Exclusions from the config files.
         const { root } = cfg;


### PR DESCRIPTION
Configuration errors would block the spell checker from running. Using the `--no-exit-code` option will report the issue, but not prevent it from running to completion.

Related to #5334 

