### PR TITLE
test: Use httpbingo instead of httpbin

### DIFF
--- a/packages/cspell-io/src/node/file/fetch.test.ts
+++ b/packages/cspell-io/src/node/file/fetch.test.ts
@@ -5,8 +5,6 @@ import { fetchHead, fetchURL } from './fetch.js';
 
 const timeout = 20000;
 
-const testOptions = { timeout };
-
 describe('fetch', () => {
     test(
         'fetch url',
@@ -16,7 +14,7 @@ describe('fetch', () => {
             expect(response.ok).toBe(true);
             expect(await response.text()).toMatch('Example Domain');
         },
-        testOptions,
+        timeout,
     );
 
     test(
@@ -26,7 +24,7 @@ describe('fetch', () => {
             const response = await fetchURL(url);
             expect(response).toBeInstanceOf(Buffer);
         },
-        testOptions,
+        timeout,
     );
 
     /*
@@ -55,7 +53,7 @@ describe('fetch', () => {
             expect(response.get('etag')).toEqual(expect.any(String));
             expect(Number.parseInt(response.get('content-length') || '', 10)).toBeGreaterThan(0);
         },
-        testOptions,
+        timeout,
     );
 
     test.each`
@@ -69,7 +67,7 @@ describe('fetch', () => {
             url = new URL(url);
             await expect(fetchURL(url)).rejects.toThrowError(expected);
         },
-        testOptions,
+        timeout,
     );
 });
 

--- a/packages/cspell-io/src/node/file/fetch.test.ts
+++ b/packages/cspell-io/src/node/file/fetch.test.ts
@@ -59,10 +59,10 @@ describe('fetch', () => {
     );
 
     test.each`
-        url                                | expected
-        ${'https://x.example.com/'}        | ${'getaddrinfo ENOTFOUND x.example.com'}
-        ${'https://www.google.com/404'}    | ${/URL not found|getaddrinfo EAI_AGAIN/}
-        ${'http://httpbin.org/status/503'} | ${'Fatal Error'}
+        url                                   | expected
+        ${'https://x.example.com/'}           | ${'getaddrinfo ENOTFOUND x.example.com'}
+        ${'https://www.google.com/404'}       | ${/URL not found|getaddrinfo EAI_AGAIN/}
+        ${'https://httpbingo.org/status/503'} | ${'Fatal Error'}
     `(
         'fetchURL with error',
         async ({ url, expected }) => {

--- a/packages/cspell-io/src/node/file/stat.test.ts
+++ b/packages/cspell-io/src/node/file/stat.test.ts
@@ -17,10 +17,10 @@ describe('stat', () => {
     });
 
     test.each`
-        url                                | expected
-        ${'https://www.google.com/404'}    | ${oc({ message: 'URL not found.', code: 'ENOENT' })}
-        ${'http://httpbin.org/status/503'} | ${oc({ message: 'Fatal Error' })}
-        ${join(__dirname, 'not-found.nf')} | ${oc({ code: 'ENOENT' })}
+        url                                   | expected
+        ${'https://www.google.com/404'}       | ${oc({ message: 'URL not found.', code: 'ENOENT' })}
+        ${'https://httpbingo.org/status/503'} | ${oc({ message: 'Fatal Error' })}
+        ${join(__dirname, 'not-found.nf')}    | ${oc({ code: 'ENOENT' })}
     `('getStat with error $url', async ({ url, expected }) => {
         const r = await getStat(url);
         expect(r).toEqual(expected);

--- a/packages/cspell-io/src/node/file/stat.test.ts
+++ b/packages/cspell-io/src/node/file/stat.test.ts
@@ -6,6 +6,8 @@ import { getStat, getStatSync } from './stat.js';
 const oc = expect.objectContaining;
 const sc = expect.stringContaining;
 
+const timeout = 20000;
+
 describe('stat', () => {
     test.each`
         url                                                                                 | expected
@@ -21,10 +23,14 @@ describe('stat', () => {
         ${'https://www.google.com/404'}       | ${oc({ message: 'URL not found.', code: 'ENOENT' })}
         ${'https://httpbingo.org/status/503'} | ${oc({ message: 'Fatal Error' })}
         ${join(__dirname, 'not-found.nf')}    | ${oc({ code: 'ENOENT' })}
-    `('getStat with error $url', async ({ url, expected }) => {
-        const r = await getStat(url);
-        expect(r).toEqual(expected);
-    });
+    `(
+        'getStat with error $url',
+        async ({ url, expected }) => {
+            const r = await getStat(url);
+            expect(r).toEqual(expected);
+        },
+        timeout,
+    );
 
     test.each`
         url           | expected


### PR DESCRIPTION
https://httpbingo.org

http://httpbin.org has been timing out lately.
It is no longer actively maintained. See: https://github.com/postmanlabs/httpbin/issues/