### PR TITLE
fix: issue.line.position.character is always 0

### DIFF
--- a/packages/cspell-lib/src/lib/textValidation/docValidator.ts
+++ b/packages/cspell-lib/src/lib/textValidation/docValidator.ts
@@ -269,7 +269,7 @@ export class DocumentValidator {
             if (!line || line.offset + line.text.length <= offset) {
                 line = document.lineAt(offset);
             }
-            return { text, offset, line, length, isFlagged, isFound, suggestionsEx };
+            return { text, offset, line: {text: line.text, offset: line.offset, position: document.positionAt(offset)}, length, isFlagged, isFound, suggestionsEx };
         }
         const issues = [...pipeSync(segmenter(parsedText), opConcatMap(textValidator.validate), opMap(mapToIssue))];
 


### PR DESCRIPTION
I've been trying cspell-lib and noticed that all my issues had the correct line numbers, but the character numbers were always 0. I think the issue comes from the usage of lineAt(), which always returns a position with 0 as the character number.  
  
My simple fix is to construct a new line object using the correct character number by calling document.positionAt(offset).  
  
Not sure if this is the best fix, but it seems to work perfectly on my side.   

