### PR TITLE
fix: Make sure binary files are not checked.

### DIFF
--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -45,7 +45,7 @@ interface DocumentWithText extends Document {
     text: string;
 }
 
-declare function isBinaryFile(filename: Uri | URL | string, languageId?: string | string[]): boolean;
+declare function isBinaryFile(filename: Uri | URL | string, languageId?: string | string[], text?: string): boolean;
 
 type DocumentUri = Uri;
 interface Position {

--- a/packages/cspell-lib/src/lib/Document/isBinaryDoc.test.ts
+++ b/packages/cspell-lib/src/lib/Document/isBinaryDoc.test.ts
@@ -1,0 +1,25 @@
+/* eslint-disable unicorn/no-hex-escape */
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+import { isBinaryDoc } from './isBinaryDoc.js';
+
+describe('isBinaryDoc', () => {
+    test.each`
+        uri                | languageId      | text                               | expected
+        ${import.meta.url} | ${'typescript'} | ${'console.log("Hello, World!");'} | ${false}
+        ${import.meta.url} | ${undefined}    | ${undefined}                       | ${false}
+        ${uh('image.jpg')} | ${undefined}    | ${undefined}                       | ${true}
+        ${uh('film.mp4')}  | ${undefined}    | ${'\x00\x00\x00\x00'}              | ${true}
+        ${uh('film.mp4')}  | ${undefined}    | ${undefined}                       | ${true}
+        ${uh('data.bin')}  | ${undefined}    | ${'\x00\x00\x00\x00'}              | ${true}
+        ${uh('data.dat')}  | ${undefined}    | ${'\x00\x00\x00\x00'}              | ${true}
+    `('isBinaryDoc $uri $languageId', ({ uri, languageId, text, expected }) => {
+        expect(isBinaryDoc({ uri, languageId, text })).toBe(expected);
+    });
+});
+
+function uh(file: string) {
+    return pathToFileURL(file).href;
+}

--- a/packages/cspell-lib/src/lib/Document/isBinaryDoc.ts
+++ b/packages/cspell-lib/src/lib/Document/isBinaryDoc.ts
@@ -1,19 +1,22 @@
-import { isGenerated, isGeneratedFile } from '../LanguageIds.js';
+import { getLanguagesForBasename, isGenerated } from '../LanguageIds.js';
 import type { Uri } from '../util/Uri.js';
 import { basename, toUri } from '../util/Uri.js';
 import type { Document } from './Document.js';
 import { normalizeLanguageIds } from './normalizeLanguageIds.js';
 
 export function isBinaryDoc(document: Document): boolean {
-    return isBinaryFile(toUri(document.uri), document.languageId);
+    return isBinaryFile(toUri(document.uri), document.languageId, document.text);
 }
 
-export function isBinaryFile(filename: Uri | URL | string, languageId?: string | string[]): boolean {
+export function isBinaryFile(filename: Uri | URL | string, languageId?: string | string[], text?: string): boolean {
     const filenameUri = toUri(filename);
     if (languageId) {
         const ids = normalizeLanguageIds(languageId);
         if (ids.length) return isGenerated(ids);
     }
     const file = basename(filenameUri);
-    return isGeneratedFile(file);
+    const ids = getLanguagesForBasename(file);
+    if (ids.length) return isGenerated(ids);
+    // Unknown file type, check the content.
+    return text?.slice(0, 1024).includes('\u0000') || false;
 }

--- a/packages/cspell-lib/src/lib/LanguageIds.ts
+++ b/packages/cspell-lib/src/lib/LanguageIds.ts
@@ -241,7 +241,7 @@ export const languageExtensionDefinitions: LanguageDefinitions = [
     },
     {
         id: 'video',
-        extensions: ['.mov', '.mpg'],
+        extensions: ['.mov', '.mpg', '.mpeg', '.mp4', '.avi', '.wmv', '.mkv', '.flv'],
         format: 'Binary',
     },
     {

--- a/packages/cspell-lib/src/lib/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/lib/spellCheckFile.test.ts
@@ -149,6 +149,7 @@ describe('Validate Spell Checking Documents', () => {
         ${f('.cspellcache')}                              | ${''}           | ${{}}                          | ${{}}                                           | ${{ checked: false, errors: undefined }}
         ${f('.eslintcache')}                              | ${''}           | ${{}}                          | ${{}}                                           | ${{ checked: false, errors: undefined }}
         ${d(f('src/big_image.txt'), undefined, 'binary')} | ${''}           | ${{}}                          | ${{}}                                           | ${{ checked: false, errors: undefined }}
+        ${d(f('src/data.dat'), '\u0000\u0000\u0000')}     | ${''}           | ${{}}                          | ${{}}                                           | ${{ checked: false, errors: undefined }}
         ${f('./ruby/Gemfile')}                            | ${''}           | ${{}}                          | ${{}}                                           | ${{ checked: true, errors: undefined, settingsUsed: oc({ languageId: 'ruby' }) }}
     `(
         'spellCheckFile $uri $settings $options',

--- a/packages/cspell-lib/src/lib/spellCheckFile.ts
+++ b/packages/cspell-lib/src/lib/spellCheckFile.ts
@@ -95,6 +95,17 @@ export async function spellCheckDocument(
     try {
         const timer = createPerfTimer('loadFile');
         const doc = await resolveDocument(document).finally(() => timer.end());
+        if (isBinaryDoc(doc)) {
+            return {
+                document,
+                options,
+                settingsUsed: settings,
+                localConfigFilepath: undefined,
+                issues: [],
+                checked: false,
+                errors: undefined,
+            };
+        }
         const result = await spellCheckFullDocument(doc, options, settings);
         const perf = result.perf || {};
         perf.loadTimeMs = timer.elapsed;


### PR DESCRIPTION
fixes #5779

- add `.mp4` to the video list
- treat unknown file types that contain 0x00 as binary.