### PR TITLE
fix: add data-science dictionary

### DIFF
--- a/packages/cspell-bundled-dicts/cspell-default.config.js
+++ b/packages/cspell-bundled-dicts/cspell-default.config.js
@@ -107,6 +107,7 @@ const settings = {
         '@cspell/dict-csharp/cspell-ext.json',
         '@cspell/dict-css/cspell-ext.json',
         '@cspell/dict-dart/cspell-ext.json',
+        '@cspell/dict-data-science/cspell-ext.json',
         '@cspell/dict-django/cspell-ext.json',
         '@cspell/dict-docker/cspell-ext.json',
         '@cspell/dict-dotnet/cspell-ext.json',

--- a/packages/cspell-bundled-dicts/cspell-default.config.ts
+++ b/packages/cspell-bundled-dicts/cspell-default.config.ts
@@ -110,6 +110,7 @@ const settings: AdvancedCSpellSettings = {
         '@cspell/dict-csharp/cspell-ext.json',
         '@cspell/dict-css/cspell-ext.json',
         '@cspell/dict-dart/cspell-ext.json',
+        '@cspell/dict-data-science/cspell-ext.json',
         '@cspell/dict-django/cspell-ext.json',
         '@cspell/dict-docker/cspell-ext.json',
         '@cspell/dict-dotnet/cspell-ext.json',

--- a/packages/cspell-bundled-dicts/package.json
+++ b/packages/cspell-bundled-dicts/package.json
@@ -58,6 +58,7 @@
     "@cspell/dict-csharp": "^4.0.6",
     "@cspell/dict-css": "^4.0.17",
     "@cspell/dict-dart": "^2.2.5",
+    "@cspell/dict-data-science": "^2.0.6",
     "@cspell/dict-django": "^4.1.4",
     "@cspell/dict-docker": "^1.1.12",
     "@cspell/dict-dotnet": "^5.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@cspell/dict-dart':
         specifier: ^2.2.5
         version: 2.2.5
+      '@cspell/dict-data-science':
+        specifier: ^2.0.6
+        version: 2.0.6
       '@cspell/dict-django':
         specifier: ^4.1.4
         version: 4.1.4
@@ -12847,7 +12850,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@18.3.1)':
     dependencies:
-      '@types/react': 19.0.2
+      '@types/react': 18.3.18
       react: 18.3.1
 
   '@docusaurus/remark-plugin-npm2yarn@3.6.3':


### PR DESCRIPTION
It was already included by python, but now it is explicitly included.