### PR TITLE
fix: trie lookup performance

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,6 +18,7 @@ on:
       - 'packages/**/package.json'
       - 'packages/**/*-lock.yaml'
       - 'packages/**/*.ts'
+      - 'packages/**/*.mts'
       - 'integration-tests/**'
       - '!integration-tests/perf/**'
       - 'package.json'
@@ -149,9 +150,14 @@ jobs:
               'integration-tests/config/repositories/${{matrix.repo}}/**',
               'integration-tests/snapshots/${{ matrix.repo }}/*',
               'integration-tests/repositories/*',
-              'integration-tests/src/**/*.ts', 'integration-tests/tsconfig.json',
-              'packages/*/src/**/*.ts', 'packages/*/tsconfig.json',
+              'integration-tests/src/**/*.ts',
+              'integration-tests/src/**/*.mts',
+              'integration-tests/tsconfig.json',
+              'packages/*/src/**/*.ts',
+              'packages/*/src/**/*.mts',
+              'packages/*/tsconfig.json',
               'packages/*/*.ts',
+              'packages/*/*.mts',
               'tools/perf-chart/lib/app.cjs',
               '*-lock.yaml'
             ) }}

--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionaryFromTrie.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionaryFromTrie.ts
@@ -211,18 +211,25 @@ function* outerWordForms(word: string, mapWord: (word: string) => string[]): Ite
     // Only generate the needed forms.
     const sent = new Set<string>();
     let w = word;
+    const ww = w;
     yield w;
     sent.add(w);
     w = word.normalize('NFC');
-    if (!sent.has(w)) yield w;
-    sent.add(w);
+    if (w !== ww) {
+        yield w;
+        sent.add(w);
+    }
     w = word.normalize('NFD');
-    if (!sent.has(w)) yield w;
-    sent.add(w);
-    for (const f of [...sent]) {
+    if (w !== ww && !sent.has(w)) {
+        yield w;
+        sent.add(w);
+    }
+    for (const f of sent) {
         for (const m of mapWord(f)) {
-            if (!sent.has(m)) yield m;
-            sent.add(m);
+            if (m !== ww && !sent.has(m)) {
+                yield m;
+                sent.add(m);
+            }
         }
     }
     return;

--- a/packages/cspell-dictionary/src/perf/has.perf.ts
+++ b/packages/cspell-dictionary/src/perf/has.perf.ts
@@ -18,17 +18,18 @@ suite('dictionary has', async (test) => {
     const dict3 = createSpellingDictionary(words3, 'test3', import.meta.url);
 
     const dictCol = createCollection([dict, dict2, dict3], 'test-collection');
+    const dictColRev = createCollection([dict3, dict2, dict], 'test-collection-reverse');
 
     test('dictionary has 100k words', () => {
         checkWords(dict, words);
     });
 
-    test('dictionary has 100k words (2nd time)', () => {
-        checkWords(dict, words);
-    });
-
     test('collection has 100k words', () => {
         checkWords(dictCol, words);
+    });
+
+    test('collection reverse has 100k words', () => {
+        checkWords(dictColRev, words);
     });
 
     test('iTrie has 100k words', () => {
@@ -58,10 +59,6 @@ suite('dictionary has Not', async (test) => {
     const dictCol = createCollection([dict, dict2, dict3], 'test-collection');
 
     test('dictionary has not 100k words', () => {
-        checkWords(dict, missingWords, false);
-    });
-
-    test('dictionary has not 100k words (2nd time)', () => {
         checkWords(dict, missingWords, false);
     });
 

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -533,6 +533,11 @@ interface ExtendedSuggestion {
      * The suggested word adjusted to match the original case.
      */
     wordAdjustedToMatchCase?: string;
+    /**
+     * The cost of using this word.
+     * The lower the cost, the better the suggestion.
+     */
+    cost?: number;
 }
 
 interface ValidationResult extends TextOffset, Pick<Issue, 'message' | 'issueType'> {

--- a/packages/cspell-lib/src/lib/Models/Suggestion.ts
+++ b/packages/cspell-lib/src/lib/Models/Suggestion.ts
@@ -11,4 +11,9 @@ export interface ExtendedSuggestion {
      * The suggested word adjusted to match the original case.
      */
     wordAdjustedToMatchCase?: string;
+    /**
+     * The cost of using this word.
+     * The lower the cost, the better the suggestion.
+     */
+    cost?: number;
 }

--- a/packages/cspell-lib/src/lib/suggestions.test.ts
+++ b/packages/cspell-lib/src/lib/suggestions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import type { SuggestionOptions } from './suggestions.js';
+import type { SuggestedWord, SuggestionOptions } from './suggestions.js';
 import { SuggestionError, suggestionsForWord, suggestionsForWords } from './suggestions.js';
 import { asyncIterableToArray } from './util/util.js';
 
@@ -22,6 +22,7 @@ describe('suggestions', () => {
         ${'apple'} | ${undefined}                            | ${{ dictionaries: ['en-gb'] }} | ${ac([sug('apple', 0, ['en_us', 'en-gb']), sug('Apple', 1, ['en_us', 'companies'])])}
     `(
         'suggestionsForWord default settings word: "$word", opts: $options, settings: $settings',
+        { timeout },
         async ({ word, options, settings, expected }) => {
             const results = await suggestionsForWord(word, options, settings);
             expect(results.word).toEqual(word);
@@ -32,7 +33,6 @@ describe('suggestions', () => {
             expect(resultsAsync[0].word).toEqual(word);
             expect(resultsAsync[0].suggestions).toEqual(expected);
         },
-        { timeout },
     );
 
     test.each`
@@ -40,18 +40,42 @@ describe('suggestions', () => {
         ${'apple'} | ${opt({ dictionaries: ['unknown'] })} | ${undefined}
     `(
         'suggestionsForWord ERRORS word: "$word", opts: $options, settings: $settings',
+        { timeout },
         async ({ word, options, settings }) => {
             await expect(suggestionsForWord(word, options, settings)).rejects.toThrow(SuggestionError);
         },
-        { timeout },
     );
-
-    function opt(opt: Partial<SuggestionOptions>): SuggestionOptions {
-        return opt;
-    }
-
-    function sug(word: string, cost: number, dicts: string[]) {
-        const dictionaries = [...dicts].sort();
-        return oc({ word, cost, dictionaries });
-    }
 });
+
+describe('Suggestions English', async () => {
+    // const configLoader = getDefaultConfigLoaderInternal();
+    // const settings = await configLoader.getGlobalSettingsAsync();
+
+    // cspell:ignore orangges
+    test('Orangges', async () => {
+        const results = await suggestionsForWord('orangges', { languageId: 'typescript', locale: 'en-US' }, {});
+        expect(results.suggestions).toEqual([
+            sug('oranges', 100),
+            sug('ranges', 185),
+            sug('orangs', 190),
+            sug('orange', 200),
+            sug('orangey', 200),
+            sug('orangier', 200),
+            sug('orangiest'),
+            sug('Orange', 201),
+        ]);
+    });
+});
+
+function opt(opt: Partial<SuggestionOptions>): SuggestionOptions {
+    return opt;
+}
+
+function sug(word: string, cost?: number, dicts?: string[]) {
+    const suggestedWord: Partial<SuggestedWord> = { word };
+    if (cost !== undefined) suggestedWord.cost = cost;
+    if (dicts) {
+        suggestedWord.dictionaries = [...dicts].sort();
+    }
+    return oc(suggestedWord);
+}

--- a/packages/cspell-lib/src/lib/textValidation/__snapshots__/docValidator.test.ts.snap
+++ b/packages/cspell-lib/src/lib/textValidation/__snapshots__/docValidator.test.ts.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`docValidator suggestions > suggestions 1`] = `
+[
+  {
+    "word": "oranges",
+    "wordAdjustedToMatchCase": "Oranges",
+  },
+  {
+    "word": "orange",
+  },
+  {
+    "word": "Orange",
+  },
+  {
+    "word": "orangs",
+    "wordAdjustedToMatchCase": "Orangs",
+  },
+  {
+    "word": "orange's",
+  },
+  {
+    "word": "Orange's",
+  },
+  {
+    "word": "ranges",
+    "wordAdjustedToMatchCase": "Ranges",
+  },
+  {
+    "word": "orangier",
+    "wordAdjustedToMatchCase": "Orangier",
+  },
+]
+`;

--- a/packages/cspell-lib/src/lib/textValidation/docValidator.test.ts
+++ b/packages/cspell-lib/src/lib/textValidation/docValidator.test.ts
@@ -283,6 +283,27 @@ describe('docValidator trace', () => {
     });
 });
 
+describe('docValidator suggestions', () => {
+    test('suggestions', async () => {
+        const doc = td(__filename, sampleCode());
+        const dVal = new DocumentValidator(doc, { generateSuggestions: true, numSuggestions: 8 }, {});
+        await dVal.prepare();
+        const issues = dVal.checkDocument();
+        expect(issues).toHaveLength(1);
+        expect(issues[0].suggestionsEx).toMatchSnapshot();
+    });
+});
+
+function sampleCode() {
+    // cspell:ignore Orangges
+    const text = `
+export function remainingOrangges(count: number): number {
+    return count % 42;
+}
+`;
+    return text;
+}
+
 function extractRawText(text: string, issues: ValidationIssue[]): string[] {
     return issues.map((issue) => {
         const start = issue.offset;

--- a/packages/cspell-tools/package.json
+++ b/packages/cspell-tools/package.json
@@ -63,7 +63,6 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@types/glob": "^8.1.0",
     "lorem-ipsum": "^2.0.8",
     "ts-json-schema-generator": "^2.3.0"
   },

--- a/packages/cspell-trie-lib/api/api.d.ts
+++ b/packages/cspell-trie-lib/api/api.d.ts
@@ -117,18 +117,16 @@ interface ITrieNode {
     readonly id: ITrieNodeId;
     /** flag End of Word */
     readonly eow: boolean;
-    /** number of children */
-    readonly size: number;
     /** get keys to children */
-    keys(): readonly string[];
+    keys(): Iterable<string>;
     /** get keys to children */
-    values(): readonly ITrieNode[];
+    values(): Iterable<ITrieNode>;
     /** get the children as key value pairs */
-    entries(): readonly Entry[];
+    entries(): Iterable<Entry>;
     /** get child ITrieNode */
     get(char: string): ITrieNode | undefined;
-    /** get a child by the key index */
-    child(idx: number): ITrieNode;
+    /** get a nested child ITrieNode */
+    getNode?: (chars: string) => ITrieNode | undefined;
     /** has child */
     has(char: string): boolean;
     /** `true` iff this node has children */
@@ -143,7 +141,7 @@ interface ITrieNodeRoot extends ITrieNode {
      * @param id an of a ITrieNode in this Trie
      */
     resolveId(id: ITrieNodeId): ITrieNode;
-    findExact?: ((word: string) => boolean) | undefined;
+    findExact: ((word: string) => boolean) | undefined;
     /**
      * Try to find a word.
      * @param word - the normalized word to look up.

--- a/packages/cspell-trie-lib/api/api.d.ts
+++ b/packages/cspell-trie-lib/api/api.d.ts
@@ -80,6 +80,11 @@ interface TrieInfo {
     forbiddenWordPrefix: string;
     isCaseAware: boolean;
 }
+interface TrieCharacteristics {
+    hasForbiddenWords: boolean;
+    hasCompoundWords: boolean;
+    hasNonStrictWords: boolean;
+}
 type PartialTrieInfo = PartialWithUndefined<TrieInfo> | undefined;
 
 interface FindResult$1 {
@@ -135,7 +140,7 @@ interface ITrieNode {
     findExact?: ((word: string) => boolean) | undefined;
 }
 interface ITrieNodeRoot extends ITrieNode {
-    info: Readonly<TrieInfo>;
+    readonly info: Readonly<TrieInfo>;
     /**
      * converts an `id` into a node.
      * @param id an of a ITrieNode in this Trie
@@ -150,9 +155,12 @@ interface ITrieNodeRoot extends ITrieNode {
      */
     find?: ((word: string, strict: boolean) => FindResult$1 | undefined) | undefined;
     isForbidden?: ((word: string) => boolean) | undefined;
-    forbidPrefix: string;
-    compoundFix: string;
-    caseInsensitivePrefix: string;
+    readonly forbidPrefix: string;
+    readonly compoundFix: string;
+    readonly caseInsensitivePrefix: string;
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
 }
 
 declare const FLAG_WORD = 1;
@@ -374,8 +382,8 @@ declare function suggestionCollector(wordToMatch: string, options: SuggestionCol
  */
 declare function impersonateCollector(collector: SuggestionCollector, word: string): SuggestionCollector;
 
-interface TrieData {
-    info: Readonly<TrieInfo>;
+interface TrieData extends Readonly<TrieCharacteristics> {
+    readonly info: Readonly<TrieInfo>;
     /** Method used to split words into individual characters. */
     wordToCharacters(word: string): readonly string[];
     /** get an iterable for all the words in the dictionary. */
@@ -384,8 +392,10 @@ interface TrieData {
     getNode(prefix: string): ITrieNode | undefined;
     has(word: string): boolean;
     isForbiddenWord(word: string): boolean;
-    hasForbiddenWords(): boolean;
-    size: number;
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+    readonly size: number;
 }
 
 interface ITrie {
@@ -461,12 +471,16 @@ interface ITrie {
      * On the returned Iterator, calling .next(goDeeper: boolean), allows for controlling the depth.
      */
     iterate(): WalkerIterator;
-    weightMap: WeightMap | undefined;
-    get isCaseAware(): boolean;
+    readonly weightMap: WeightMap | undefined;
+    readonly isCaseAware: boolean;
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
 }
 interface FindWordOptions$1 {
     caseSensitive?: boolean;
     useLegacyWordCompounds?: boolean | number;
+    checkForbidden?: boolean;
 }
 
 declare function buildITrieFromWords(words: Iterable<string>, info?: PartialTrieInfo): ITrie;

--- a/packages/cspell-trie-lib/src/lib/ITrie.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrie.ts
@@ -119,6 +119,8 @@ export class ITrieImpl implements ITrie {
     private root: ITrieNodeRoot;
     private count?: number;
     weightMap: WeightMap | undefined;
+    #optionsCompound = this.createFindOptions({ compoundMode: 'compound' });
+
     constructor(
         readonly data: TrieData,
         private numNodes?: number,
@@ -157,8 +159,7 @@ export class ITrieImpl implements ITrie {
      * @param text - text to find in the Trie
      */
     find(text: string): ITrieNode | undefined {
-        const options = this.createFindOptions({ compoundMode: 'compound' });
-        return findWordNode(this.data.getRoot(), text, options).node;
+        return findWordNode(this.data.getRoot(), text, this.#optionsCompound).node;
     }
 
     has(word: string, minLegacyCompoundLength?: boolean | number): boolean {

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/FindOptions.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/FindOptions.ts
@@ -4,7 +4,8 @@ import type { CompoundModes } from './CompoundModes.js';
 export interface FindOptions {
     matchCase: boolean;
     compoundMode: CompoundModes;
-    legacyMinCompoundLength?: number;
+    legacyMinCompoundLength?: number | undefined;
+    checkForbidden?: boolean | undefined;
 }
 
 export type PartialFindOptions = PartialWithUndefined<FindOptions> | undefined;

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/ITrieNode.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/ITrieNode.ts
@@ -39,18 +39,16 @@ export interface ITrieNode {
     readonly id: ITrieNodeId;
     /** flag End of Word */
     readonly eow: boolean;
-    /** number of children */
-    readonly size: number;
     /** get keys to children */
-    keys(): readonly string[];
+    keys(): Iterable<string>;
     /** get keys to children */
-    values(): readonly ITrieNode[];
+    values(): Iterable<ITrieNode>;
     /** get the children as key value pairs */
-    entries(): readonly Entry[];
+    entries(): Iterable<Entry>;
     /** get child ITrieNode */
     get(char: string): ITrieNode | undefined;
-    /** get a child by the key index */
-    child(idx: number): ITrieNode;
+    /** get a nested child ITrieNode */
+    getNode?: (chars: string) => ITrieNode | undefined;
     /** has child */
     has(char: string): boolean;
     /** `true` iff this node has children */
@@ -67,7 +65,7 @@ export interface ITrieNodeRoot extends ITrieNode {
      */
     resolveId(id: ITrieNodeId): ITrieNode;
 
-    findExact?: ((word: string) => boolean) | undefined;
+    findExact: ((word: string) => boolean) | undefined;
     /**
      * Try to find a word.
      * @param word - the normalized word to look up.

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/ITrieNode.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/ITrieNode.ts
@@ -58,7 +58,7 @@ export interface ITrieNode {
 }
 
 export interface ITrieNodeRoot extends ITrieNode {
-    info: Readonly<TrieInfo>;
+    readonly info: Readonly<TrieInfo>;
     /**
      * converts an `id` into a node.
      * @param id an of a ITrieNode in this Trie
@@ -76,7 +76,11 @@ export interface ITrieNodeRoot extends ITrieNode {
 
     isForbidden?: ((word: string) => boolean) | undefined;
 
-    forbidPrefix: string;
-    compoundFix: string;
-    caseInsensitivePrefix: string;
+    readonly forbidPrefix: string;
+    readonly compoundFix: string;
+    readonly caseInsensitivePrefix: string;
+
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
 }

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/TrieInfo.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/TrieInfo.ts
@@ -6,4 +6,11 @@ export interface TrieInfo {
     forbiddenWordPrefix: string;
     isCaseAware: boolean;
 }
+
+export interface TrieCharacteristics {
+    hasForbiddenWords: boolean;
+    hasCompoundWords: boolean;
+    hasNonStrictWords: boolean;
+}
+
 export type PartialTrieInfo = PartialWithUndefined<TrieInfo> | undefined;

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/find.test.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/find.test.ts
@@ -27,11 +27,18 @@ describe('Validate findWord', () => {
         expect(findWord(trie, word, opts)).toEqual(expected);
     });
 
+    const ncf = { checkForbidden: false };
+
     const tests: [string, PartialFindOptions, FindFullResult][] = [
         [
             'errorCodes',
-            { matchCase: false, compoundMode: 'compound' },
+            { matchCase: false, compoundMode: 'compound', checkForbidden: true },
             frCompoundFound('errorCodes', { forbidden: false }),
+        ],
+        [
+            'errorCodes',
+            { matchCase: false, compoundMode: 'compound', checkForbidden: false },
+            frCompoundFound('errorCodes', { forbidden: undefined }),
         ],
         [
             'errorcodes',
@@ -42,6 +49,12 @@ describe('Validate findWord', () => {
         ['code', { matchCase: true, compoundMode: 'none' }, frFound('code', { forbidden: false })],
         ['cafe', { matchCase: true, compoundMode: 'none' }, frNotFound({ forbidden: false })],
         ['café', { matchCase: true, compoundMode: 'none' }, frFound('café', { forbidden: false })],
+
+        // Do not check forbidden words.
+        ['Code', { matchCase: true, compoundMode: 'none', ...ncf }, frNotFound()],
+        ['code', { matchCase: true, compoundMode: 'none', ...ncf }, frFound('code')],
+        ['cafe', { matchCase: true, compoundMode: 'none', ...ncf }, frNotFound()],
+        ['café', { matchCase: true, compoundMode: 'none', ...ncf }, frFound('café')],
 
         // non-normalized words
         ['café', { matchCase: false, compoundMode: 'none' }, frFound('café')],
@@ -156,12 +169,8 @@ describe('Validate Legacy Compound lookup', () => {
 
 type PartialFindFullResult = Partial<FindFullResult>;
 
-function fr({
-    found = false,
-    forbidden = undefined,
-    compoundUsed = false,
-    caseMatched = true,
-}: PartialFindFullResult): FindFullResult {
+function fr(r: PartialFindFullResult): FindFullResult {
+    const { found = false, forbidden = undefined, compoundUsed = false, caseMatched = true } = r;
     return {
         found,
         forbidden,

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/find.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/find.ts
@@ -134,7 +134,8 @@ export function findCompoundNode(
     ];
     const compoundPrefix = compoundCharacter || ignoreCasePrefix;
     const possibleCompoundPrefix = ignoreCasePrefix && compoundCharacter ? ignoreCasePrefix + compoundCharacter : '';
-    const w = word.normalize();
+    const nw = word.normalize();
+    const w = [...nw];
 
     function determineRoot(s: FindCompoundChain): FindCompoundChain {
         const prefix = s.compoundPrefix;
@@ -161,7 +162,7 @@ export function findCompoundNode(
         const s = stack[i];
         const h = w[i++];
         const n = s.cr || s.n;
-        const c = n?.get(h);
+        const c = (h && n?.get(h)) || undefined;
         if (c && i < word.length) {
             // Go deeper.
             caseMatched = s.caseMatched;
@@ -183,7 +184,7 @@ export function findCompoundNode(
                 if (!r.cr) {
                     break;
                 }
-                if (!i && !r.caseMatched && w !== w.toLowerCase()) {
+                if (!i && !r.caseMatched && nw !== nw.toLowerCase()) {
                     // It is not going to be found.
                     break;
                 }
@@ -197,7 +198,7 @@ export function findCompoundNode(
         }
     }
 
-    const found = (i && i === word.length && word) || false;
+    const found = (i === word.length && word) || false;
     const result: FindFullNodeResult = { found, compoundUsed, node, forbidden: undefined, caseMatched };
     return result;
 }

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/trie-util.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/trie-util.ts
@@ -42,8 +42,8 @@ export function countNodes(root: ITrieNode): number {
     function walk(n: ITrieNode) {
         if (seen.has(n.id)) return;
         seen.add(n.id);
-        for (let i = 0; i < n.size; ++i) {
-            walk(n.child(i));
+        for (const c of n.values()) {
+            walk(c);
         }
     }
 
@@ -64,9 +64,8 @@ export function countWords(root: ITrieNode): number {
         // add the node to the set to avoid getting stuck on circular references.
         visited.set(n, cnt);
 
-        const size = n.size;
-        for (let i = 0; i < size; ++i) {
-            cnt += walk(n.child(i));
+        for (const c of n.values()) {
+            cnt += walk(c);
         }
         visited.set(n, cnt);
         return cnt;

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlob.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlob.ts
@@ -33,8 +33,8 @@ export class FastTrieBlob implements TrieData {
         readonly info: Readonly<TrieInfo>,
     ) {
         this.wordToCharacters = (word: string) => [...word];
-        this._forbidIdx = this._searchNodeForChar(0, this.info.forbiddenWordPrefix) || 0;
-        this._caseInsensitiveIdx = this._searchNodeForChar(0, this.info.stripCaseAndAccentsPrefix) || 0;
+        this._forbidIdx = this.#searchNodeForChar(0, this.info.forbiddenWordPrefix) || 0;
+        this._caseInsensitiveIdx = this.#searchNodeForChar(0, this.info.stripCaseAndAccentsPrefix) || 0;
 
         if (checkSorted) {
             assertSorted(this.nodes, bitMasksInfo.NodeMaskChildCharIndex);
@@ -210,8 +210,9 @@ export class FastTrieBlob implements TrieData {
     static toITrieNodeRoot(trie: FastTrieBlob): ITrieNodeRoot {
         return new FastTrieBlobIRoot(
             new FastTrieBlobInternalsAndMethods(trie.nodes, trie._charIndex, trie.bitMasksInfo, trie.info, {
+                nodeFindNode: (idx: number, word: string) => trie.#lookupNode(idx, trie.wordToUtf8Seq(word)),
                 nodeFindExact: (idx: number, word: string) => trie.#has(idx, word),
-                nodeGetChild: (idx: number, letter: string) => trie._searchNodeForChar(idx, letter),
+                nodeGetChild: (idx: number, letter: string) => trie.#searchNodeForChar(idx, letter),
                 isForbidden: (word: string) => trie.isForbiddenWord(word),
                 findExact: (word: string) => trie.has(word),
             }),
@@ -273,7 +274,7 @@ export class FastTrieBlob implements TrieData {
     }
 
     /** Search from nodeIdx for the node index representing the character. */
-    private _searchNodeForChar(nodeIdx: number, char: string): number | undefined {
+    #searchNodeForChar(nodeIdx: number, char: string): number | undefined {
         const charIndexes = this.letterToUtf8Seq(char);
         return this.#lookupNode(nodeIdx, charIndexes);
     }

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobBuilder.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobBuilder.ts
@@ -285,8 +285,8 @@ export class FastTrieBlobBuilder implements TrieBuilder<FastTrieBlob> {
                 ),
                 this.charIndex.build(),
                 this.bitMasksInfo,
+                this.options,
             ),
-            this.options,
         );
     }
 

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.test.ts
@@ -36,12 +36,9 @@ describe('FastTrieBlob', () => {
         const root = createTrieRootFromList(words);
         const ft = FastTrieBlobBuilder.fromTrieRoot(root);
         const iTrieRoot = FastTrieBlob.toITrieNodeRoot(ft);
-        const keys = iTrieRoot.keys();
-        const values = iTrieRoot.values();
+        const keys = [...iTrieRoot.keys()];
+        const values = [...iTrieRoot.values()];
         expect(values.length).toBe(keys.length);
-        const valueIds = values.map((v) => v.id);
-        const idsFromLookUp = keys.map((_, i) => iTrieRoot.child(i).id);
-        expect(valueIds).toEqual(idsFromLookUp);
     });
 
     test('extended number of letters', () => {

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.ts
@@ -64,6 +64,12 @@ class FastTrieBlobINode implements ITrieNode {
         return new FastTrieBlobINode(this.trie, idx);
     }
 
+    getNode(chars: string): ITrieNode | undefined {
+        const idx = this.trie.nodeFindNode(this.id, chars);
+        if (idx === undefined) return undefined;
+        return new FastTrieBlobINode(this.trie, idx);
+    }
+
     has(char: string): boolean {
         const idx = this.trie.nodeGetChild(this.id, char);
         return idx !== undefined;

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.ts
@@ -221,8 +221,15 @@ class FastTrieBlobINode implements ITrieNode {
 }
 
 export class FastTrieBlobIRoot extends FastTrieBlobINode implements ITrieNodeRoot {
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+
     constructor(trie: FastTrieBlobInternalsAndMethods, nodeIdx: number) {
         super(trie, nodeIdx);
+        this.hasForbiddenWords = trie.hasForbiddenWords;
+        this.hasCompoundWords = trie.hasCompoundWords;
+        this.hasNonStrictWords = trie.hasNonStrictWords;
     }
     resolveId(id: ITrieNodeId): ITrieNode {
         return new FastTrieBlobINode(this.trie, id as number);

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobIRoot.ts
@@ -1,6 +1,5 @@
 import type { FindResult, ITrieNode, ITrieNodeId, ITrieNodeRoot } from '../ITrieNode/ITrieNode.js';
-import type { TrieInfo } from '../ITrieNode/TrieInfo.js';
-import type { FastTrieBlobInternals } from './FastTrieBlobInternals.js';
+import type { FastTrieBlobInternalsAndMethods } from './FastTrieBlobInternals.js';
 import { Utf8Accumulator } from './Utf8.js';
 
 const EmptyKeys: readonly string[] = Object.freeze([]);
@@ -24,15 +23,15 @@ class FastTrieBlobINode implements ITrieNode {
     protected charToIdx: Readonly<Record<string, NodeIndex>> | undefined;
 
     constructor(
-        readonly trie: FastTrieBlobInternals,
+        readonly trie: FastTrieBlobInternalsAndMethods,
         readonly nodeIdx: NodeIndex,
-        protected nodeHas: (idx: number, word: string) => boolean,
     ) {
         const node = trie.nodes[nodeIdx];
         this.node = node;
         this.eow = !!(node[0] & trie.NodeMaskEOW);
         this._count = node.length - 1;
         this.id = nodeIdx;
+        this.findExact = (word: string) => trie.nodeFindExact(nodeIdx, word);
     }
 
     /** get keys to children */
@@ -54,19 +53,19 @@ class FastTrieBlobINode implements ITrieNode {
         if (this._entries) return this._entries;
         if (!this._count) return EmptyEntries;
         const entries = this.getNodesEntries();
-        this._entries = entries.map(([key, value]) => [key, new FastTrieBlobINode(this.trie, value, this.nodeHas)]);
+        this._entries = entries.map(([key, value]) => [key, new FastTrieBlobINode(this.trie, value)]);
         return this._entries;
     }
 
     /** get child ITrieNode */
     get(char: string): ITrieNode | undefined {
-        const idx = this.getCharToIdxMap()[char];
+        const idx = this.trie.nodeGetChild(this.id, char);
         if (idx === undefined) return undefined;
-        return this.child(idx);
+        return new FastTrieBlobINode(this.trie, idx);
     }
 
     has(char: string): boolean {
-        const idx = this.getCharToIdxMap()[char];
+        const idx = this.trie.nodeGetChild(this.id, char);
         return idx !== undefined;
     }
 
@@ -78,7 +77,7 @@ class FastTrieBlobINode implements ITrieNode {
         if (!this._values && !this.containsChainedIndexes()) {
             const n = this.node[keyIdx + 1];
             const nodeIdx = n >>> this.trie.NodeChildRefShift;
-            return new FastTrieBlobINode(this.trie, nodeIdx, this.nodeHas);
+            return new FastTrieBlobINode(this.trie, nodeIdx);
         }
         return this.values()[keyIdx];
     }
@@ -96,7 +95,19 @@ class FastTrieBlobINode implements ITrieNode {
     }
 
     findExact(word: string): boolean {
-        return this.nodeHas(this.id, word);
+        return this.trie.nodeFindExact(this.id, word);
+    }
+
+    isForbidden(word: string): boolean {
+        const n = this.trie.nodeGetChild(this.id, this.trie.info.forbiddenWordPrefix);
+        if (n === undefined) return false;
+        return this.trie.nodeFindExact(n, word);
+    }
+
+    findCaseInsensitive(word: string): boolean {
+        const n = this.trie.nodeGetChild(this.id, this.trie.info.stripCaseAndAccentsPrefix);
+        if (n === undefined) return false;
+        return this.trie.nodeFindExact(n, word);
     }
 
     private containsChainedIndexes(): boolean {
@@ -204,19 +215,11 @@ class FastTrieBlobINode implements ITrieNode {
 }
 
 export class FastTrieBlobIRoot extends FastTrieBlobINode implements ITrieNodeRoot {
-    constructor(
-        trie: FastTrieBlobInternals,
-        nodeIdx: number,
-        readonly info: Readonly<TrieInfo>,
-        readonly findExact: (word: string) => boolean,
-        readonly isForbidden: (word: string) => boolean,
-        readonly findCaseInsensitive: (word: string) => boolean,
-        nodeHas: (idx: number, word: string) => boolean,
-    ) {
-        super(trie, nodeIdx, nodeHas);
+    constructor(trie: FastTrieBlobInternalsAndMethods, nodeIdx: number) {
+        super(trie, nodeIdx);
     }
     resolveId(id: ITrieNodeId): ITrieNode {
-        return new FastTrieBlobINode(this.trie, id as number, this.nodeHas);
+        return new FastTrieBlobINode(this.trie, id as number);
     }
 
     find(word: string, strict: boolean): FindResult | undefined {
@@ -229,15 +232,19 @@ export class FastTrieBlobIRoot extends FastTrieBlobINode implements ITrieNodeRoo
         return found ? { found: word, compoundUsed: false, caseMatched: false } : undefined;
     }
 
+    get info() {
+        return this.trie.info;
+    }
+
     get forbidPrefix(): string {
-        return this.info.forbiddenWordPrefix;
+        return this.trie.info.forbiddenWordPrefix;
     }
 
     get compoundFix(): string {
-        return this.info.compoundCharacter;
+        return this.trie.info.compoundCharacter;
     }
 
     get caseInsensitivePrefix(): string {
-        return this.info.stripCaseAndAccentsPrefix;
+        return this.trie.info.stripCaseAndAccentsPrefix;
     }
 }

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobInternals.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobInternals.ts
@@ -1,4 +1,4 @@
-import { PartialTrieInfo, TrieInfo } from '../ITrieNode/TrieInfo.js';
+import { PartialTrieInfo, TrieCharacteristics, TrieInfo } from '../ITrieNode/TrieInfo.js';
 import { mergeOptionalWithDefaults } from '../utils/mergeOptionalWithDefaults.js';
 import { CharIndex } from './CharIndex.js';
 import type { FastTrieBlobBitMaskInfo } from './FastTrieBlobBitMaskInfo.js';
@@ -29,7 +29,7 @@ export class FastTrieBlobInternals implements FastTrieBlobBitMaskInfo {
     }
 }
 
-interface TrieMethods {
+interface TrieMethods extends Readonly<TrieCharacteristics> {
     readonly nodeFindNode: (idx: number, word: string) => number | undefined;
     readonly nodeFindExact: (idx: number, word: string) => boolean;
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
@@ -43,6 +43,9 @@ export class FastTrieBlobInternalsAndMethods extends FastTrieBlobInternals imple
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
     readonly isForbidden: (word: string) => boolean;
     readonly findExact: (word: string) => boolean;
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
 
     constructor(
         nodes: Nodes,
@@ -57,6 +60,9 @@ export class FastTrieBlobInternalsAndMethods extends FastTrieBlobInternals imple
         this.isForbidden = trieMethods.isForbidden;
         this.findExact = trieMethods.findExact;
         this.nodeFindNode = trieMethods.nodeFindNode;
+        this.hasForbiddenWords = trieMethods.hasForbiddenWords;
+        this.hasCompoundWords = trieMethods.hasCompoundWords;
+        this.hasNonStrictWords = trieMethods.hasNonStrictWords;
     }
 }
 

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobInternals.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/FastTrieBlobInternals.ts
@@ -30,6 +30,7 @@ export class FastTrieBlobInternals implements FastTrieBlobBitMaskInfo {
 }
 
 interface TrieMethods {
+    readonly nodeFindNode: (idx: number, word: string) => number | undefined;
     readonly nodeFindExact: (idx: number, word: string) => boolean;
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
     readonly isForbidden: (word: string) => boolean;
@@ -37,6 +38,7 @@ interface TrieMethods {
 }
 
 export class FastTrieBlobInternalsAndMethods extends FastTrieBlobInternals implements TrieMethods {
+    readonly nodeFindNode: (idx: number, word: string) => number | undefined;
     readonly nodeFindExact: (idx: number, word: string) => boolean;
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
     readonly isForbidden: (word: string) => boolean;
@@ -54,6 +56,7 @@ export class FastTrieBlobInternalsAndMethods extends FastTrieBlobInternals imple
         this.nodeGetChild = trieMethods.nodeGetChild;
         this.isForbidden = trieMethods.isForbidden;
         this.findExact = trieMethods.findExact;
+        this.nodeFindNode = trieMethods.nodeFindNode;
     }
 }
 

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlob.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlob.ts
@@ -53,6 +53,9 @@ export class TrieBlob implements TrieData {
     #beAdj = endianness() === 'BE' ? 3 : 0;
 
     readonly wordToCharacters = (word: string) => [...word];
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
 
     constructor(
         protected nodes: Uint32Array,
@@ -66,6 +69,9 @@ export class TrieBlob implements TrieData {
         this.#forbidIdx = this._lookupNode(0, this.info.forbiddenWordPrefix);
         this.#compoundIdx = this._lookupNode(0, this.info.compoundCharacter);
         this.#nonStrictIdx = this._lookupNode(0, this.info.stripCaseAndAccentsPrefix);
+        this.hasForbiddenWords = !!this.#forbidIdx;
+        this.hasCompoundWords = !!this.#compoundIdx;
+        this.hasNonStrictWords = !!this.#nonStrictIdx;
     }
 
     public wordToUtf8Seq(word: string): Utf8Seq {
@@ -84,18 +90,6 @@ export class TrieBlob implements TrieData {
         return !!this.#forbidIdx && this.#hasWord(this.#forbidIdx, word);
     }
 
-    hasForbiddenWords(): boolean {
-        return !!this.#forbidIdx;
-    }
-
-    hasCompoundWords(): boolean {
-        return !!this.#compoundIdx;
-    }
-
-    hasNonStrictWords(): boolean {
-        return !!this.#nonStrictIdx;
-    }
-
     /**
      * Try to find the word in the trie. The word must be normalized.
      * If `strict` is `true` the case and accents must match.
@@ -105,7 +99,7 @@ export class TrieBlob implements TrieData {
      * @param strict - if `true` the case and accents must match.
      */
     find(word: string, strict: boolean): FindResult | undefined {
-        if (!this.hasCompoundWords()) {
+        if (!this.hasCompoundWords) {
             const found = this.#hasWord(0, word);
             if (found) return { found: word, compoundUsed: false, caseMatched: true };
             if (strict || !this.#nonStrictIdx) return { found: false, compoundUsed: false, caseMatched: false };
@@ -135,6 +129,9 @@ export class TrieBlob implements TrieData {
                 nodeFindNode: (idx, word) => this.#findNode(idx, word),
                 isForbidden: (word) => this.isForbiddenWord(word),
                 findExact: (word) => this.has(word),
+                hasCompoundWords: this.hasCompoundWords,
+                hasForbiddenWords: this.hasForbiddenWords,
+                hasNonStrictWords: this.hasNonStrictWords,
             },
         );
         return new TrieBlobIRoot(trieData, 0, this.info, {
@@ -151,9 +148,10 @@ export class TrieBlob implements TrieData {
      */
     #hasWord(nodeIdx: number, word: string): boolean {
         const nodeIdxFound = this.#findNode(nodeIdx, word);
-        if (nodeIdxFound === undefined) return false;
+        if (!nodeIdxFound) return false;
         const node = this.nodes[nodeIdxFound];
-        return (node & TrieBlob.NodeMaskEOW) === TrieBlob.NodeMaskEOW;
+        const m = TrieBlob.NodeMaskEOW;
+        return (node & m) === m;
     }
 
     #findNode(nodeIdx: number, word: string): number | undefined {
@@ -391,8 +389,8 @@ export class TrieBlob implements TrieData {
     //     }
     // }
 
-    static NodeMaskEOW = 0x0000_0100;
-    static NodeMaskNumChildren = (1 << NodeHeaderNumChildrenBits) - 1;
+    static NodeMaskEOW = 0x0000_0100 & 0xffff;
+    static NodeMaskNumChildren = ((1 << NodeHeaderNumChildrenBits) - 1) & 0xffff;
     static NodeMaskNumChildrenShift = NodeHeaderNumChildrenShift;
     static NodeChildRefShift = 8;
     /**

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlob.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlob.ts
@@ -132,6 +132,7 @@ export class TrieBlob implements TrieData {
             {
                 nodeFindExact: (idx, word) => this.#hasWord(idx, word),
                 nodeGetChild: (idx, letter) => this._lookupNode(idx, letter),
+                nodeFindNode: (idx, word) => this.#findNode(idx, word),
                 isForbidden: (word) => this.isForbiddenWord(word),
                 findExact: (word) => this.has(word),
             },
@@ -149,11 +150,15 @@ export class TrieBlob implements TrieData {
      * Check if the word is in the trie starting at the given node index.
      */
     #hasWord(nodeIdx: number, word: string): boolean {
-        const wordIndexes = this.wordToUtf8Seq(word);
-        const nodeIdxFound = this.#lookupNode(nodeIdx, wordIndexes);
+        const nodeIdxFound = this.#findNode(nodeIdx, word);
         if (nodeIdxFound === undefined) return false;
         const node = this.nodes[nodeIdxFound];
         return (node & TrieBlob.NodeMaskEOW) === TrieBlob.NodeMaskEOW;
+    }
+
+    #findNode(nodeIdx: number, word: string): number | undefined {
+        const wordIndexes = this.wordToUtf8Seq(word);
+        return this.#lookupNode(nodeIdx, wordIndexes);
     }
 
     /**

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.test.ts
@@ -31,12 +31,9 @@ describe('FastTrieBlob', () => {
     test('toITrieNodeRoot.values', () => {
         const trie = createTrieBlob(words);
         const iTrieRoot = trie.getRoot();
-        const keys = iTrieRoot.keys();
-        const values = iTrieRoot.values();
+        const keys = [...iTrieRoot.keys()];
+        const values = [...iTrieRoot.values()];
         expect(values.length).toBe(keys.length);
-        const valueIds = values.map((v) => v.id);
-        const idsFromLookUp = keys.map((_, i) => iTrieRoot.child(i).id);
-        expect(valueIds).toEqual(idsFromLookUp);
     });
 
     test('toITrieNodeRoot with large number of characters', async () => {

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.ts
@@ -14,6 +14,7 @@ type Node = number;
 type NodeIndex = number;
 
 interface TrieMethods {
+    readonly nodeFindNode: (idx: number, word: string) => number | undefined;
     readonly nodeFindExact: (idx: number, word: string) => boolean;
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
     readonly isForbidden: (word: string) => boolean;
@@ -30,6 +31,7 @@ export class TrieBlobInternals implements TrieMethods, BitMaskInfo {
     readonly isForbidden: (word: string) => boolean;
     readonly findExact: (word: string) => boolean;
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
+    readonly nodeFindNode: (idx: number, word: string) => number | undefined;
 
     constructor(
         readonly nodes: Uint32Array,
@@ -47,6 +49,7 @@ export class TrieBlobInternals implements TrieMethods, BitMaskInfo {
         this.isForbidden = methods.isForbidden;
         this.findExact = methods.findExact;
         this.nodeGetChild = methods.nodeGetChild;
+        this.nodeFindNode = methods.nodeFindNode;
     }
 }
 
@@ -150,6 +153,11 @@ class TrieBlobINode implements ITrieNode {
         }
         this.charToIdx = map;
         return map;
+    }
+
+    getNode(word: string): ITrieNode | undefined {
+        const n = this.trie.nodeFindNode(this.nodeIdx, word);
+        return n === undefined ? undefined : new TrieBlobINode(this.trie, n);
     }
 
     findExact(word: string): boolean {

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.ts
@@ -1,5 +1,5 @@
 import type { ITrieNode, ITrieNodeId, ITrieNodeRoot } from '../ITrieNode/ITrieNode.js';
-import type { TrieInfo } from '../ITrieNode/TrieInfo.js';
+import type { TrieCharacteristics, TrieInfo } from '../ITrieNode/TrieInfo.js';
 import { CharIndex } from './CharIndex.js';
 import { Utf8Accumulator } from './Utf8.js';
 
@@ -13,7 +13,7 @@ interface BitMaskInfo {
 type Node = number;
 type NodeIndex = number;
 
-interface TrieMethods {
+interface TrieMethods extends Readonly<TrieCharacteristics> {
     readonly nodeFindNode: (idx: number, word: string) => number | undefined;
     readonly nodeFindExact: (idx: number, word: string) => boolean;
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
@@ -33,6 +33,10 @@ export class TrieBlobInternals implements TrieMethods, BitMaskInfo {
     readonly nodeGetChild: (idx: number, letter: string) => number | undefined;
     readonly nodeFindNode: (idx: number, word: string) => number | undefined;
 
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+
     constructor(
         readonly nodes: Uint32Array,
         readonly charIndex: Readonly<CharIndex>,
@@ -50,6 +54,9 @@ export class TrieBlobInternals implements TrieMethods, BitMaskInfo {
         this.findExact = methods.findExact;
         this.nodeGetChild = methods.nodeGetChild;
         this.nodeFindNode = methods.nodeFindNode;
+        this.hasForbiddenWords = methods.hasForbiddenWords;
+        this.hasCompoundWords = methods.hasCompoundWords;
+        this.hasNonStrictWords = methods.hasNonStrictWords;
     }
 }
 
@@ -272,6 +279,10 @@ export class TrieBlobIRoot extends TrieBlobINode implements ITrieNodeRoot {
     find: ITrieNodeRoot['find'];
     isForbidden: ITrieNodeRoot['isForbidden'];
 
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+
     constructor(
         trie: TrieBlobInternals,
         nodeIdx: number,
@@ -281,6 +292,9 @@ export class TrieBlobIRoot extends TrieBlobINode implements ITrieNodeRoot {
         super(trie, nodeIdx);
         this.find = methods.find;
         this.isForbidden = trie.isForbidden;
+        this.hasForbiddenWords = trie.hasForbiddenWords;
+        this.hasCompoundWords = trie.hasCompoundWords;
+        this.hasNonStrictWords = trie.hasNonStrictWords;
     }
     resolveId(id: ITrieNodeId): ITrieNode {
         return new TrieBlobINode(this.trie, id as number);

--- a/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieBlob/TrieBlobIRoot.ts
@@ -20,7 +20,7 @@ interface TrieMethods {
     readonly findExact: (word: string) => boolean;
 }
 
-export class TrieBlobInternals implements BitMaskInfo {
+export class TrieBlobInternals implements TrieMethods, BitMaskInfo {
     readonly NodeMaskEOW: number;
     readonly NodeMaskNumChildren: number;
     readonly NodeMaskChildCharIndex: number;

--- a/packages/cspell-trie-lib/src/lib/TrieData.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieData.ts
@@ -1,8 +1,8 @@
 import type { ITrieNode, ITrieNodeRoot } from './ITrieNode/ITrieNode.js';
-import type { TrieInfo } from './ITrieNode/TrieInfo.js';
+import type { TrieCharacteristics, TrieInfo } from './ITrieNode/TrieInfo.js';
 
-export interface TrieData {
-    info: Readonly<TrieInfo>;
+export interface TrieData extends Readonly<TrieCharacteristics> {
+    readonly info: Readonly<TrieInfo>;
     /** Method used to split words into individual characters. */
     wordToCharacters(word: string): readonly string[];
     /** get an iterable for all the words in the dictionary. */
@@ -11,6 +11,8 @@ export interface TrieData {
     getNode(prefix: string): ITrieNode | undefined;
     has(word: string): boolean;
     isForbiddenWord(word: string): boolean;
-    hasForbiddenWords(): boolean;
-    size: number;
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+    readonly size: number;
 }

--- a/packages/cspell-trie-lib/src/lib/TrieNode/TrieNodeTrie.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/TrieNodeTrie.ts
@@ -13,8 +13,15 @@ export class TrieNodeTrie implements TrieData {
     private _iTrieRoot: ITrieNodeRoot | undefined;
     readonly info: TrieOptions;
     private _size: number | undefined;
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+
     constructor(readonly root: TrieRoot) {
         this.info = mergeOptionalWithDefaults(root);
+        this.hasForbiddenWords = !!root.c[root.forbiddenWordPrefix];
+        this.hasCompoundWords = !!root.c[root.compoundCharacter];
+        this.hasNonStrictWords = !!root.c[root.stripCaseAndAccentsPrefix];
     }
 
     wordToCharacters = (word: string): string[] => [...word];
@@ -41,11 +48,6 @@ export class TrieNodeTrie implements TrieData {
 
     isForbiddenWord(word: string): boolean {
         return findWordExact(this.root.c[this.root.forbiddenWordPrefix], word);
-    }
-
-    hasForbiddenWords(): boolean {
-        const root = this.root;
-        return !!root.c[root.forbiddenWordPrefix];
     }
 
     get size() {

--- a/packages/cspell-trie-lib/src/lib/TrieNode/find.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/find.ts
@@ -179,7 +179,8 @@ export function findCompoundNode(
     ];
     const compoundPrefix = compoundCharacter || ignoreCasePrefix;
     const possibleCompoundPrefix = ignoreCasePrefix && compoundCharacter ? ignoreCasePrefix + compoundCharacter : '';
-    const w = word.normalize();
+    const nw = word.normalize();
+    const w = [...nw];
 
     function determineRoot(s: FindCompoundChain): FindCompoundChain {
         const prefix = s.compoundPrefix;
@@ -228,7 +229,7 @@ export function findCompoundNode(
                 if (!r.cr) {
                     break;
                 }
-                if (!i && !r.caseMatched && w !== w.toLowerCase()) {
+                if (!i && !r.caseMatched && nw !== nw.toLowerCase()) {
                     // It is not going to be found.
                     break;
                 }

--- a/packages/cspell-trie-lib/src/lib/TrieNode/trie.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/trie.ts
@@ -105,10 +105,17 @@ class ImplITrieNode implements ITrieNode {
 class ImplITrieRoot extends ImplITrieNode implements ITrieNodeRoot {
     readonly info: Readonly<TrieInfo>;
 
+    readonly hasForbiddenWords: boolean;
+    readonly hasCompoundWords: boolean;
+    readonly hasNonStrictWords: boolean;
+
     protected constructor(readonly root: TrieRoot) {
         super(root);
         const { stripCaseAndAccentsPrefix, compoundCharacter, forbiddenWordPrefix, isCaseAware } = root;
         this.info = { stripCaseAndAccentsPrefix, compoundCharacter, forbiddenWordPrefix, isCaseAware };
+        this.hasForbiddenWords = !!root.c[forbiddenWordPrefix];
+        this.hasCompoundWords = !!root.c[compoundCharacter];
+        this.hasNonStrictWords = !!root.c[stripCaseAndAccentsPrefix];
     }
 
     get eow(): boolean {

--- a/packages/cspell-trie-lib/src/lib/TrieNode/trie.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/trie.ts
@@ -58,6 +58,10 @@ class ImplITrieNode implements ITrieNode {
         return ImplITrieNode.toITrieNode(n);
     }
 
+    getNode(chars: string): ITrieNode | undefined {
+        return this.findNode(chars);
+    }
+
     has(char: string): boolean {
         const c = this.node.c;
         return (c && char in c) || false;
@@ -72,6 +76,25 @@ class ImplITrieNode implements ITrieNode {
 
     hasChildren(): boolean {
         return !!this.node.c;
+    }
+
+    #findTrieNode(word: string): TrieNode | undefined {
+        let node: TrieNode | undefined = this.node;
+        for (const char of word) {
+            if (!node) return undefined;
+            node = node.c?.[char];
+        }
+        return node;
+    }
+
+    findNode(word: string): ITrieNode | undefined {
+        const node = this.#findTrieNode(word);
+        return node && ImplITrieNode.toITrieNode(node);
+    }
+
+    findExact(word: string): boolean {
+        const node = this.#findTrieNode(word);
+        return !!node && !!node.f;
     }
 
     static toITrieNode(node: TrieNode): ITrieNode {

--- a/packages/cspell-trie-lib/src/lib/buildITrie.ts
+++ b/packages/cspell-trie-lib/src/lib/buildITrie.ts
@@ -7,5 +7,5 @@ export function buildITrieFromWords(words: Iterable<string>, info: PartialTrieIn
     const builder = new FastTrieBlobBuilder(info);
     builder.insert(words);
     const ft = builder.build();
-    return new ITrieImpl(ft.size > 100 ? ft.toTrieBlob() : ft);
+    return new ITrieImpl(ft.size > 1000 ? ft.toTrieBlob() : ft);
 }

--- a/packages/cspell-trie-lib/src/lib/constants.ts
+++ b/packages/cspell-trie-lib/src/lib/constants.ts
@@ -12,4 +12,7 @@ export const defaultTrieInfo: TrieInfo = Object.freeze({
     forbiddenWordPrefix: FORBID_PREFIX,
     stripCaseAndAccentsPrefix: CASE_INSENSITIVE_PREFIX,
     isCaseAware: true,
+    hasForbiddenWords: false,
+    hasCompoundWords: false,
+    hasNonStrictWords: false,
 });

--- a/packages/cspell-trie-lib/src/lib/io/importV3.test.ts
+++ b/packages/cspell-trie-lib/src/lib/io/importV3.test.ts
@@ -134,14 +134,10 @@ function toTree(root: ITrieNode): string {
     function* walk(n: ITrieNode, prefix: string): Generator<string> {
         const nextPrefix = '.'.repeat(prefix.length);
         if (n.hasChildren()) {
-            const keys = n
-                .keys()
-                .map((k, i) => ({ k, i }))
-                .sort((a, b) => (a.k < b.k ? -1 : 1));
-            for (const key of keys) {
-                const c = n.child(key.i);
-                if (!c) continue;
-                yield* walk(c, prefix + key.k);
+            const entries = [...n.entries()];
+            entries.sort((a, b) => (a[0] < b[0] ? -1 : 1));
+            for (const [key, c] of entries) {
+                yield* walk(c, prefix + key);
                 prefix = nextPrefix;
             }
         }

--- a/packages/cspell-trie-lib/src/lib/io/importV3FastBlob.test.ts
+++ b/packages/cspell-trie-lib/src/lib/io/importV3FastBlob.test.ts
@@ -121,14 +121,10 @@ function toTree(root: ITrieNode): string {
     function* walk(n: ITrieNode, prefix: string): Generator<string> {
         const nextPrefix = '.'.repeat(prefix.length);
         if (n.hasChildren()) {
-            const keys = n
-                .keys()
-                .map((k, i) => ({ k, i }))
-                .sort((a, b) => (a.k < b.k ? -1 : 1));
-            for (const key of keys) {
-                const c = n.child(key.i);
-                if (!c) continue;
-                yield* walk(c, prefix + key.k);
+            const entries = [...n.entries()];
+            entries.sort((a, b) => (a[0] < b[0] ? -1 : 1));
+            for (const [key, c] of entries) {
+                yield* walk(c, prefix + key);
                 prefix = nextPrefix;
             }
         }

--- a/packages/cspell-trie-lib/src/lib/suggestions/suggestAStar.ts
+++ b/packages/cspell-trie-lib/src/lib/suggestions/suggestAStar.ts
@@ -77,8 +77,10 @@ export function* getSuggestionsAStar(
     const compRootIgnoreCase = rootIgnoreCase && rootIgnoreCase.get(comp);
     const emitted: Record<string, number> = Object.create(null);
 
+    const srcLetters = [...srcWord];
+
     /** Initial limit is based upon the length of the word. */
-    let limit = BC * Math.min(srcWord.length * opCosts.wordLengthCostFactor, changeLimit);
+    let limit = BC * Math.min(srcLetters.length * opCosts.wordLengthCostFactor, changeLimit);
 
     pathHeap.add(rootPNode);
     if (rootIgnoreCase) {
@@ -146,7 +148,7 @@ export function* getSuggestionsAStar(
     }
 
     function processPath(p: PNode) {
-        const len = srcWord.length;
+        const len = srcLetters.length;
 
         if (p.n.eow && p.i === len) {
             const word = pNodeToWord(p);
@@ -159,7 +161,7 @@ export function* getSuggestionsAStar(
 
     function calcEdges(p: PNode): void {
         const { n, i, t } = p;
-        const s = srcWord[i];
+        const s = srcLetters[i];
         const sg = visMap[s] || 0;
         const cost0 = p.c;
         const cost = cost0 + BC + (i ? 0 : opCosts.firstLetterBias);
@@ -178,7 +180,7 @@ export function* getSuggestionsAStar(
             }
 
             // Double letter, delete 1
-            const ns = srcWord[i + 1];
+            const ns = srcLetters[i + 1];
             if (s == ns && m) {
                 storePath(t, m, i + 2, cost0 + DL, s, p, 'dd', s);
             }
@@ -229,9 +231,9 @@ export function* getSuggestionsAStar(
     }
 
     function processWeightMapEdges(p: PNode, weightMap: WeightMap) {
-        delLetters(p, weightMap, srcWord, storePath);
-        insLetters(p, weightMap, srcWord, storePath);
-        repLetters(p, weightMap, srcWord, storePath);
+        delLetters(p, weightMap, srcLetters, storePath);
+        insLetters(p, weightMap, srcLetters, storePath);
+        repLetters(p, weightMap, srcLetters, storePath);
         return;
     }
 
@@ -261,16 +263,16 @@ export function* getSuggestionsAStar(
     }
 }
 
-function delLetters(pNode: PNode, weightMap: WeightMap, word: string, storePath: FnStorePath) {
+function delLetters(pNode: PNode, weightMap: WeightMap, letters: string[], storePath: FnStorePath) {
     const { t, n } = pNode;
     const trie = weightMap.insDel;
     let ii = pNode.i;
     const cost0 = pNode.c - pNode.i;
 
-    const len = word.length;
+    const len = letters.length;
 
     for (let nn = trie.n; ii < len && nn; ) {
-        const tt = nn[word[ii]];
+        const tt = nn[letters[ii]];
         if (!tt) return;
         ++ii;
         if (tt.c !== undefined) {
@@ -280,7 +282,7 @@ function delLetters(pNode: PNode, weightMap: WeightMap, word: string, storePath:
     }
 }
 
-function insLetters(p: PNode, weightMap: WeightMap, _word: string, storePath: FnStorePath) {
+function insLetters(p: PNode, weightMap: WeightMap, _letters: string[], storePath: FnStorePath) {
     const { t, i, c, n } = p;
     const cost0 = c;
 
@@ -291,16 +293,16 @@ function insLetters(p: PNode, weightMap: WeightMap, _word: string, storePath: Fn
     });
 }
 
-function repLetters(pNode: PNode, weightMap: WeightMap, word: string, storePath: FnStorePath) {
+function repLetters(pNode: PNode, weightMap: WeightMap, letters: string[], storePath: FnStorePath) {
     const node = pNode.n;
     const pt = pNode.t;
     const cost0 = pNode.c;
-    const len = word.length;
+    const len = letters.length;
     const trie = weightMap.replace;
     let i = pNode.i;
 
     for (let n = trie.n; i < len && n; ) {
-        const t = n[word[i]];
+        const t = n[letters[i]];
         if (!t) return;
         ++i;
         // yield { i, t };

--- a/packages/cspell-trie-lib/src/lib/suggestions/suggestTrieData.test.ts
+++ b/packages/cspell-trie-lib/src/lib/suggestions/suggestTrieData.test.ts
@@ -1,6 +1,10 @@
+import { DictionaryDefinition } from '@cspell/cspell-types';
 import { describe, expect, test } from 'vitest';
 
+import { readFastTrieBlobFromConfig, readTrieFromConfig } from '../../test/dictionaries.test.helper.js';
+import { createWeightMap } from '../distance/weightedMaps.js';
 import { ITrieImpl } from '../ITrie.js';
+import { mapDictionaryInformation } from '../mappers/mapDictionaryInfo.js';
 import { parseDictionaryLegacy } from '../SimpleDictionaryParser.js';
 import { TrieNodeTrie } from '../TrieNode/TrieNodeTrie.js';
 import { cleanCopy } from '../utils/util.js';
@@ -377,4 +381,135 @@ function sugOpts(opts: Partial<SuggestionCollectorOptions>): SuggestionCollector
 
 function sugOptsMaxNum(maxNumSuggestions: number): SuggestionCollectorOptions {
     return sugOpts({ numSuggestions: maxNumSuggestions });
+}
+
+describe('Validate Suggest A Star with English Dict', async () => {
+    const changeLimit = 3;
+
+    const trie = new TrieNodeTrie((await _getTrie()).root);
+    const fastTrie = await _getFastTrieBlob();
+    const trieBlob = fastTrie.toTrieBlob();
+
+    // cspell:ignore Orangges
+    test('Tests suggestions for Orangges Trie', () => {
+        const results = suggest(trie, 'Orangges', { changeLimit: changeLimit, weightMap: dictWeightMap() });
+        expect(results).toEqual([
+            sr('oranges', 101),
+            sr('orangs', 191),
+            sr('Orange', 200),
+            sr('orange', 201),
+            sr('orangey', 201),
+            sr('orangier', 201),
+            sr('orangiest', 201),
+            sr('orangeries', 241),
+        ]);
+    });
+
+    test('Tests suggestions for Orangges FastTrie', () => {
+        const results = suggest(fastTrie, 'Orangges', {
+            changeLimit: changeLimit,
+            weightMap: dictWeightMap(),
+        });
+        expect(results).toEqual([
+            sr('oranges', 101),
+            sr('orangs', 191),
+            sr('Orange', 200),
+            sr('orange', 201),
+            sr('orangey', 201),
+            sr('orangier', 201),
+            sr('orangiest', 201),
+            sr('orangeries', 241),
+        ]);
+    });
+
+    test('Tests suggestions for Orangges TrieBlob', () => {
+        const results = suggest(trieBlob, 'Orangges', {
+            changeLimit: changeLimit,
+            weightMap: dictWeightMap(),
+        });
+        expect(results).toEqual([
+            sr('oranges', 101),
+            sr('orangs', 191),
+            sr('Orange', 200),
+            sr('orange', 201),
+            sr('orangey', 201),
+            sr('orangier', 201),
+            sr('orangiest', 201),
+            sr('orangeries', 241),
+        ]);
+    });
+
+    function sr(word: string, cost: number) {
+        return expect.objectContaining({ word, cost });
+    }
+});
+
+function _getTrie() {
+    return readTrieFromConfig('@cspell/dict-en_us/cspell-ext.json');
+}
+
+function _getFastTrieBlob() {
+    return readFastTrieBlobFromConfig('@cspell/dict-en_us/cspell-ext.json');
+}
+
+function dictWeightMap() {
+    return createWeightMap(...mapDictionaryInformation(dictDef().dictionaryInformation));
+}
+
+function dictDef() {
+    return {
+        name: 'en_us',
+        path: './en_US.trie.gz',
+        repMap: [["'|`|’", "'"]],
+        description: 'American English Dictionary',
+        dictionaryInformation: {
+            locale: 'en-US',
+            alphabet: 'a-zA-Z',
+            suggestionEditCosts: [
+                { description: "Words like 'break' and 'brake'", map: '(ate)(eat)|(ake)(eak)', replace: 75 },
+                {
+                    description: 'Sounds alike',
+                    // cspell:disable-next-line
+                    map: 'f(ph)(gh)|(sion)(tion)(cion)|(ail)(ale)|(r)(ur)(er)(ure)(or)',
+                    replace: 75,
+                },
+                {
+                    description: 'Double letter score',
+                    map: 'l(ll)|s(ss)|t(tt)|e(ee)|b(bb)|d(dd)',
+                    replace: 75,
+                },
+                {
+                    // cspell:disable-next-line
+                    map: 'aeiou',
+                    replace: 98,
+                    swap: 75,
+                    insDel: 90,
+                },
+                {
+                    description: 'Common vowel sounds.',
+                    map: 'o(oh)(oo)|(oo)(ou)|(oa)(ou)|(ee)(ea)',
+                    replace: 75,
+                },
+                {
+                    map: 'o(oo)|a(aa)|e(ee)|u(uu)|(eu)(uu)|(ou)(ui)(ow)|(ie)(ei)|i(ie)|e(en)|e(ie)',
+                    replace: 50,
+                },
+                {
+                    description: "Do not rank `'s` high on the list.",
+                    map: "($)('$)('s$)|(s$)(s'$)(s's$)",
+                    replace: 10,
+                    penalty: 180,
+                },
+                {
+                    description: "Plurals ending in 'y'",
+                    map: '(ys)(ies)',
+                    replace: 75,
+                },
+                {
+                    map: '(d$)(t$)(dt$)',
+                    replace: 75,
+                },
+            ],
+        },
+    } as const satisfies DictionaryDefinition;
 }

--- a/packages/cspell-trie-lib/src/lib/walker/walker.ts
+++ b/packages/cspell-trie-lib/src/lib/walker/walker.ts
@@ -158,7 +158,7 @@ function _walkerWords2(root: TrieNode): Iterable<string> {
  * Walks the Trie and yields each word.
  */
 export function* walkerWordsITrie(root: ITrieNode): Iterable<string> {
-    type Children = readonly string[];
+    type Children = readonly Readonly<[string, ITrieNode]>[];
     interface Stack {
         t: string;
         n: ITrieNode;
@@ -168,21 +168,18 @@ export function* walkerWordsITrie(root: ITrieNode): Iterable<string> {
 
     let depth = 0;
     const stack: Stack[] = [];
-    const keys = root.keys();
-    stack[depth] = { t: '', n: root, c: Array.isArray(keys) ? keys : [...root.keys()], ci: 0 };
+    stack[depth] = { t: '', n: root, c: [...root.entries()], ci: 0 };
     while (depth >= 0) {
         let s = stack[depth];
         let baseText = s.t;
         while (s.ci < s.c.length && s.n) {
-            const char = s.c[s.ci++];
-            const node = s.n.get(char);
+            const [char, node] = s.c[s.ci++];
             if (!node) continue;
             const text = baseText + char;
             if (node.eow) yield text;
             depth++;
             baseText = text;
-            const keys = node.keys();
-            const c = Array.isArray(keys) ? keys : [...keys];
+            const c = [...node.entries()];
             if (stack[depth]) {
                 s = stack[depth];
                 s.t = text;

--- a/packages/cspell-trie-lib/src/lib/walker/walker.ts
+++ b/packages/cspell-trie-lib/src/lib/walker/walker.ts
@@ -168,7 +168,8 @@ export function* walkerWordsITrie(root: ITrieNode): Iterable<string> {
 
     let depth = 0;
     const stack: Stack[] = [];
-    stack[depth] = { t: '', n: root, c: root.keys(), ci: 0 };
+    const keys = root.keys();
+    stack[depth] = { t: '', n: root, c: Array.isArray(keys) ? keys : [...root.keys()], ci: 0 };
     while (depth >= 0) {
         let s = stack[depth];
         let baseText = s.t;
@@ -180,7 +181,8 @@ export function* walkerWordsITrie(root: ITrieNode): Iterable<string> {
             if (node.eow) yield text;
             depth++;
             baseText = text;
-            const c = node.keys();
+            const keys = node.keys();
+            const c = Array.isArray(keys) ? keys : [...keys];
             if (stack[depth]) {
                 s = stack[depth];
                 s.t = text;

--- a/packages/cspell-trie-lib/src/perf/charIndex.perf.ts
+++ b/packages/cspell-trie-lib/src/perf/charIndex.perf.ts
@@ -55,12 +55,31 @@ suite('encode to sequence', async (test) => {
         }
     });
 
-    const buffer = new Uint8Array(1024);
+    const buffer = new ArrayBuffer(1024);
+    const u8buffer = new Uint8Array(buffer);
 
     test('TextEncoder.encodeInto to Uint8Array' + msgSuffix, () => {
         for (const word of words) {
-            encoder.encodeInto(word, buffer);
+            encoder.encodeInto(word, u8buffer);
         }
+    });
+
+    test('TextEncoder.encodeInto to Uint8Array slice' + msgSuffix, () => {
+        let s: Uint8Array | undefined;
+        for (const word of words) {
+            const n = encoder.encodeInto(word, u8buffer);
+            s = u8buffer.slice(0, n.written);
+        }
+        return s;
+    });
+
+    test('TextEncoder.encodeInto to Uint8Array from buffer' + msgSuffix, () => {
+        let s: Uint8Array | undefined;
+        for (const word of words) {
+            const n = encoder.encodeInto(word, u8buffer);
+            s = new Uint8Array(buffer, 0, n.written);
+        }
+        return s;
     });
 
     test('Normalize("NFC")' + msgSuffix, () => {

--- a/packages/cspell-trie-lib/src/perf/misc.perf.ts
+++ b/packages/cspell-trie-lib/src/perf/misc.perf.ts
@@ -1,0 +1,51 @@
+import { suite } from 'perf-insight';
+
+interface SpreadObject {
+    i: number;
+    value: string;
+    node: string;
+    word: string;
+}
+
+suite('Operators', async (test) => {
+    const iterations = 100_000;
+    const objects: SpreadObject[] = Array.from({ length: 1000 }, (_, i) => ({
+        i,
+        value: i.toString(),
+        node: 'node',
+        word: `word ${i}`,
+    }));
+
+    test('spread omit', () => {
+        let obj: Omit<SpreadObject, 'node'> | undefined;
+        for (let i = iterations; i > 0; --i) {
+            const { node: _, ...rest } = objects[i % objects.length];
+            obj = rest;
+        }
+        return obj;
+    });
+
+    test('field wise assignment', () => {
+        let obj: Omit<SpreadObject, 'node'> | undefined;
+        for (let i = iterations; i > 0; --i) {
+            const v = objects[i % objects.length];
+            obj = {
+                i: v.i,
+                value: v.value,
+                word: v.word,
+            };
+        }
+        return obj;
+    });
+
+    test('spread explicity', () => {
+        let obj: Omit<SpreadObject, 'node'> | undefined;
+        for (let j = iterations; j > 0; --j) {
+            const { i, value, word } = objects[j % objects.length];
+            obj = { i, value, word };
+        }
+        return obj;
+    });
+});
+
+// cspell:ignore tion aeiou

--- a/packages/cspell/src/app/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/app/__snapshots__/app.test.ts.snap
@@ -2152,7 +2152,7 @@ exports[`Validate cli > app 'typos --no-show-suggestions' Expect Error: [Functio
 exports[`Validate cli > app 'typos --show-suggestions' Expect Error: [Function CheckFailed] 1`] = `[]`;
 
 exports[`Validate cli > app 'typos --show-suggestions' Expect Error: [Function CheckFailed] 2`] = `
-"log	code.ts:1:26 - Unknown word (Orangges) Suggestions: [Oranges, orange, Orange, Orangs, Orangey]
+"log	code.ts:1:26 - Unknown word (Orangges) Suggestions: [Oranges, orange, Orange, Orangs, Orange's]
 log
 log	test.md:5:3 - Forbidden word (blacklist) Suggestions: [denylist*, backlist, backlit, blackest, blackish]
 log

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,9 +790,6 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
     devDependencies:
-      '@types/glob':
-        specifier: ^8.1.0
-        version: 8.1.0
       lorem-ipsum:
         specifier: ^2.0.8
         version: 2.0.8


### PR DESCRIPTION
This is currently a place holder for per work.

Initial Perf:
```
File: src/perf/has.perf.ts
Running Perf Suite: trie has
✔ trie has words             7.31 ops/sec      4 iterations  546.87ms time
✔ fastTrieBlob has words    14.43 ops/sec      8 iterations  554.57ms time
✔ trieBlob has words        19.27 ops/sec     10 iterations  518.86ms time
✔ iTrieFast has words       12.64 ops/sec      7 iterations  553.83ms time
✔ iTrieBlob has words       16.79 ops/sec      9 iterations  536.03ms time
done.
File: src/perf/has.perf.ts
Running Perf Suite: dictionary has
✔ dictionary has 100k words               24.43 ops/sec     13 iterations  532.14ms time
✔ dictionary has 100k words (2nd time)    24.68 ops/sec     13 iterations  526.69ms time
✔ collection has 100k words               13.44 ops/sec      7 iterations  520.71ms time
✔ iTrie has 100k words                    32.54 ops/sec     17 iterations  522.51ms time
✔ iTrie.hasWord has 100k words            33.18 ops/sec     17 iterations  512.32ms time
✔ iTrie.data has 100k words               37.27 ops/sec     19 iterations  509.79ms time
Running Perf Suite: dictionary has Not
✔ dictionary has not 100k words                6.65 ops/sec      4 iterations  601.33ms time
✔ dictionary has not 100k words (2nd time)     6.36 ops/sec      4 iterations  628.84ms time
✔ collection has not 100k words                2.57 ops/sec      2 iterations  776.87ms time
✔ iTrie has not 100k words                    29.93 ops/sec     15 iterations  501.20ms time
✔ iTrie.hasWord has not 100k words            27.78 ops/sec     14 iterations  503.89ms time
✔ iTrie.data has not 100k words               33.93 ops/sec     17 iterations  500.99ms time
done.
```

result:
```
File: src/perf/has.perf.ts
Running Perf Suite: trie has
✔ trie has words             6.44 ops/sec      4 iterations  620.65ms time
✔ fastTrieBlob has words    13.74 ops/sec      7 iterations  509.65ms time
✔ trieBlob has words        19.24 ops/sec     10 iterations  519.73ms time
✔ iTrieFast has words       13.90 ops/sec      7 iterations  503.53ms time
✔ iTrieBlob has words       16.88 ops/sec      9 iterations  533.31ms time
done.
File: src/perf/has.perf.ts
Running Perf Suite: dictionary has
✔ dictionary has 100k words            25.89 ops/sec     13 iterations  502.22ms time
✔ collection has 100k words            13.81 ops/sec      7 iterations  506.81ms time
✔ collection reverse has 100k words    13.26 ops/sec      7 iterations  527.84ms time
✔ iTrie has 100k words                 36.84 ops/sec     19 iterations  515.72ms time
✔ iTrie.hasWord has 100k words         33.99 ops/sec     18 iterations  529.51ms time
✔ iTrie.data has 100k words            38.55 ops/sec     20 iterations  518.75ms time
Running Perf Suite: dictionary has Not
✔ dictionary has not 100k words        6.37 ops/sec      4 iterations  627.52ms time
✔ collection has not 100k words        2.71 ops/sec      2 iterations  738.63ms time
✔ iTrie has not 100k words            28.77 ops/sec     16 iterations  556.20ms time
✔ iTrie.hasWord has not 100k words    25.99 ops/sec     13 iterations  500.14ms time
✔ iTrie.data has not 100k words       34.15 ops/sec     18 iterations  527.10ms time
done.
```