### PR TITLE
fix: Adding `defineConfig()` to `cspell-types`

### DIFF
--- a/packages/cspell-types/src/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-types/src/__snapshots__/index.test.ts.snap
@@ -5,5 +5,6 @@ exports[`Validate that the types build > Make sure exports do not change. 1`] = 
   "ConfigFields",
   "IssueType",
   "MessageTypes",
+  "defineConfig",
 ]
 `;

--- a/packages/cspell-types/src/defineConfig.test.ts
+++ b/packages/cspell-types/src/defineConfig.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+
+import { defineConfig } from './defineConfig.js';
+
+describe('defineConfig', () => {
+    test('defineConfig is a pure pass-through', () => {
+        const config = { name: 'test' };
+        Object.freeze(config);
+        expect(defineConfig(config)).toBe(config);
+    });
+});

--- a/packages/cspell-types/src/defineConfig.ts
+++ b/packages/cspell-types/src/defineConfig.ts
@@ -1,0 +1,5 @@
+import { CSpellSettings } from "./CSpellSettingsDef";
+
+export function defineConfig(config: CSpellSettings) {
+	return config;
+}

--- a/packages/cspell-types/src/index.ts
+++ b/packages/cspell-types/src/index.ts
@@ -112,3 +112,4 @@ export type { ParsedText, Parser, ParseResult, ParserName, ParserOptions } from 
 export type { SuggestionCostMapDef, SuggestionCostsDefs } from './suggestionCostsDef.js';
 export type { MappedText } from './TextMap.js';
 export type { TextDocumentOffset, TextOffset } from './TextOffset.js';
+export { defineConfig } from "./defineConfig.js"


### PR DESCRIPTION
Closes #5358 