### PR TITLE
fix: Make sure empty string is not checked.

### DIFF
--- a/packages/cspell-lib/src/lib/textValidation/lineValidatorFactory.ts
+++ b/packages/cspell-lib/src/lib/textValidation/lineValidatorFactory.ts
@@ -287,7 +287,7 @@ export function lineValidatorFactory(sDict: SpellingDictionary, options: Validat
                 };
                 return vr;
             }
-            if (possibleWord.text.endsWith('.')) {
+            if (possibleWord.text.endsWith('.') && possibleWord.text.length > 1) {
                 const pw = { ...possibleWord, text: possibleWord.text.slice(0, -1) };
                 if (isWordFlagged(pw)) {
                     const vr: ValidationIssueRO = {


### PR DESCRIPTION
For some strange reason, the Hungarian dictionary ends up with a forbid on empty string. This would happen when matching against `".`.

