### PR TITLE
feat: implement `unknownWords` config (part 1)

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -1502,6 +1502,17 @@
           "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
           "type": "number"
         },
+        "unknownWords": {
+          "default": "report",
+          "description": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+          "enum": [
+            "report",
+            "ignore",
+            "ignore-all"
+          ],
+          "markdownDescription": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+          "type": "string"
+        },
         "usePnP": {
           "default": false,
           "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
@@ -2110,6 +2121,17 @@
       "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
       "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
       "type": "number"
+    },
+    "unknownWords": {
+      "default": "report",
+      "description": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+      "enum": [
+        "report",
+        "ignore",
+        "ignore-all"
+      ],
+      "markdownDescription": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+      "type": "string"
     },
     "useGitignore": {
       "default": false,

--- a/packages/cspell-dictionary/src/SpellingDictionary/CachingDictionary.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/CachingDictionary.ts
@@ -1,6 +1,7 @@
 import type { CacheStats } from '../util/AutoCache.js';
 import { autoCache, extractStats } from '../util/AutoCache.js';
 import type { PreferredSuggestion, SearchOptions, SpellingDictionary } from './SpellingDictionary.js';
+import type { SuggestOptionsRO } from './SuggestOptions.js';
 import type { SpellingDictionaryCollection } from './SpellingDictionaryCollection.js';
 import { canonicalSearchOptions } from './SpellingDictionaryMethods.js';
 
@@ -31,6 +32,7 @@ export interface CachingDictionary {
     isForbidden(word: string): boolean;
     stats(): CallStats;
     getPreferredSuggestions(word: string): PreferredSuggestion[] | undefined;
+    suggest(word: string, suggestOptions?: SuggestOptionsRO): import('cspell-trie-lib').SuggestionResult[];
 }
 
 interface LogEntryBase extends SearchOptions {
@@ -79,6 +81,7 @@ class CachedDict implements CachingDictionary {
         (word: string) => this.dict.getPreferredSuggestions?.(word),
         DefaultAutoCacheSize,
     );
+    readonly suggest = (word: string, suggestOptions?: SuggestOptionsRO) => this.dict.suggest(word, suggestOptions);
 
     stats(): CallStats {
         return {

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -686,6 +686,8 @@ interface ValidationOptions extends IncludeExcludeOptions {
     ignoreCase: boolean;
     ignoreRandomStrings?: boolean | undefined;
     minRandomLength?: number | undefined;
+    /** Controls how unknown words are handled */
+    unknownWords?: 'report' | 'ignore' | 'ignore-all';
 }
 interface IncludeExcludeOptions {
     ignoreRegExpList?: RegExp[];

--- a/packages/cspell-lib/src/lib/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-lib/src/lib/__snapshots__/index.test.ts.snap
@@ -58,6 +58,7 @@ exports[`Validate the cspell API > Verify API exports 1`] = `
     "suggestWords": "suggestWords",
     "suggestionNumChanges": "suggestionNumChanges",
     "suggestionsTimeout": "suggestionsTimeout",
+    "unknownWords": "unknownWords",
     "useGitignore": "useGitignore",
     "usePnP": "usePnP",
     "userWords": "userWords",

--- a/packages/cspell-lib/src/lib/textValidation/ValidationTypes.ts
+++ b/packages/cspell-lib/src/lib/textValidation/ValidationTypes.ts
@@ -17,6 +17,8 @@ export interface ValidationOptions extends IncludeExcludeOptions {
     ignoreCase: boolean;
     ignoreRandomStrings?: boolean | undefined;
     minRandomLength?: number | undefined;
+    /** Controls how unknown words are handled */
+    unknownWords?: 'report' | 'ignore' | 'ignore-all';
 }
 
 export interface CheckOptions extends ValidationOptions {

--- a/packages/cspell-lib/src/lib/textValidation/lineValidatorFactory.ts
+++ b/packages/cspell-lib/src/lib/textValidation/lineValidatorFactory.ts
@@ -58,6 +58,7 @@ export function lineValidatorFactory(sDict: SpellingDictionary, options: Validat
         ignoreCase = true,
         ignoreRandomStrings = defaultCSpellSettings.ignoreRandomStrings,
         minRandomLength = defaultCSpellSettings.minRandomLength,
+        unknownWords = 'report',
     } = options;
     const hasWordOptions: SearchOptions = {
         ignoreCase,
@@ -314,6 +315,11 @@ export function lineValidatorFactory(sDict: SpellingDictionary, options: Validat
         }
 
         function _checkPossibleWords(possibleWord: TextOffsetRO): ValidationIssue[] {
+            // If unknown words should be completely ignored, return empty array
+            if (unknownWords === 'ignore-all') {
+                return [];
+            }
+
             const flagged = checkForFlaggedWord(possibleWord);
             if (flagged) return [flagged];
 
@@ -357,6 +363,39 @@ export function lineValidatorFactory(sDict: SpellingDictionary, options: Validat
                     nonMatching.map((w) => ({ ...w, line: lineSegment.line })).map(annotateIsFlagged),
                     hexSequences,
                 );
+                
+                // In ignore mode, only report words with simple fixes
+                if (unknownWords === 'ignore') {
+                    // Keep only words that have suggestions with small edit distance
+                    const withSugs = filtered.map((issue) => {
+                        const sugs = dictCol.suggest(issue.text, {
+                            numSuggestions: 1,
+                            compoundMethod: 0,
+                            includeTies: false,
+                            ignoreCase,
+                            timeout: 100,
+                            numChanges: 1, // Only consider very simple changes (1 edit distance)
+                        });
+                        
+                        // Only add words with simple fixes (1 edit distance) and at least one auto-fixable.
+                        if (sugs.length > 0 && sugs.some((sug) => sug.isPreferred)) {
+                            const extendedSugs = sugs.map(sug => {
+                                return {
+                                    word: sug.word,
+                                    ...(sug.isPreferred === true ? { isPreferred: true } : {}),
+                                    ...(typeof sug.cost === 'number' ? { cost: sug.cost } : {})
+                                };
+                            });
+
+                            return { ...issue, suggestionsEx: extendedSugs };
+                        }
+
+                        return null;
+                    }).filter(issue => !!issue);
+                    
+                    return withSugs;
+                }
+                
                 if (filtered.length < mismatches.length) {
                     return filtered;
                 }

--- a/packages/cspell-lib/src/lib/textValidation/lineValidatorFactory.ts
+++ b/packages/cspell-lib/src/lib/textValidation/lineValidatorFactory.ts
@@ -390,7 +390,7 @@ export function lineValidatorFactory(sDict: SpellingDictionary, options: Validat
                             return { ...issue, suggestionsEx: extendedSugs };
                         }
 
-                        return null;
+                        return undefined;
                     }).filter(issue => !!issue);
                     
                     return withSugs;

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -1502,6 +1502,17 @@
           "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
           "type": "number"
         },
+        "unknownWords": {
+          "default": "report",
+          "description": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+          "enum": [
+            "report",
+            "ignore",
+            "ignore-all"
+          ],
+          "markdownDescription": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+          "type": "string"
+        },
         "usePnP": {
           "default": false,
           "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
@@ -2110,6 +2121,17 @@
       "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
       "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
       "type": "number"
+    },
+    "unknownWords": {
+      "default": "report",
+      "description": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+      "enum": [
+        "report",
+        "ignore",
+        "ignore-all"
+      ],
+      "markdownDescription": "Controls how unknown words are handled.\n\n- `report` - Report all unknown words (default behavior)\n- `ignore` - Ignore most unknown words, but report those with simple fixes\n- `ignore-all` - Ignore all unknown words",
+      "type": "string"
     },
     "useGitignore": {
       "default": false,

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -281,7 +281,7 @@ export interface Settings extends ReportingConfiguration, BaseSetting, PnPSettin
     loadDefaultConfiguration?: boolean;
 }
 
-export interface ReportingConfiguration extends ReporterConfigurationBase, SuggestionsConfiguration {}
+export interface ReportingConfiguration extends ReporterConfigurationBase, SuggestionsConfiguration, UnknownWordsConfiguration {}
 
 export interface SuggestionsConfiguration {
     /**
@@ -308,6 +308,19 @@ export interface SuggestionsConfiguration {
      * @default 3
      */
     suggestionNumChanges?: number;
+}
+
+export interface UnknownWordsConfiguration {
+    /**
+     * Controls how unknown words are handled.
+     * 
+     * - `report` - Report all unknown words (default behavior)
+     * - `ignore` - Ignore most unknown words, but report those with simple fixes
+     * - `ignore-all` - Ignore all unknown words
+     * 
+     * @default "report"
+     */
+    unknownWords?: "report" | "ignore" | "ignore-all";
 }
 
 /**

--- a/packages/cspell-types/src/configFields.ts
+++ b/packages/cspell-types/src/configFields.ts
@@ -52,6 +52,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     suggestionNumChanges: 'suggestionNumChanges',
     suggestionsTimeout: 'suggestionsTimeout',
     suggestWords: 'suggestWords',
+    unknownWords: 'unknownWords',
     useGitignore: 'useGitignore',
     usePnP: 'usePnP',
     userWords: 'userWords',


### PR DESCRIPTION
Implement `unknownWords` config based on the following discussion: https://github.com/streetsidesoftware/cspell/discussions/5751.

- `report` - the default
- `ignore` - ignore most unknown words except ones with simple fixes (must have a preferred fix).
- `ignore-all` - ignore all unknown words.

I'm mostly interested in the `ignore` option, where I want `cspell` to error only for common English words with a simple fix (e.g., `necesary` -> `necessary`), which will allow us to adopt `cspell` without having to deal with a custom dictionary.

Feel free to take over this pull request. I'm unfamiliar with this repository, but I wanted to try a proof of concept to see if it would work for our app—It did!