### PR TITLE
chore(deps): replace strip-ansi with native Node API

### DIFF
--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -99,7 +99,6 @@
     "file-entry-cache": "^9.1.0",
     "get-stdin": "^9.0.0",
     "semver": "^7.6.3",
-    "strip-ansi": "^7.1.0",
     "tinyglobby": "^0.2.9"
   },
   "engines": {

--- a/packages/cspell/src/app/app.test.ts
+++ b/packages/cspell/src/app/app.test.ts
@@ -6,7 +6,6 @@ import * as Util from 'node:util';
 import { toFileDirURL } from '@cspell/url';
 import chalk from 'chalk';
 import * as Commander from 'commander';
-import stripAnsi from 'strip-ansi';
 import { afterEach, beforeEach, type Constructable, describe, expect, test, vi } from 'vitest';
 
 import * as app from './app.mjs';
@@ -393,7 +392,7 @@ function makeLogger() {
 
     function normalizedHistory() {
         let t = history.map((a) => a.replaceAll('\u001B[2K', '').trimEnd()).join('\n');
-        t = stripAnsi(t);
+        t = Util.stripVTControlCharacters(t);
         t = t.replaceAll('\r', '');
         t = t.replace(RegExp(escapeRegExp(projectRootUri.toString()), 'gi'), '.');
         t = t.replace(RegExp(escapeRegExp(projectRoot), 'gi'), '.');

--- a/packages/cspell/src/app/emitters/traceEmitter.test.ts
+++ b/packages/cspell/src/app/emitters/traceEmitter.test.ts
@@ -1,6 +1,6 @@
 import { posix, win32 } from 'node:path';
+import { stripVTControlCharacters } from 'node:util';
 
-import strip from 'strip-ansi';
 import { describe, expect, test, vi } from 'vitest';
 
 import type { TraceResult } from '../application.mjs';
@@ -17,7 +17,7 @@ describe('traceEmitter', () => {
             dictionaryPathFormat: 'long',
             iPath: posix,
         });
-        expect(strip(report.table)).toEqual('Word F Dictionary Dictionary Location');
+        expect(stripVTControlCharacters(report.table)).toEqual('Word F Dictionary Dictionary Location');
     });
 
     test('posix format long', () => {
@@ -28,7 +28,7 @@ describe('traceEmitter', () => {
             dictionaryPathFormat: 'long',
             iPath: posix,
         });
-        const lines = report.table.split('\n').map(strip);
+        const lines = report.table.split('\n').map(stripVTControlCharacters);
         expect(lines.reduce((a, b) => Math.max(a, b.length), 0)).toBeLessThanOrEqual(lineWidth);
         const output = lines.join('\n');
         expect(output).toEqual(`\
@@ -42,7 +42,7 @@ errorcode  - softwareTerms*    node_modules/@cspell/.../dict/softwareTerms.txt`)
 
     test('posix format short', () => {
         const consoleLines: string[] = [];
-        vi.spyOn(console, 'log').mockImplementation((a) => consoleLines.push(strip(a)));
+        vi.spyOn(console, 'log').mockImplementation((a) => consoleLines.push(stripVTControlCharacters(a)));
         const lineWidth = 80;
         emitTraceResults('errorcode', true, sampleResults(), {
             cwd: '/this_is_a_very/long/path',
@@ -64,7 +64,7 @@ errorcode  - softwareTerms*    node_modules/@cspell/.../dict/softwareTerms.txt`)
 
     test('win32 format long', () => {
         const consoleLines: string[] = [];
-        vi.spyOn(console, 'log').mockImplementation((a) => consoleLines.push(strip(a)));
+        vi.spyOn(console, 'log').mockImplementation((a) => consoleLines.push(stripVTControlCharacters(a)));
         const lineWidth = 80;
         emitTraceResults('errorcode', true, sampleResultsWin32(), {
             cwd: 'D:/this_is_a_very/long/path',
@@ -88,7 +88,7 @@ errorcode  - softwareTerms*    node_modules/@cspell/.../dict/softwareTerms.txt`)
 
     test('win32 format full', () => {
         const lines: string[] = [];
-        vi.spyOn(console, 'log').mockImplementation((a) => lines.push(strip(a)));
+        vi.spyOn(console, 'log').mockImplementation((a) => lines.push(stripVTControlCharacters(a)));
         const lineWidth = 80;
         emitTraceResults('errorcode', true, sampleResultsWin32(), {
             cwd: 'D:/this_is_a_very/long/path',

--- a/packages/cspell/src/app/util/pad.ts
+++ b/packages/cspell/src/app/util/pad.ts
@@ -1,4 +1,4 @@
-import strip from 'strip-ansi';
+import { stripVTControlCharacters } from "node:util";
 
 export function pad(s: string, w: number): string {
     const p = padWidth(s, w);
@@ -28,5 +28,5 @@ export function width(s: string): number {
 }
 
 export function ansiWidth(s: string): number {
-    return width(strip(s));
+    return width(stripVTControlCharacters(s));
 }

--- a/packages/cspell/src/app/util/table.test.ts
+++ b/packages/cspell/src/app/util/table.test.ts
@@ -1,4 +1,5 @@
-import strip from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
+
 import { describe, expect, test } from 'vitest';
 
 import type { Table } from './table.js';
@@ -15,7 +16,7 @@ describe('Validate table.ts', () => {
             ],
         };
         const x = tableToLines(table);
-        expect(x.map(strip)).toEqual([
+        expect(x.map(stripVTControlCharacters)).toEqual([
             'id     | name    ',
             '27438  | Computer',
             '273438 | Desk    ',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,9 +255,6 @@ importers:
       semver:
         specifier: ^7.6.3
         version: 7.6.3
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       tinyglobby:
         specifier: ^0.2.9
         version: 0.2.9


### PR DESCRIPTION
## Overview

This pull request replaces `strip-ansi` with native Node utilities [`util.stripVTControlCharacters`](https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr) added in Node 16.

The impact of this pull request is reducing the amount of unneeded dependencies.