### PR TITLE
fix: lock version of `micromatch`

### DIFF
--- a/packages/cspell-glob/package.json
+++ b/packages/cspell-glob/package.json
@@ -50,7 +50,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "micromatch": "^4.0.5"
+    "micromatch": "4.0.5"
   },
   "devDependencies": {
     "@types/micromatch": "^4.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,7 +544,7 @@ importers:
   packages/cspell-glob:
     dependencies:
       micromatch:
-        specifier: ^4.0.5
+        specifier: 4.0.5
         version: 4.0.5
     devDependencies:
       '@types/micromatch':


### PR DESCRIPTION
The behavior on Windows has changed. Until that is fixed, lock the version to `4.0.5`.

See: https://github.com/micromatch/micromatch/issues/256