### PR TITLE
docs: add examples for spellchecker and spell-checker ignores

### DIFF
--- a/docs/configuration/document-settings.md
+++ b/docs/configuration/document-settings.md
@@ -12,7 +12,7 @@ nav_order: 11
 It is possible to add spell check settings into your source code.
 This is to help with file specific issues that may not be applicable to the entire project.
 
-All settings are prefixed with `cSpell:` or `spell-checker:`.
+All settings are prefixed with `cSpell:`, `spell-checker:`, or `spellchecker:`.
 
 - `disable` -- turn off the spell checker for a section of code.
 - `enable` -- turn the spell checker back on after it has been turned off.

--- a/docs/configuration/document-settings.md
+++ b/docs/configuration/document-settings.md
@@ -83,10 +83,18 @@ const str = 'goedemorgen'; // <- will NOT be flagged as an error.
 
 _Ignore_ allows you the specify a list of words you want to ignore within the document.
 
+- `/* cSpell: ignore */`
+- `/* spell-checker: ignore */`
+- `/* spellchecker: ignore */`
+
 ```javascript
 // cSpell:ignore zaallano, wooorrdd
 // cSpell:ignore zzooommmmmmmm
 const wackyWord = ['zaallano', 'wooorrdd', 'zzooommmmmmmm'];
+
+// spell-checker: ignore ieeees
+/* spellchecker: ignore beees,treeees */
+const moreWords = ['ieeees', 'beees', 'treeees'];
 ```
 
 **Note:** words defined with `ignore` will be ignored for the entire file.

--- a/website/docs/Configuration/document-settings.md
+++ b/website/docs/Configuration/document-settings.md
@@ -12,7 +12,7 @@ nav_order: 11
 It is possible to add spell check settings into your source code.
 This is to help with file specific issues that may not be applicable to the entire project.
 
-All settings are prefixed with `cSpell:` or `spell-checker:`.
+All settings are prefixed with `cSpell:`, `spell-checker:`, or `spellchecker:`.
 
 - `disable` -- turn off the spell checker for a section of code.
 - `enable` -- turn the spell checker back on after it has been turned off.
@@ -83,10 +83,18 @@ const str = 'goedemorgen'; // <- will NOT be flagged as an error.
 
 _Ignore_ allows you the specify a list of words you want to ignore within the document.
 
+- `/* cSpell: ignore */`
+- `/* spell-checker: ignore */`
+- `/* spellchecker: ignore */`
+
 ```javascript
 // cSpell:ignore zaallano, wooorrdd
 // cSpell:ignore zzooommmmmmmm
 const wackyWord = ['zaallano', 'wooorrdd', 'zzooommmmmmmm'];
+
+// spell-checker: ignore ieeees
+/* spellchecker: ignore beees,treeees */
+const moreWords = ['ieeees', 'beees', 'treeees'];
 ```
 
 **Note:** words defined with `ignore` will be ignored for the entire file.


### PR DESCRIPTION
This adds examples for using spellchecker and spell-checker ignores. The PR tries to follow the same format as disables from the section above. 