### PR TITLE
fix: Replace file-entry-cache

### DIFF
--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -88,6 +88,7 @@
     "@cspell/cspell-types": "workspace:*",
     "@cspell/dynamic-import": "workspace:*",
     "@cspell/url": "workspace:*",
+    "@types/flat-cache": "^2.0.2",
     "chalk": "^5.4.1",
     "chalk-template": "^1.1.0",
     "commander": "^14.0.0",
@@ -99,6 +100,7 @@
     "cspell-lib": "workspace:*",
     "fast-json-stable-stringify": "^2.1.0",
     "file-entry-cache": "^9.1.0",
+    "flat-cache": "^5.0.0",
     "semver": "^7.7.2",
     "tinyglobby": "^0.2.14"
   },

--- a/packages/cspell/package.json
+++ b/packages/cspell/package.json
@@ -99,7 +99,6 @@
     "cspell-io": "workspace:*",
     "cspell-lib": "workspace:*",
     "fast-json-stable-stringify": "^2.1.0",
-    "file-entry-cache": "^9.1.0",
     "flat-cache": "^5.0.0",
     "semver": "^7.7.2",
     "tinyglobby": "^0.2.14"
@@ -108,7 +107,6 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "@types/file-entry-cache": "^5.0.4",
     "@types/glob": "^8.1.0",
     "@types/micromatch": "^4.0.9",
     "@types/semver": "^7.7.0",

--- a/packages/cspell/src/util/cache/DiskCache.test.ts
+++ b/packages/cspell/src/util/cache/DiskCache.test.ts
@@ -52,7 +52,7 @@ describe('DiskCache', () => {
     describe('constructor', () => {
         test('creates file-entry-cache in specified location', () => {
             expect(mockCreateFileEntryCache).toHaveBeenCalledTimes(1);
-            expect(mockCreateFileEntryCache).toHaveBeenCalledWith(path.resolve('.foobar'), false);
+            expect(mockCreateFileEntryCache).toHaveBeenCalledWith(path.resolve('.foobar'), false, undefined);
         });
     });
 

--- a/packages/cspell/src/util/cache/file-entry-cache.mts
+++ b/packages/cspell/src/util/cache/file-entry-cache.mts
@@ -1,8 +1,2 @@
-import type { FileEntryCache } from 'file-entry-cache';
-import fileEntryCache from 'file-entry-cache';
-
-export type { FileDescriptor, FileEntryCache } from 'file-entry-cache';
-
-export function createFromFile(pathToCache: string, useChecksum?: boolean): FileEntryCache {
-    return fileEntryCache.createFromFile(pathToCache, useChecksum);
-}
+export type { FileDescriptor, FileEntryCache } from './file-entry-cache/index.js';
+export { createFromFile } from './file-entry-cache/index.js';

--- a/packages/cspell/src/util/cache/file-entry-cache/index.ts
+++ b/packages/cspell/src/util/cache/file-entry-cache/index.ts
@@ -1,0 +1,450 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Cache } from 'flat-cache';
+import flatCache from 'flat-cache';
+
+export function createFromFile(filePath: string, useChecksum?: boolean, currentWorkingDir?: string): FileEntryCache {
+    const fname = path.basename(filePath);
+    const dir = path.dirname(filePath);
+    return create(fname, dir, useChecksum, currentWorkingDir);
+}
+
+export function create(
+    cacheId: string,
+    dir: string,
+    useChecksum?: boolean,
+    currentWorkingDir?: string,
+): FileEntryCache {
+    const cache = flatCache.load(cacheId, dir);
+    return new ImplFileEntryCache(cache, useChecksum ?? false, currentWorkingDir);
+}
+
+class ImplFileEntryCache implements FileEntryCache {
+    readonly cache: Cache;
+    readonly useChecksum: boolean;
+    #normalizedEntries: Record<string, CacheEntry> = Object.create(null);
+
+    /**
+     * To enable relative paths as the key with current working directory
+     */
+    readonly currentWorkingDir: string | undefined;
+
+    constructor(cache: Cache, useChecksum?: boolean, currentWorkingDir?: string) {
+        this.cache = cache;
+        this.useChecksum = useChecksum || false;
+        this.currentWorkingDir = currentWorkingDir;
+        this.#removeNotFoundFiles();
+    }
+
+    #removeNotFoundFiles() {
+        const cachedEntries = this.cache.keys();
+        // Remove not found entries
+        for (const fPath of cachedEntries) {
+            try {
+                const filePath = this.resolveKeyToFile(fPath);
+                fs.statSync(filePath);
+            } catch (error) {
+                if (isNodeError(error) && error.code === 'ENOENT') {
+                    this.cache.removeKey(fPath);
+                }
+            }
+        }
+    }
+
+    /**
+     * Given a buffer, calculate md5 hash of its content.
+     * @param  buffer buffer to calculate hash on
+     * @return content hash digest
+     */
+    getHash(buffer: Buffer | string): string {
+        return crypto.createHash('md5').update(buffer).digest('hex');
+    }
+
+    /**
+     * Return whether or not a file has changed since last time reconcile was called.
+     * @method hasFileChanged
+     * @param  file  the filepath to check
+     * @return whether or not the file has changed
+     */
+    hasFileChanged(file: string): boolean | undefined {
+        return this.getFileDescriptor(file).changed;
+    }
+
+    /**
+     * Given an array of file paths it return and object with three arrays:
+     *  - changedFiles: Files that changed since previous run
+     *  - notChangedFiles: Files that haven't change
+     *  - notFoundFiles: Files that were not found, probably deleted
+     *
+     * @param files the files to analyze and compare to the previous seen files
+     */
+    analyzeFiles(files: string[] = []): AnalyzedFilesInfo {
+        const res: AnalyzedFilesInfo = {
+            changedFiles: [],
+            notFoundFiles: [],
+            notChangedFiles: [],
+        };
+
+        for (const entry of this.normalizeEntries(files)) {
+            if (entry.changed) {
+                res.changedFiles.push(entry.key);
+                continue;
+            }
+
+            if (entry.notFound) {
+                res.notFoundFiles.push(entry.key);
+                continue;
+            }
+
+            res.notChangedFiles.push(entry.key);
+        }
+
+        return res;
+    }
+
+    getFileDescriptor(file: string): FileDescriptor {
+        let fstat: fs.Stats;
+
+        try {
+            fstat = fs.statSync(file);
+        } catch (error) {
+            this.removeEntry(file);
+            return { key: file, notFound: true, err: toError(error) };
+        }
+
+        if (this.useChecksum) {
+            return this.#getFileDescriptorUsingChecksum(file);
+        }
+
+        return this.#getFileDescriptorUsingMtimeAndSize(file, fstat);
+    }
+
+    #getFileDescriptorUsingMtimeAndSize(file: string, fstat: fs.Stats): FileDescriptor {
+        const key = this.#getFileKey(file);
+        let meta = this.cache.getKey(key);
+        const cacheExists = !!meta;
+
+        const cSize = fstat.size;
+        const cTime = fstat.mtime.getTime();
+
+        let isDifferentDate;
+        let isDifferentSize;
+
+        if (meta) {
+            isDifferentDate = cTime !== meta.mtime;
+            isDifferentSize = cSize !== meta.size;
+        } else {
+            meta = { size: cSize, mtime: cTime };
+        }
+
+        const nEntry = {
+            key,
+            changed: !cacheExists || isDifferentDate || isDifferentSize,
+            meta,
+        };
+
+        this.#normalizedEntries[key] = nEntry;
+
+        return nEntry;
+    }
+
+    #getFileDescriptorUsingChecksum(file: string): FileDescriptor {
+        let meta = this.cache.getKey(this.#getFileKey(file));
+        const cacheExists = Boolean(meta);
+
+        let contentBuffer;
+        try {
+            contentBuffer = fs.readFileSync(file);
+        } catch {
+            contentBuffer = '';
+        }
+
+        let isDifferent = true;
+        const hash = this.getHash(contentBuffer);
+
+        if (meta) {
+            isDifferent = hash !== meta.hash;
+        } else {
+            meta = { hash };
+        }
+
+        const nEntry = (this.#normalizedEntries[this.#getFileKey(file)] = {
+            key: this.#getFileKey(file),
+            changed: !cacheExists || isDifferent,
+            meta,
+        });
+
+        return nEntry;
+    }
+
+    /**
+     * Return the list o the files that changed compared
+     * against the ones stored in the cache
+     *
+     * @method getUpdated
+     * @param files the array of files to compare against the ones in the cache
+     */
+    getUpdatedFiles(files?: string[]): string[] {
+        files ||= [];
+
+        return this.normalizeEntries(files)
+            .filter((entry) => entry.changed)
+            .map((entry) => entry.key);
+    }
+
+    /**
+     * Return the list of files
+     * @param files
+     */
+    normalizeEntries(files?: string[]): FileDescriptor[] {
+        files ||= [];
+
+        const nEntries = files.map((file) => this.getFileDescriptor(file));
+
+        // NormalizeEntries = nEntries;
+        return nEntries;
+    }
+
+    /**
+     * Remove an entry from the file-entry-cache. Useful to force the file to still be considered
+     * modified the next time the process is run
+     *
+     * @method removeEntry
+     * @param entryName
+     */
+    removeEntry(entryName: string): void {
+        delete this.#normalizedEntries[this.#getFileKey(entryName)];
+        this.cache.removeKey(this.#getFileKey(entryName));
+    }
+
+    /**
+     * Delete the cache file from the disk
+     * @method deleteCacheFile
+     */
+    deleteCacheFile(): void {
+        this.cache.removeCacheFile();
+    }
+
+    /**
+     * Remove the cache from the file and clear the memory cache
+     */
+    destroy(): void {
+        this.#normalizedEntries = Object.create(null);
+        this.cache.destroy();
+    }
+
+    #getMetaForFileUsingCheckSum(cacheEntry: CacheEntry): Meta {
+        let filePath = cacheEntry.key;
+        if (this.currentWorkingDir) {
+            filePath = path.join(this.currentWorkingDir, filePath);
+        }
+
+        const contentBuffer = fs.readFileSync(filePath);
+        const hash = this.getHash(contentBuffer);
+        const meta: Meta = Object.assign(cacheEntry.meta || {}, { hash });
+        delete meta.size;
+        delete meta.mtime;
+        return meta;
+    }
+
+    #getMetaForFileUsingMtimeAndSize(cacheEntry: CacheEntry): Meta {
+        let filePath = cacheEntry.key;
+        if (this.currentWorkingDir) {
+            filePath = path.join(this.currentWorkingDir, filePath);
+        }
+
+        const stat = fs.statSync(filePath);
+        const meta = Object.assign(cacheEntry.meta || {}, {
+            size: stat.size,
+            mtime: stat.mtime.getTime(),
+        });
+        delete meta.hash;
+        return meta;
+    }
+
+    /**
+     * Sync the files and persist them to the cache
+     * @method reconcile
+     */
+    reconcile(noPrune: boolean = true): void {
+        this.#removeNotFoundFiles();
+
+        const entries = this.#normalizedEntries;
+        const keys = Object.keys(entries);
+
+        if (keys.length === 0) {
+            return;
+        }
+
+        for (const entryName of keys) {
+            const cacheEntry = entries[entryName];
+
+            try {
+                const meta = this.useChecksum
+                    ? this.#getMetaForFileUsingCheckSum(cacheEntry)
+                    : this.#getMetaForFileUsingMtimeAndSize(cacheEntry);
+                this.cache.setKey(this.#getFileKey(entryName), meta);
+            } catch (error) {
+                // If the file does not exists we don't save it
+                // other errors are just thrown
+                if (!isNodeError(error) || error.code !== 'ENOENT') {
+                    throw error;
+                }
+            }
+        }
+
+        this.cache.save(noPrune);
+    }
+
+    resolveKeyToFile(key: string): string {
+        if (this.currentWorkingDir) {
+            return path.resolve(this.currentWorkingDir, key);
+        }
+        return key;
+    }
+
+    #getFileKey(file: string): string {
+        if (this.currentWorkingDir && path.isAbsolute(file)) {
+            return path.relative(this.currentWorkingDir, file);
+        }
+        return file;
+    }
+}
+
+interface NodeError extends Error {
+    code?: string;
+}
+
+function isNodeError(error: unknown): error is NodeError {
+    return typeof error === 'object' && error !== null && 'code' in error;
+}
+
+function toError(error: unknown): Error {
+    if (error instanceof Error) {
+        return error;
+    }
+    if (typeof error === 'string') {
+        return new Error(error);
+    }
+    return new Error('Unknown error', { cause: error });
+}
+
+export interface AnalyzedFilesInfo {
+    readonly changedFiles: string[];
+    readonly notFoundFiles: string[];
+    readonly notChangedFiles: string[];
+}
+
+interface UserData {
+    data?: unknown;
+}
+
+interface Meta extends UserData {
+    size?: number | undefined;
+    mtime?: number | undefined;
+    hash?: string | undefined;
+}
+
+interface CacheEntry {
+    key: string;
+    notFound?: boolean;
+    err?: Error | undefined;
+    changed?: boolean | undefined;
+    meta?: Meta | undefined;
+}
+
+export type FileDescriptor = Readonly<CacheEntry>;
+
+export interface FileEntryCache {
+    /**
+     * The flat cache storage used to persist the metadata of the `files
+     * @type {Object}
+     */
+    cache: Cache;
+
+    /**
+     * To enable relative paths as the key with current working directory
+     * @type {string}
+     */
+    currentWorkingDir: string | undefined;
+
+    /**
+     * Given a buffer, calculate md5 hash of its content.
+     * @method getHash
+     * @param  {Buffer} buffer   buffer to calculate hash on
+     * @return {String}          content hash digest
+     */
+    getHash(buffer: Buffer | string): string;
+
+    /**
+     * Return whether or not a file has changed since last time reconcile was called.
+     * @method hasFileChanged
+     * @param  {String}  file  the filepath to check
+     * @return {Boolean}       whether or not the file has changed
+     */
+    hasFileChanged(file: string): boolean | undefined;
+
+    /**
+     * Given an array of file paths it return and object with three arrays:
+     *  - changedFiles: Files that changed since previous run
+     *  - notChangedFiles: Files that haven't change
+     *  - notFoundFiles: Files that were not found, probably deleted
+     *
+     * @param  {Array} files the files to analyze and compare to the previous seen files
+     * @return {[type]}       [description]
+     */
+    analyzeFiles(files?: string[]): AnalyzedFilesInfo;
+
+    getFileDescriptor(file: string): FileDescriptor;
+
+    /**
+     * Return the list o the files that changed compared
+     * against the ones stored in the cache
+     *
+     * @method getUpdated
+     * @param files {Array} the array of files to compare against the ones in the cache
+     * @returns {Array}
+     */
+    getUpdatedFiles(files?: string[]): string[];
+
+    /**
+     * Return the list of files
+     * @method normalizeEntries
+     * @param files
+     * @returns {*}
+     */
+    normalizeEntries(files?: string[]): FileDescriptor[];
+
+    /**
+     * Remove an entry from the file-entry-cache. Useful to force the file to still be considered
+     * modified the next time the process is run
+     *
+     * @method removeEntry
+     * @param entryName
+     */
+    removeEntry(entryName: string): void;
+
+    /**
+     * Delete the cache file from the disk
+     * @method deleteCacheFile
+     */
+    deleteCacheFile(): void;
+
+    /**
+     * Remove the cache from the file and clear the memory cache
+     */
+    destroy(): void;
+
+    /**
+     * Sync the files and persist them to the cache
+     * @method reconcile
+     */
+    reconcile(noPrune?: boolean): void;
+}
+
+export function normalizePath(filePath: string): string {
+    if (path.sep === '/') return filePath;
+    return filePath.split(path.sep).join('/');
+}

--- a/packages/cspell/src/util/cache/file-entry-cache/index.ts
+++ b/packages/cspell/src/util/cache/file-entry-cache/index.ts
@@ -343,79 +343,7 @@ interface CacheEntry {
 export type FileDescriptor = Readonly<CacheEntry>;
 
 export interface FileEntryCache {
-    /**
-     * The flat cache storage used to persist the metadata of the `files
-     * @type {Object}
-     */
-    cache: Cache;
-
-    /**
-     * To enable relative paths as the key with current working directory
-     * @type {string}
-     */
-    currentWorkingDir: string | undefined;
-
-    /**
-     * Given a buffer, calculate md5 hash of its content.
-     * @method getHash
-     * @param  {Buffer} buffer   buffer to calculate hash on
-     * @return {String}          content hash digest
-     */
-    getHash(buffer: Buffer | string): string;
-
-    /**
-     * Return whether or not a file has changed since last time reconcile was called.
-     * @method hasFileChanged
-     * @param  {String}  file  the filepath to check
-     * @return {Boolean}       whether or not the file has changed
-     */
-    hasFileChanged(file: string): boolean | undefined;
-
-    /**
-     * Given an array of file paths it return and object with three arrays:
-     *  - changedFiles: Files that changed since previous run
-     *  - notChangedFiles: Files that haven't change
-     *  - notFoundFiles: Files that were not found, probably deleted
-     *
-     * @param  {Array} files the files to analyze and compare to the previous seen files
-     * @return {[type]}       [description]
-     */
-    analyzeFiles(files?: string[]): AnalyzedFilesInfo;
-
     getFileDescriptor(file: string): FileDescriptor;
-
-    /**
-     * Return the list o the files that changed compared
-     * against the ones stored in the cache
-     *
-     * @method getUpdated
-     * @param files {Array} the array of files to compare against the ones in the cache
-     * @returns {Array}
-     */
-    getUpdatedFiles(files?: string[]): string[];
-
-    /**
-     * Return the list of files
-     * @method normalizeEntries
-     * @param files
-     * @returns {*}
-     */
-    normalizeEntries(files?: string[]): FileDescriptor[];
-
-    /**
-     * Remove an entry from the file-entry-cache. Useful to force the file to still be considered
-     * modified the next time the process is run
-     *
-     * @method removeEntry
-     * @param entryName
-     */
-    removeEntry(entryName: string): void;
-
-    /**
-     * Delete the cache file from the disk
-     * @method deleteCacheFile
-     */
-    deleteCacheFile(): void;
 
     /**
      * Remove the cache from the file and clear the memory cache
@@ -424,7 +352,6 @@ export interface FileEntryCache {
 
     /**
      * Sync the files and persist them to the cache
-     * @method reconcile
      */
     reconcile(noPrune?: boolean): void;
 }

--- a/packages/cspell/src/util/cache/fileEntryCache.ts
+++ b/packages/cspell/src/util/cache/fileEntryCache.ts
@@ -5,7 +5,6 @@
 export type { FileDescriptor } from './file-entry-cache.mjs';
 import { mkdirSync } from 'node:fs';
 import * as path from 'node:path';
-import { isMainThread } from 'node:worker_threads';
 
 import type { FileEntryCache as FecFileEntryCache } from './file-entry-cache.mjs';
 import * as fec from './file-entry-cache.mjs';
@@ -16,71 +15,7 @@ export function createFromFile(pathToCache: string, useCheckSum: boolean, useRel
     const absPathToCache = path.resolve(pathToCache);
     const relDir = path.dirname(absPathToCache);
     mkdirSync(relDir, { recursive: true });
-    const create = wrap(() => fec.createFromFile(absPathToCache, useCheckSum));
-    const feCache = create();
-    const cacheWrapper: FileEntryCache = {
-        currentWorkingDir: relDir,
-        get cache() {
-            return feCache.cache;
-        },
-        getHash(buffer: Buffer): string {
-            return feCache.getHash(buffer);
-        },
-        hasFileChanged: wrap((cwd, file: string) => {
-            // console.log(file);
-            return feCache.hasFileChanged(resolveFile(cwd, file));
-        }),
-        analyzeFiles: wrap((cwd, files?: string[]) => {
-            return feCache.analyzeFiles(resolveFiles(cwd, files));
-        }),
-
-        getFileDescriptor: wrap((cwd, file: string) => {
-            return feCache.getFileDescriptor(resolveFile(cwd, file));
-        }),
-        getUpdatedFiles: wrap((cwd, files?: string[]) => {
-            return feCache.getUpdatedFiles(resolveFiles(cwd, files));
-        }),
-        normalizeEntries: wrap((cwd, files?: string[]) => {
-            return feCache.normalizeEntries(resolveFiles(cwd, files));
-        }),
-        removeEntry: wrap((cwd, file: string) => {
-            // console.log(file);
-            return feCache.removeEntry(resolveFile(cwd, file));
-        }),
-        deleteCacheFile(): void {
-            feCache.deleteCacheFile();
-        },
-        destroy(): void {
-            feCache.destroy();
-        },
-        reconcile: wrap((_cwd, noPrune?: boolean) => {
-            feCache.reconcile(noPrune);
-        }),
-    };
-
-    return cacheWrapper;
-
-    function resolveFile(cwd: string, file: string): string {
-        if (!useRelative) return normalizePath(file);
-        const r = path.relative(relDir, path.resolve(cwd, file));
-        return normalizePath(r);
-    }
-
-    function resolveFiles(cwd: string, files: string[] | undefined): string[] | undefined {
-        return files?.map((file) => resolveFile(cwd, file));
-    }
-
-    function wrap<P extends unknown[], T>(fn: (cwd: string, ...params: P) => T): (...params: P) => T {
-        return (...params: P) => {
-            const cwd = process.cwd();
-            try {
-                isMainThread && process.chdir(relDir);
-                return fn(cwd, ...params);
-            } finally {
-                isMainThread && process.chdir(cwd);
-            }
-        };
-    }
+    return fec.createFromFile(absPathToCache, useCheckSum, useRelative ? relDir : undefined);
 }
 
 export function normalizePath(filePath: string): string {

--- a/packages/cspell/src/util/cache/fileEntryCache.ts
+++ b/packages/cspell/src/util/cache/fileEntryCache.ts
@@ -19,6 +19,7 @@ export function createFromFile(pathToCache: string, useCheckSum: boolean, useRel
     const create = wrap(() => fec.createFromFile(absPathToCache, useCheckSum));
     const feCache = create();
     const cacheWrapper: FileEntryCache = {
+        currentWorkingDir: relDir,
         get cache() {
             return feCache.cache;
         },

--- a/packages/cspell/vitest.config.mjs
+++ b/packages/cspell/vitest.config.mjs
@@ -33,6 +33,7 @@ export default mergeConfig(
                     'coverage',
                     'dist/**',
                     'esm/**',
+                    'tools/**',
                     'fixtures/**',
                     'lib/**',
                     'vitest*',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@cspell/url':
         specifier: workspace:*
         version: link:../cspell-url
+      '@types/flat-cache':
+        specifier: ^2.0.2
+        version: 2.0.2
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -263,6 +266,9 @@ importers:
       file-entry-cache:
         specifier: ^9.1.0
         version: 9.1.0
+      flat-cache:
+        specifier: ^5.0.0
+        version: 5.0.0
       semver:
         specifier: ^7.7.2
         version: 7.7.2
@@ -4159,6 +4165,9 @@ packages:
 
   '@types/file-entry-cache@5.0.4':
     resolution: {integrity: sha512-Fa2gRWMSgbVEJ6GeDkFfBEDK/wpFBHkfeRt7oaeOjuPMdPr8KtA3y+onRuZNxgPOwyABD1chCzmE7pz10ouNog==}
+
+  '@types/flat-cache@2.0.2':
+    resolution: {integrity: sha512-uZRK+n0d9JBzcEqjRJGD9SiPtDKUn4E5w4n6iFHqAdgylJFc2Eh2KK9UimvH/saz6dwGC36Jt1DzyKBvHiEIgA==}
 
   '@types/glob@8.1.0':
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
@@ -14228,6 +14237,8 @@ snapshots:
   '@types/file-entry-cache@5.0.4':
     dependencies:
       '@types/node': 24.0.14
+
+  '@types/flat-cache@2.0.2': {}
 
   '@types/glob@8.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,6 @@ importers:
       fast-json-stable-stringify:
         specifier: ^2.1.0
         version: 2.1.0
-      file-entry-cache:
-        specifier: ^9.1.0
-        version: 9.1.0
       flat-cache:
         specifier: ^5.0.0
         version: 5.0.0
@@ -276,9 +273,6 @@ importers:
         specifier: ^0.2.14
         version: 0.2.14
     devDependencies:
-      '@types/file-entry-cache':
-        specifier: ^5.0.4
-        version: 5.0.4
       '@types/glob':
         specifier: ^8.1.0
         version: 8.1.0
@@ -696,7 +690,7 @@ importers:
         version: 5.8.3
       vitest-fetch-mock:
         specifier: ^0.4.5
-        version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
+        version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))
 
   packages/cspell-json-reporter:
     dependencies:
@@ -1412,7 +1406,7 @@ importers:
         version: 3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       '@docusaurus/preset-classic':
         specifier: ^3.8.1
-        version: 3.8.1(@algolia/client-search@5.33.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)
+        version: 3.8.1(@algolia/client-search@5.32.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)
       '@docusaurus/remark-plugin-npm2yarn':
         specifier: ^3.8.1
         version: 3.8.1
@@ -1476,59 +1470,59 @@ packages:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
 
-  '@algolia/client-abtesting@5.33.0':
-    resolution: {integrity: sha512-Pyv+iHkkq7BJWFKzdrXm/JSbcTGvrGqJnIMwHYYlKDjuEBWhYt/z4WDLP9MbFZ9cTKb4qe8OvzEmS/0ERW3ibg==}
+  '@algolia/client-abtesting@5.32.0':
+    resolution: {integrity: sha512-HG/6Eib6DnJYm/B2ijWFXr4txca/YOuA4K7AsEU0JBrOZSB+RU7oeDyNBPi3c0v0UDDqlkBqM3vBU/auwZlglA==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/client-analytics@5.33.0':
-    resolution: {integrity: sha512-qkRc7ovjWQQJng6U1yM5esLPNDB0leGCaOh3FEfeWRyLB0xnjLsBEUkKanYq9GrewPvi17l78nDhkqB2SYzTCw==}
+  '@algolia/client-analytics@5.32.0':
+    resolution: {integrity: sha512-8Y9MLU72WFQOW3HArYv16+Wvm6eGmsqbxxM1qxtm0hvSASJbxCm+zQAZe5stqysTlcWo4BJ82KEH1PfgHbJAmQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/client-common@5.33.0':
-    resolution: {integrity: sha512-Gq8Z4Fv0DkqDkf/bZl7ZwIF7PSCnRFwpyQoNDnUg+s4SwerXx6VwZJlIx/t5b9+l7vwWsjnKVivCfM4Ab5gw+g==}
+  '@algolia/client-common@5.32.0':
+    resolution: {integrity: sha512-w8L+rgyXMCPBKmEdOT+RfgMrF0mT6HK60vPYWLz8DBs/P7yFdGo7urn99XCJvVLMSKXrIbZ2FMZ/i50nZTXnuQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/client-insights@5.33.0':
-    resolution: {integrity: sha512-/tp1oWD3lpSXhAC4n8j0GMDbmN6pd+pATeO1GeURAFP5TVF+2Jz+NbQ1et0uCTzdazOfjEjSIv0fQSLo7bqSgA==}
+  '@algolia/client-insights@5.32.0':
+    resolution: {integrity: sha512-AdWfynhUeX7jz/LTiFU3wwzJembTbdLkQIOLs4n7PyBuxZ3jz4azV1CWbIP8AjUOFmul6uXbmYza+KqyS5CzOA==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/client-personalization@5.33.0':
-    resolution: {integrity: sha512-hZNSqe2BXkrBQ04t5NSlqsNl4u0QrFfhXHbjO5iZ14TWt5jyOdtFMBxF3Qc0o0sqTVYnFIp0xtUbEi+/HkGeyQ==}
+  '@algolia/client-personalization@5.32.0':
+    resolution: {integrity: sha512-bTupJY4xzGZYI4cEQcPlSjjIEzMvv80h7zXGrXY1Y0KC/n/SLiMv84v7Uy+B6AG1Kiy9FQm2ADChBLo1uEhGtQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/client-query-suggestions@5.33.0':
-    resolution: {integrity: sha512-kpu2hCIR+848T0lcf3W1GCMe+HQp/LcHceIglA6Dyw6i+y9wH3w8kmXqIV2Svv6JQ9ojEqIL8Knk7NEvD3xIBg==}
+  '@algolia/client-query-suggestions@5.32.0':
+    resolution: {integrity: sha512-if+YTJw1G3nDKL2omSBjQltCHUQzbaHADkcPQrGFnIGhVyHU3Dzq4g46uEv8mrL5sxL8FjiS9LvekeUlL2NRqw==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/client-search@5.33.0':
-    resolution: {integrity: sha512-Z5SAqPLxF8KyE9YPO4tAdHrXyb87DUJ0lXhFrcrG+dl/AQT9nqycQhtqDqdcQnfZrj02PImSWZQpxQj34nGZKw==}
+  '@algolia/client-search@5.32.0':
+    resolution: {integrity: sha512-kmK5nVkKb4DSUgwbveMKe4X3xHdMsPsOVJeEzBvFJ+oS7CkBPmpfHAEq+CcmiPJs20YMv6yVtUT9yPWL5WgAhg==}
     engines: {node: '>= 14.0.0'}
 
   '@algolia/events@4.0.1':
     resolution: {integrity: sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==}
 
-  '@algolia/ingestion@1.33.0':
-    resolution: {integrity: sha512-KNJI60N+twnDLiIY+oGO2Q+syS+yBNOmNdhsB5vCzzrhi3CYs+bufnJ67/BUUfnt+T5+3VlnkvUgDkGBmmZXmA==}
+  '@algolia/ingestion@1.32.0':
+    resolution: {integrity: sha512-PZTqjJbx+fmPuT2ud1n4vYDSF1yrT//vOGI9HNYKNA0PM0xGUBWigf5gRivHsXa3oBnUlTyHV9j7Kqx5BHbVHQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/monitoring@1.33.0':
-    resolution: {integrity: sha512-47R0kMDTSj8Q7rCUgIRv5Xc518tCBBS0KIZ5oRKg+hspQaJmEO+fxwGLrIIwp5JiaK6y+5sbS7bhtaajelJhpg==}
+  '@algolia/monitoring@1.32.0':
+    resolution: {integrity: sha512-kYYoOGjvNQAmHDS1v5sBj+0uEL9RzYqH/TAdq8wmcV+/22weKt/fjh+6LfiqkS1SCZFYYrwGnirrUhUM36lBIQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/recommend@5.33.0':
-    resolution: {integrity: sha512-HpeLoVQuv5kW9xL0RSq1exa8ueNwyx+9B02dzFonlQzKTaSedM0jiWo6m3nWpi1hChAKqjzkL40FkxrgyrWTSg==}
+  '@algolia/recommend@5.32.0':
+    resolution: {integrity: sha512-jyIBLdskjPAL7T1g57UMfUNx+PzvYbxKslwRUKBrBA6sNEsYCFdxJAtZSLUMmw6MC98RDt4ksmEl5zVMT5bsuw==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/requester-browser-xhr@5.33.0':
-    resolution: {integrity: sha512-uOqDkvY7s9c9rkaZ4+n69LkTmZ5ax3el+8u6ipvODfj1P3HzrGvMUVFy/nGSXxw+XITKcIRphPQcyqn15b02dA==}
+  '@algolia/requester-browser-xhr@5.32.0':
+    resolution: {integrity: sha512-eDp14z92Gt6JlFgiexImcWWH+Lk07s/FtxcoDaGrE4UVBgpwqOO6AfQM6dXh1pvHxlDFbMJihHc/vj3gBhPjqQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/requester-fetch@5.33.0':
-    resolution: {integrity: sha512-NzTEGjwjPhUXPsrjj9nXM43+jtBVeL6UgGNBTQKsxjpqJ3EEAQ2Kq5g7DRK6mVDTQiTBWvBLKChJpn4qxwtLsg==}
+  '@algolia/requester-fetch@5.32.0':
+    resolution: {integrity: sha512-rnWVglh/K75hnaLbwSc2t7gCkbq1ldbPgeIKDUiEJxZ4mlguFgcltWjzpDQ/t1LQgxk9HdIFcQfM17Hid3aQ6Q==}
     engines: {node: '>= 14.0.0'}
 
-  '@algolia/requester-node-http@5.33.0':
-    resolution: {integrity: sha512-FhEE19ScAYuXL3VLj2I3KhL7683gZwZoa+BQZUEnA05vSbVBhCAqUBQgiVu7j2RF3VceqLX3+GEeY0bHs4y7eA==}
+  '@algolia/requester-node-http@5.32.0':
+    resolution: {integrity: sha512-LbzQ04+VLkzXY4LuOzgyjqEv/46Gwrk55PldaglMJ4i4eDXSRXGKkwJpXFwsoU+c1HMQlHIyjJBhrfsfdyRmyQ==}
     engines: {node: '>= 14.0.0'}
 
   '@ampproject/remapping@2.3.0':
@@ -3080,8 +3074,8 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@gerrit0/mini-shiki@3.8.0':
-    resolution: {integrity: sha512-tloLVqvvoyv636PilYZwNhCmZ+xxgRicysMvpKdZ4Y6+9IH6v4lp7GodbDDncApNQjflwTSnXuYQoe3el5C59w==}
+  '@gerrit0/mini-shiki@3.7.0':
+    resolution: {integrity: sha512-7iY9wg4FWXmeoFJpUL2u+tsmh0d0jcEJHAIzVxl3TG4KL493JNnisdLAILZ77zcD+z3J0keEXZ+lFzUgzQzPDg==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -3822,17 +3816,17 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@shikijs/engine-oniguruma@3.8.0':
-    resolution: {integrity: sha512-Tx7kR0oFzqa+rY7t80LjN8ZVtHO3a4+33EUnBVx2qYP3fGxoI9H0bvnln5ySelz9SIUTsS0/Qn+9dg5zcUMsUw==}
+  '@shikijs/engine-oniguruma@3.7.0':
+    resolution: {integrity: sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==}
 
-  '@shikijs/langs@3.8.0':
-    resolution: {integrity: sha512-mfGYuUgjQ5GgXinB5spjGlBVhG2crKRpKkfADlp8r9k/XvZhtNXxyOToSnCEnF0QNiZnJjlt5MmU9PmhRdwAbg==}
+  '@shikijs/langs@3.7.0':
+    resolution: {integrity: sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==}
 
-  '@shikijs/themes@3.8.0':
-    resolution: {integrity: sha512-yaZiLuyO23sXe16JFU76KyUMTZCJi4EMQKIrdQt7okoTzI4yAaJhVXT2Uy4k8yBIEFRiia5dtD7gC1t8m6y3oQ==}
+  '@shikijs/themes@3.7.0':
+    resolution: {integrity: sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==}
 
-  '@shikijs/types@3.8.0':
-    resolution: {integrity: sha512-I/b/aNg0rP+kznVDo7s3UK8jMcqEGTtoPDdQ+JlQ2bcJIyu/e2iRvl42GLIDMK03/W1YOHOuhlhQ7aM+XbKUeg==}
+  '@shikijs/types@3.7.0':
+    resolution: {integrity: sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -4163,9 +4157,6 @@ packages:
   '@types/express@4.17.23':
     resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
 
-  '@types/file-entry-cache@5.0.4':
-    resolution: {integrity: sha512-Fa2gRWMSgbVEJ6GeDkFfBEDK/wpFBHkfeRt7oaeOjuPMdPr8KtA3y+onRuZNxgPOwyABD1chCzmE7pz10ouNog==}
-
   '@types/flat-cache@2.0.2':
     resolution: {integrity: sha512-uZRK+n0d9JBzcEqjRJGD9SiPtDKUn4E5w4n6iFHqAdgylJFc2Eh2KK9UimvH/saz6dwGC36Jt1DzyKBvHiEIgA==}
 
@@ -4238,11 +4229,11 @@ packages:
   '@types/node@20.19.8':
     resolution: {integrity: sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==}
 
-  '@types/node@22.16.4':
-    resolution: {integrity: sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==}
+  '@types/node@22.16.3':
+    resolution: {integrity: sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==}
 
-  '@types/node@24.0.14':
-    resolution: {integrity: sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==}
+  '@types/node@24.0.13':
+    resolution: {integrity: sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4504,8 +4495,8 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  acorn-import-phases@1.0.4:
-    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+  acorn-import-phases@1.0.3:
+    resolution: {integrity: sha512-jtKLnfoOzm28PazuQ4dVBcE9Jeo6ha1GAJvq3N0LlNOszmTfx+wSycBehn+FN0RnyeR77IBxN/qVYMw0Rlj0Xw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       acorn: ^8.14.0
@@ -4570,8 +4561,8 @@ packages:
     peerDependencies:
       algoliasearch: '>= 3.1 < 6'
 
-  algoliasearch@5.33.0:
-    resolution: {integrity: sha512-WdgSkmyTec5n2W2FA2/7Q7TCSajCV0X6w57u3H5GHnw0UCp/G5xb33/Jx1FX3uMtz17P3wGEzMCP82d0LJqMow==}
+  algoliasearch@5.32.0:
+    resolution: {integrity: sha512-84xBncKNPBK8Ae89F65+SyVcOihrIbm/3N7to+GpRBHEUXGjA3ydWTMpcRW6jmFzkBQ/eqYy/y+J+NBpJWYjBg==}
     engines: {node: '>= 14.0.0'}
 
   ansi-align@3.0.1:
@@ -4777,8 +4768,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  birpc@2.5.0:
-    resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
+  birpc@2.4.0:
+    resolution: {integrity: sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -5710,8 +5701,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.183:
-    resolution: {integrity: sha512-vCrDBYjQCAEefWGjlK3EpoSKfKbT10pR4XXPdn65q7snuNOZnthoVpBfZPykmDapOKfoD+MMIPG8ZjKyyc9oHA==}
+  electron-to-chromium@1.5.182:
+    resolution: {integrity: sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -10567,112 +10558,112 @@ packages:
 
 snapshots:
 
-  '@algolia/autocomplete-core@1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)(search-insights@2.17.2)':
+  '@algolia/autocomplete-core@1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)(search-insights@2.17.2)':
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)(search-insights@2.17.2)
-      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)(search-insights@2.17.2)
+      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
       - search-insights
 
-  '@algolia/autocomplete-plugin-algolia-insights@1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)(search-insights@2.17.2)':
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)(search-insights@2.17.2)':
     dependencies:
-      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)
+      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)
       search-insights: 2.17.2
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@algolia/autocomplete-preset-algolia@1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)':
+  '@algolia/autocomplete-preset-algolia@1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)':
     dependencies:
-      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)
-      '@algolia/client-search': 5.33.0
-      algoliasearch: 5.33.0
+      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)
+      '@algolia/client-search': 5.32.0
+      algoliasearch: 5.32.0
 
-  '@algolia/autocomplete-shared@1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)':
+  '@algolia/autocomplete-shared@1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)':
     dependencies:
-      '@algolia/client-search': 5.33.0
-      algoliasearch: 5.33.0
+      '@algolia/client-search': 5.32.0
+      algoliasearch: 5.32.0
 
-  '@algolia/client-abtesting@5.33.0':
+  '@algolia/client-abtesting@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/client-analytics@5.33.0':
+  '@algolia/client-analytics@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/client-common@5.33.0': {}
+  '@algolia/client-common@5.32.0': {}
 
-  '@algolia/client-insights@5.33.0':
+  '@algolia/client-insights@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/client-personalization@5.33.0':
+  '@algolia/client-personalization@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/client-query-suggestions@5.33.0':
+  '@algolia/client-query-suggestions@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/client-search@5.33.0':
+  '@algolia/client-search@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
   '@algolia/events@4.0.1': {}
 
-  '@algolia/ingestion@1.33.0':
+  '@algolia/ingestion@1.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/monitoring@1.33.0':
+  '@algolia/monitoring@1.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/recommend@5.33.0':
+  '@algolia/recommend@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
-  '@algolia/requester-browser-xhr@5.33.0':
+  '@algolia/requester-browser-xhr@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
+      '@algolia/client-common': 5.32.0
 
-  '@algolia/requester-fetch@5.33.0':
+  '@algolia/requester-fetch@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
+      '@algolia/client-common': 5.32.0
 
-  '@algolia/requester-node-http@5.33.0':
+  '@algolia/requester-node-http@5.32.0':
     dependencies:
-      '@algolia/client-common': 5.33.0
+      '@algolia/client-common': 5.32.0
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -11955,12 +11946,12 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
-  '@docsearch/react@3.9.0(@algolia/client-search@5.33.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.32.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)':
     dependencies:
-      '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)(search-insights@2.17.2)
-      '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.33.0)(algoliasearch@5.33.0)
+      '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)(search-insights@2.17.2)
+      '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.32.0)(algoliasearch@5.32.0)
       '@docsearch/css': 3.9.0
-      algoliasearch: 5.33.0
+      algoliasearch: 5.32.0
     optionalDependencies:
       '@types/react': 19.1.8
       react: 19.1.0
@@ -12518,7 +12509,7 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.8.1(@algolia/client-search@5.33.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)':
+  '@docusaurus/preset-classic@3.8.1(@algolia/client-search@5.32.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)':
     dependencies:
       '@docusaurus/core': 3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       '@docusaurus/plugin-content-blog': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -12533,7 +12524,7 @@ snapshots:
       '@docusaurus/plugin-svgr': 3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       '@docusaurus/theme-classic': 3.8.1(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       '@docusaurus/theme-common': 3.8.1(@docusaurus/plugin-content-docs@3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@docusaurus/theme-search-algolia': 3.8.1(@algolia/client-search@5.33.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)
+      '@docusaurus/theme-search-algolia': 3.8.1(@algolia/client-search@5.32.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)
       '@docusaurus/types': 3.8.1(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -12648,9 +12639,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.8.1(@algolia/client-search@5.33.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)':
+  '@docusaurus/theme-search-algolia@3.8.1(@algolia/client-search@5.32.0)(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(@types/react@19.1.8)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)(typescript@5.8.3)':
     dependencies:
-      '@docsearch/react': 3.9.0(@algolia/client-search@5.33.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.32.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.2)
       '@docusaurus/core': 3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
       '@docusaurus/logger': 3.8.1
       '@docusaurus/plugin-content-docs': 3.8.1(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
@@ -12658,8 +12649,8 @@ snapshots:
       '@docusaurus/theme-translations': 3.8.1
       '@docusaurus/utils': 3.8.1(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@docusaurus/utils-validation': 3.8.1(@swc/core@1.7.26)(acorn@8.15.0)(esbuild@0.25.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      algoliasearch: 5.33.0
-      algoliasearch-helper: 3.26.0(algoliasearch@5.33.0)
+      algoliasearch: 5.32.0
+      algoliasearch-helper: 3.26.0(algoliasearch@5.32.0)
       clsx: 2.1.1
       eta: 2.2.0
       fs-extra: 11.3.0
@@ -12989,12 +12980,12 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
-  '@gerrit0/mini-shiki@3.8.0':
+  '@gerrit0/mini-shiki@3.7.0':
     dependencies:
-      '@shikijs/engine-oniguruma': 3.8.0
-      '@shikijs/langs': 3.8.0
-      '@shikijs/themes': 3.8.0
-      '@shikijs/types': 3.8.0
+      '@shikijs/engine-oniguruma': 3.7.0
+      '@shikijs/langs': 3.7.0
+      '@shikijs/themes': 3.7.0
+      '@shikijs/types': 3.7.0
       '@shikijs/vscode-textmate': 10.0.2
 
   '@hapi/hoek@9.3.0': {}
@@ -13136,7 +13127,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -13866,20 +13857,20 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@shikijs/engine-oniguruma@3.8.0':
+  '@shikijs/engine-oniguruma@3.7.0':
     dependencies:
-      '@shikijs/types': 3.8.0
+      '@shikijs/types': 3.7.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@3.8.0':
+  '@shikijs/langs@3.7.0':
     dependencies:
-      '@shikijs/types': 3.8.0
+      '@shikijs/types': 3.7.0
 
-  '@shikijs/themes@3.8.0':
+  '@shikijs/themes@3.7.0':
     dependencies:
-      '@shikijs/types': 3.8.0
+      '@shikijs/types': 3.7.0
 
-  '@shikijs/types@3.8.0':
+  '@shikijs/types@3.7.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -13929,11 +13920,11 @@ snapshots:
   '@simple-libs/child-process-utils@1.0.1':
     dependencies:
       '@simple-libs/stream-utils': 1.1.0
-      '@types/node': 22.16.4
+      '@types/node': 22.16.3
 
   '@simple-libs/stream-utils@1.1.0':
     dependencies:
-      '@types/node': 22.16.4
+      '@types/node': 22.16.3
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -14164,11 +14155,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/braces@3.0.5': {}
 
@@ -14178,18 +14169,18 @@ snapshots:
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 22.16.4
+      '@types/node': 20.19.8
 
   '@types/configstore@6.0.2': {}
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.0.7
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/debug@4.1.12':
     dependencies:
@@ -14215,14 +14206,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
 
   '@types/express-serve-static-core@5.0.7':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -14234,16 +14225,12 @@ snapshots:
       '@types/qs': 6.14.0
       '@types/serve-static': 1.15.8
 
-  '@types/file-entry-cache@5.0.4':
-    dependencies:
-      '@types/node': 24.0.14
-
   '@types/flat-cache@2.0.2': {}
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 24.0.14
+      '@types/node': 24.0.13
 
   '@types/gtag.js@0.0.12': {}
 
@@ -14261,7 +14248,7 @@ snapshots:
 
   '@types/http-proxy@1.17.16':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/is-empty@1.2.3': {}
 
@@ -14297,7 +14284,7 @@ snapshots:
 
   '@types/node-forge@1.3.13':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/node@17.0.45': {}
 
@@ -14305,11 +14292,11 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.16.4':
+  '@types/node@22.16.3':
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@24.0.14':
+  '@types/node@24.0.13':
     dependencies:
       undici-types: 7.8.0
 
@@ -14354,14 +14341,14 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 20.19.8
 
   '@types/semver@7.7.0': {}
 
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -14370,17 +14357,17 @@ snapshots:
   '@types/serve-static@1.15.8':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       '@types/send': 0.17.5
 
   '@types/shelljs@0.8.17':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 24.0.13
       glob: 11.0.3
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/supports-color@8.1.3': {}
 
@@ -14390,7 +14377,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -14655,7 +14642,7 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-phases@1.0.4(acorn@8.15.0):
+  acorn-import-phases@1.0.3(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
@@ -14711,26 +14698,26 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  algoliasearch-helper@3.26.0(algoliasearch@5.33.0):
+  algoliasearch-helper@3.26.0(algoliasearch@5.32.0):
     dependencies:
       '@algolia/events': 4.0.1
-      algoliasearch: 5.33.0
+      algoliasearch: 5.32.0
 
-  algoliasearch@5.33.0:
+  algoliasearch@5.32.0:
     dependencies:
-      '@algolia/client-abtesting': 5.33.0
-      '@algolia/client-analytics': 5.33.0
-      '@algolia/client-common': 5.33.0
-      '@algolia/client-insights': 5.33.0
-      '@algolia/client-personalization': 5.33.0
-      '@algolia/client-query-suggestions': 5.33.0
-      '@algolia/client-search': 5.33.0
-      '@algolia/ingestion': 1.33.0
-      '@algolia/monitoring': 1.33.0
-      '@algolia/recommend': 5.33.0
-      '@algolia/requester-browser-xhr': 5.33.0
-      '@algolia/requester-fetch': 5.33.0
-      '@algolia/requester-node-http': 5.33.0
+      '@algolia/client-abtesting': 5.32.0
+      '@algolia/client-analytics': 5.32.0
+      '@algolia/client-common': 5.32.0
+      '@algolia/client-insights': 5.32.0
+      '@algolia/client-personalization': 5.32.0
+      '@algolia/client-query-suggestions': 5.32.0
+      '@algolia/client-search': 5.32.0
+      '@algolia/ingestion': 1.32.0
+      '@algolia/monitoring': 1.32.0
+      '@algolia/recommend': 5.32.0
+      '@algolia/requester-browser-xhr': 5.32.0
+      '@algolia/requester-fetch': 5.32.0
+      '@algolia/requester-node-http': 5.32.0
 
   ansi-align@3.0.1:
     dependencies:
@@ -14947,7 +14934,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  birpc@2.5.0: {}
+  birpc@2.4.0: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -15013,7 +15000,7 @@ snapshots:
   browserslist@4.25.1:
     dependencies:
       caniuse-lite: 1.0.30001727
-      electron-to-chromium: 1.5.183
+      electron-to-chromium: 1.5.182
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
@@ -15948,7 +15935,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.183: {}
+  electron-to-chromium@1.5.182: {}
 
   emoji-regex@10.4.0: {}
 
@@ -16635,7 +16622,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       require-like: 0.1.2
 
   eventemitter3@4.0.7: {}
@@ -17819,7 +17806,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -17827,13 +17814,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.0.14
+      '@types/node': 20.19.8
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -20278,7 +20265,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.1
       ast-kit: 2.1.1
-      birpc: 2.5.0
+      birpc: 2.4.0
       debug: 4.4.1(supports-color@8.1.1)
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
@@ -21248,7 +21235,7 @@ snapshots:
 
   typedoc@0.28.7(typescript@5.8.3):
     dependencies:
-      '@gerrit0/mini-shiki': 3.8.0
+      '@gerrit0/mini-shiki': 3.7.0
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
@@ -21315,7 +21302,7 @@ snapshots:
       '@types/concat-stream': 2.0.3
       '@types/debug': 4.1.12
       '@types/is-empty': 1.2.3
-      '@types/node': 22.16.4
+      '@types/node': 22.16.3
       '@types/unist': 3.0.3
       concat-stream: 2.0.0
       debug: 4.4.1(supports-color@8.1.1)
@@ -21535,13 +21522,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.4(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -21571,7 +21558,7 @@ snapshots:
       terser: 5.43.1
       yaml: 2.8.0
 
-  vite@7.0.4(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
+  vite@7.0.4(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.6
       fdir: 6.4.6(picomatch@4.0.2)
@@ -21580,15 +21567,15 @@ snapshots:
       rollup: 4.45.0
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.0.14
+      '@types/node': 24.0.13
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.43.1
       yaml: 2.8.0
 
-  vitest-fetch-mock@0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)):
+  vitest-fetch-mock@0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.8)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
@@ -21632,7 +21619,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -21654,12 +21641,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.4(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.0.14)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.13)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.0.14
+      '@types/node': 24.0.13
     transitivePeerDependencies:
       - jiti
       - less
@@ -21810,7 +21797,7 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn-import-phases: 1.0.3(acorn@8.15.0)
       browserslist: 4.25.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.2
@@ -21842,7 +21829,7 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn-import-phases: 1.0.3(acorn@8.15.0)
       browserslist: 4.25.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.2


### PR DESCRIPTION
Deprecating the use of file-entry-cache.

v10 of `file-entry-cache` breaks the spell checker and bloats the cache size.

This PR is the first step in reducing the dependency upon file-entry-cache and its dependencies.