### PR TITLE
chore: Force setup-node to v4.1.0

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -12,7 +12,7 @@ runs:
       uses: pnpm/action-setup@v4
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.1.0
       with:
         registry-url: 'https://registry.npmjs.org'
         node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -22,5 +22,5 @@ runs:
       run: |
         npm i -g --force corepack
         corepack enable
-        corepack install
+        pnpm -v
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,7 +12,7 @@ runs:
       uses: pnpm/action-setup@v4
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.1.0
       with:
         registry-url: 'https://registry.npmjs.org'
         node-version: ${{ inputs.node-version }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,4 +1,4 @@
-name: setup_node
+name: setup_node_and_install_dependencies
 description: Setup Node, install Pnpm, and install dependencies.
 inputs:
   node-version:

--- a/.github/workflows/build-version-release.yml
+++ b/.github/workflows/build-version-release.yml
@@ -70,7 +70,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/build-version-release.yml
+++ b/.github/workflows/build-version-release.yml
@@ -66,8 +66,8 @@ jobs:
         with:
           token: ${{ env.GITHUB_TOKEN }} # needed to trigger workflows
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v4.1.0
@@ -75,6 +75,9 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Version
         run: |

--- a/.github/workflows/build-version-release.yml
+++ b/.github/workflows/build-version-release.yml
@@ -66,18 +66,10 @@ jobs:
         with:
           token: ${{ env.GITHUB_TOKEN }} # needed to trigger workflows
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: 18
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Version
         run: |

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -15,13 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - run: pnpm -v
 

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -19,7 +19,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
 

--- a/.github/workflows/cspell-action.yml
+++ b/.github/workflows/cspell-action.yml
@@ -15,18 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
-        with:
-          cache: pnpm
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - run: pnpm -v
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
 
       - run: pnpm run prepare-cspell-action
       - uses: streetsidesoftware/cspell-action@v6

--- a/.github/workflows/cspell-cli.yml
+++ b/.github/workflows/cspell-cli.yml
@@ -16,13 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - run: pnpm -v
 

--- a/.github/workflows/cspell-cli.yml
+++ b/.github/workflows/cspell-cli.yml
@@ -20,7 +20,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
 

--- a/.github/workflows/cspell-cli.yml
+++ b/.github/workflows/cspell-cli.yml
@@ -16,18 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
-        with:
-          cache: pnpm
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - run: pnpm -v
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
 
       - # It is necessary to run `pnpm i` in order install some dictionaries.
         name: prepare-cspell-action

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.1.0
         with:
           node-version: 20.x
           cache: pnpm

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,13 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4.1.0
         with:
           node-version: 20.x
           cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Build website
         run: |

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,16 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: 20.x
-          cache: pnpm
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Build website
         run: |

--- a/.github/workflows/reuseable-load-integrations-repo-list.yml
+++ b/.github/workflows/reuseable-load-integrations-repo-list.yml
@@ -54,19 +54,10 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - run: pnpm -v
 
       - run: pnpm i
 

--- a/.github/workflows/reuseable-load-integrations-repo-list.yml
+++ b/.github/workflows/reuseable-load-integrations-repo-list.yml
@@ -58,7 +58,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/reuseable-load-integrations-repo-list.yml
+++ b/.github/workflows/reuseable-load-integrations-repo-list.yml
@@ -54,14 +54,17 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - run: pnpm -v
 

--- a/.github/workflows/update-dependabot.yml
+++ b/.github/workflows/update-dependabot.yml
@@ -31,7 +31,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: 20.x

--- a/.github/workflows/update-dependabot.yml
+++ b/.github/workflows/update-dependabot.yml
@@ -27,17 +27,10 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
-          registry-url: 'https://registry.npmjs.org'
           node-version: 20.x
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Run Action
         id: dependabot

--- a/.github/workflows/update-dependabot.yml
+++ b/.github/workflows/update-dependabot.yml
@@ -27,14 +27,17 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v4.1.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: 20.x
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Run Action
         id: dependabot

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -58,16 +58,8 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
-        with:
-          cache: pnpm
-
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
 
       - name: Update Root
         run: |

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -62,7 +62,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -58,13 +58,16 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Use Node.js
         uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Update Root
         run: |

--- a/.github/workflows/update-dictionaries.yml
+++ b/.github/workflows/update-dictionaries.yml
@@ -57,13 +57,10 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
-          cache: pnpm
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install
         run: pnpm install
@@ -160,21 +157,15 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Patch
         if: ${{ env.PATCH }}
         run: |
           echo "$PATCH" | git apply
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - run: pnpm -v
 
       - name: Cache Build
         id: step-cache-build
@@ -261,21 +252,15 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Patch
         if: ${{ env.PATCH }}
         run: |
           echo "$PATCH" | git apply
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - run: pnpm -v
 
       - name: Install and Build
         run: |
@@ -321,14 +306,10 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: restore repos
         uses: actions/download-artifact@v4

--- a/.github/workflows/update-dictionaries.yml
+++ b/.github/workflows/update-dictionaries.yml
@@ -61,7 +61,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: pnpm
 
@@ -169,7 +169,7 @@ jobs:
           echo "$PATCH" | git apply
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -270,7 +270,7 @@ jobs:
           echo "$PATCH" | git apply
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -325,7 +325,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/update-integration-repositories.yml
+++ b/.github/workflows/update-integration-repositories.yml
@@ -77,16 +77,10 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - run: pnpm -v
 
       - name: Cache Build
         id: step-cache-build
@@ -167,14 +161,10 @@ jobs:
         with:
           ref: ${{ env.REF_BRANCH }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.1.0
+      - name: Setup Node and Pnpm
+        uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
 
       - name: restore repos
         uses: actions/download-artifact@v4

--- a/.github/workflows/update-integration-repositories.yml
+++ b/.github/workflows/update-integration-repositories.yml
@@ -81,7 +81,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -171,7 +171,7 @@ jobs:
         run: corepack enable
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'


### PR DESCRIPTION
Corepack seems to have been broken during the 4.2.0 roll out of setup-node. Rolling back to version 4.1.0 does not see to fix it.

The workaround is to force install corepack after node has been setup.

See: https://github.com/actions/setup-node/issues/1222

