### PR TITLE
fix: Remove object from cache

### DIFF
--- a/packages/flatpack-json/src/Flatpack.mts
+++ b/packages/flatpack-json/src/Flatpack.mts
@@ -599,6 +599,24 @@ export class FlatpackStore {
         assigned.set(this.refUndefined, 0);
         calcAvailableIndexes();
         addElements(this.root);
+        this.#cleanCache();
+    }
+
+    /**
+     * Remove objects from the cache after the FlatpackStore has been built.
+     */
+    #cleanCache() {
+        const toRemove = new Set<unknown>();
+
+        for (const key of this.cache.keys()) {
+            if (key && typeof key === 'object') {
+                toRemove.add(key);
+            }
+        }
+
+        for (const key of toRemove) {
+            this.cache.delete(key);
+        }
     }
 
     toJSON(): Flatpacked {

--- a/packages/flatpack-json/src/Flatpack.test.mts
+++ b/packages/flatpack-json/src/Flatpack.test.mts
@@ -177,6 +177,18 @@ describe('Flatpack', async () => {
         const s2 = fp.stringify();
         expect(s2).toEqual(s1);
     });
+
+    test('Updating the object used.', () => {
+        const data: Record<string, number | string | number[]> & { d: number[] } = { a: 1, b: 2, d: [1, 2, 3] };
+        const fp = new FlatpackStore(data);
+        const v = fp.toJSON();
+        expect(fromJSON(v)).toEqual(data);
+        data.c = 3;
+        data.d.push(4);
+        fp.setValue(data);
+        expect(fromJSON(fp.toJSON())).toEqual(data);
+        expect(fp.toJSON()).not.toEqual(v);
+    });
 });
 
 async function sampleFileList() {


### PR DESCRIPTION
flatpack-json was caching the objects it got for performance. But this created an issue when one of those objects were updated in the background. Since the object was cached, it was assumed that nothing had changed.