### PR TITLE
fix: cspell-tools - compounds

### DIFF
--- a/packages/cspell-tools/src/compiler/wordListCompiler.test.ts
+++ b/packages/cspell-tools/src/compiler/wordListCompiler.test.ts
@@ -214,7 +214,7 @@ describe('', () => {
         ${'HELLO|*hello*|*HELLO*'}       | ${['*hello*']}
         ${'HELLO|*HELLO*'}               | ${['*HELLO*']}
         ${'Hello|*Hello*'}               | ${['*Hello*']}
-        ${'hello|+hello+'}               | ${['hello', '+hello+']}
+        ${'hello|+hello+'}               | ${['*hello*' /* this is on purpose */]}
         ${'hello|hello+'}                | ${['hello*']}
         ${'hello|+hello'}                | ${['*hello']}
         ${'hello|hello+|+hello|+hello+'} | ${['*hello*']}

--- a/packages/cspell-tools/src/compiler/wordListCompiler.ts
+++ b/packages/cspell-tools/src/compiler/wordListCompiler.ts
@@ -124,7 +124,11 @@ function applyFlags(word: string, flags: Flags): string[] {
     if (flags === (Flags.none | Flags.sfx)) return ['*' + word];
     if (flags === (Flags.none | Flags.pfx)) return [word + '*'];
     if (flags === (Flags.none | Flags.pfx | Flags.sfx)) return [word + '*', '*' + word];
-    if (flags === (Flags.none | Flags.both)) return [word, '+' + word + '+'];
+    if (flags === (Flags.none | Flags.both)) {
+        // the "correct" answer is [word, '+' + word + '+']
+        // but practically it makes sense to allow all combinations.
+        return ['*' + word + '*'];
+    }
     if (flags === (Flags.none | Flags.both | Flags.sfx)) return [word, '+' + word + '*'];
     if (flags === (Flags.none | Flags.both | Flags.pfx)) return [word, '*' + word + '+'];
     if (flags === (Flags.both | Flags.pfx)) return ['*' + word + '+'];


### PR DESCRIPTION
This PR changes a single rule when merging compound forms:

When a word is allowed to be stand alone and a midfix compound, then allow it to be a prefix as well as a suffix.

The logic:
If we allow `code` and `strongcodetype`, then `codetype` or `strongcode` should also be allowed.