### PR TITLE
docs: Fix link to Dictionaries

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -78,7 +78,7 @@ Or you can specify a path to a config file with the `--config <path>` argument o
 - `maxNumberOfProblems` - defaults to **_100_** per file.
 - `minWordLength` - defaults to **_4_** - the minimum length of a word before it is checked.
 - `allowCompoundWords` - defaults to **_false_**; set to **true** to allow compound words by default.
-- `dictionaries` - list of the names of the dictionaries to use. See [Dictionaries](#Dictionaries) below.
+- `dictionaries` - list of the names of the dictionaries to use. See [Dictionaries](../docs/dictionaries.md) below.
 - `dictionaryDefinitions` - this list defines any custom dictionaries to use. This is how you can include other languages like Spanish.
 
   **Example**


### PR DESCRIPTION
Fix https://github.com/streetsidesoftware/cspell/issues/5579

> In the [Configuration](https://cspell.org/configuration/#cspelljson-sections) documentation, the link to the Dictionaries doesn't work.