### PR TITLE
chore: prevent the summary from failing the build

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -231,6 +231,8 @@ jobs:
       - prepare
       - pre-build
     runs-on: ubuntu-latest
+    # We do not want to fail the build if the user does not have permissions to comment on the PR.
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Writing a comment to a PR needs special permission. For now, just just skip it if it fails.

See: [mshick/add-pr-comment](https://github.com/mshick/add-pr-comment/tree/main#proxy-for-fork-based-prs)