### PR TITLE
docs: Have the schema / docs align with actual

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,13 @@ Node JS version 18 or higher is required.
 
 ### Commands
 
-| Command                   | Description                                                                                   |
-| ------------------------- | --------------------------------------------------------------------------------------------- |
-| `pnpm install`            | Installs all the dependencies for all packages                                                |
-| `pnpm run build`          | To compile the typescript into javascript                                                     |
-| `pnpm test`               | Runs the unit tests for all packages                                                          |
-| `pnpm run check-spelling` | Checks the spelling for all sources files                                                     |
-| `pnpm run coverage`       | Generates coverage information for all projects. Open `coverage/index.html` to view coverage. |
+| Command                      | Description                                                                                   |
+| ---------------------------- | --------------------------------------------------------------------------------------------- |
+| `corepack enable`            | Makes sure the right version of the package manager is running.                               |
+| `pnpm install`               | Installs all the dependencies for all packages                                                |
+| `pnpm run build`             | To compile the typescript into javascript                                                     |
+| `pnpm test`                  | Runs the unit tests for all packages                                                          |
+| `pnpm ibt`                   | A shortcut to run install / build / test                                                      |
+| `pnpm update-test-snapshots` | Will build all the packages and run `pnpm test -- -u` in each package to update the snapshots |
+| `pnpm run check-spelling`    | Checks the spelling for all sources files                                                     |
+| `pnpm run coverage`          | Generates coverage information for all projects. Open `coverage/index.html` to view coverage. |

--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -15,7 +15,7 @@
       "properties": {
         "cacheFormat": {
           "$ref": "#/definitions/CacheFormat",
-          "default": "legacy",
+          "default": "universal",
           "description": "Format of the cache file.\n- `legacy` - use absolute paths in the cache file\n- `universal` - use a sharable format.",
           "markdownDescription": "Format of the cache file.\n- `legacy` - use absolute paths in the cache file\n- `universal` - use a sharable format."
         },

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -15,7 +15,7 @@
       "properties": {
         "cacheFormat": {
           "$ref": "#/definitions/CacheFormat",
-          "default": "legacy",
+          "default": "universal",
           "description": "Format of the cache file.\n- `legacy` - use absolute paths in the cache file\n- `universal` - use a sharable format.",
           "markdownDescription": "Format of the cache file.\n- `legacy` - use absolute paths in the cache file\n- `universal` - use a sharable format."
         },

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -370,7 +370,7 @@ export interface CacheSettings {
      * Format of the cache file.
      * - `legacy` - use absolute paths in the cache file
      * - `universal` - use a sharable format.
-     * @default 'legacy'
+     * @default 'universal'
      */
     cacheFormat?: CacheFormat | undefined;
 }


### PR DESCRIPTION
The actual default is `universal`.

https://github.com/streetsidesoftware/cspell/blob/8053a7d10ce7820dc2d44dea47eb4b25964633af/packages/cspell/src/app/util/cache/createCache.ts#L57