### PR TITLE
fix: Add eslint plugin helpers

### DIFF
--- a/packages/cspell-eslint-plugin/fixtures/dictionaries/README.md
+++ b/packages/cspell-eslint-plugin/fixtures/dictionaries/README.md
@@ -1,0 +1,3 @@
+# JSON Support
+
+This directory contains sample to test JSON support.

--- a/packages/cspell-eslint-plugin/fixtures/dictionaries/README.md
+++ b/packages/cspell-eslint-plugin/fixtures/dictionaries/README.md
@@ -1,3 +1,7 @@
-# JSON Support
+# Example `supportNonStrictSearches`
 
-This directory contains sample to test JSON support.
+This contains an example on how to use:
+
+- `supportNonStrictSearches`
+- `defineCSpellConfig`
+- `defineCSpellPluginOptions`

--- a/packages/cspell-eslint-plugin/fixtures/dictionaries/eslint.config.mjs
+++ b/packages/cspell-eslint-plugin/fixtures/dictionaries/eslint.config.mjs
@@ -1,0 +1,41 @@
+// @ts-check
+import eslint from '@eslint/js';
+import { defineCSpellConfig, defineCSpellPluginOptions } from '@cspell/eslint-plugin';
+import cspellRecommended from '@cspell/eslint-plugin/recommended';
+
+/**
+ * @type { import("eslint").Linter.Config[] }
+ */
+const config = [
+    eslint.configs.recommended,
+    cspellRecommended,
+    {
+        ignores: ['eslint.config.mjs'],
+    },
+    {
+        files: ['**/*.js'],
+        rules: {
+            '@cspell/spellchecker': [
+                'warn',
+                defineCSpellPluginOptions({
+                    debugMode: false,
+                    autoFix: false,
+                    cspell: defineCSpellConfig({
+                        dictionaryDefinitions: [
+                            {
+                                name: 'custom-dict',
+                                supportNonStrictSearches: false,
+                                // cspell: words Codeco
+                                words: ['IPv4', 'IPv6', 'Codeco'],
+                                suggestWords: ['codeco->Codeco'],
+                            },
+                        ],
+                        dictionaries: ['custom-dict'],
+                    }),
+                }),
+            ],
+        },
+    },
+];
+
+export default config;

--- a/packages/cspell-eslint-plugin/fixtures/dictionaries/package.json
+++ b/packages/cspell-eslint-plugin/fixtures/dictionaries/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "@internal/issue-4870-fixture",
+  "name": "@internal/dictionary-fixture",
   "version": "1.0.0",
   "description": "",
-  "main": "sample.js",
+  "private": true,
+  "type": "module",
   "scripts": {
     "test": "eslint ."
   },
@@ -10,7 +11,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@cspell/eslint-plugin": "workspace:^",
+    "@cspell/eslint-plugin": "workspace:*",
+    "es-toolkit": "^1.38.0",
     "eslint": "^8.50.0"
   }
 }

--- a/packages/cspell-eslint-plugin/fixtures/dictionaries/sample.js
+++ b/packages/cspell-eslint-plugin/fixtures/dictionaries/sample.js
@@ -1,0 +1,7 @@
+/**
+ * This is a sample from codeco.
+ * @returns
+ */
+export function sample() {
+    return 'sample';
+}

--- a/packages/cspell-eslint-plugin/fixtures/import-support/package.json
+++ b/packages/cspell-eslint-plugin/fixtures/import-support/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@internal/import-support",
+  "name": "@internal/import-support-fixture",
   "version": "1.0.0",
   "description": "",
   "private": true,

--- a/packages/cspell-eslint-plugin/fixtures/issue-4870/eslint.config.mjs
+++ b/packages/cspell-eslint-plugin/fixtures/issue-4870/eslint.config.mjs
@@ -3,7 +3,7 @@ import nodePlugin from 'eslint-plugin-n';
 import cspellRecommended from '@cspell/eslint-plugin/recommended';
 
 /**
- * @type { import("eslint").Linter.FlatConfig[] }
+ * @type { import("eslint").Linter.Config[] }
  */
 const config = [
     eslint.configs.recommended,

--- a/packages/cspell-eslint-plugin/fixtures/json-support/eslint.config.mjs
+++ b/packages/cspell-eslint-plugin/fixtures/json-support/eslint.config.mjs
@@ -4,7 +4,7 @@ import cspellRecommended from '@cspell/eslint-plugin/recommended';
 import eslintPluginJsonc from 'eslint-plugin-jsonc';
 
 /**
- * @type { import("eslint").Linter.FlatConfig[] }
+ * @type { import("eslint").Linter.Config[] }
  */
 const config = [
     eslint.configs.recommended,

--- a/packages/cspell-eslint-plugin/fixtures/json-support/package.json
+++ b/packages/cspell-eslint-plugin/fixtures/json-support/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-support",
+  "name": "@internal/json-support-fixture",
   "version": "1.0.0",
   "description": "",
   "scripts": {
@@ -10,7 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "@cspell/eslint-plugin": "workspace:*",
-    "eslint-plugin-mdx": "^3.1.5",
+    "eslint-plugin-jsonc": "^2.20.1",
     "eslint": "^8.50.0"
   }
 }

--- a/packages/cspell-eslint-plugin/fixtures/mdx-support/package.json
+++ b/packages/cspell-eslint-plugin/fixtures/mdx-support/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-support",
+  "name": "@internal/markdown-support-fixture",
   "version": "1.0.0",
   "description": "",
   "scripts": {

--- a/packages/cspell-eslint-plugin/fixtures/yaml-support/eslint.config.mjs
+++ b/packages/cspell-eslint-plugin/fixtures/yaml-support/eslint.config.mjs
@@ -4,7 +4,7 @@ import parserYml from 'yaml-eslint-parser';
 import pluginYml from 'eslint-plugin-yml';
 
 /**
- * @type { import("eslint").Linter.FlatConfig[] }
+ * @type { import("eslint").Linter.Config[] }
  */
 const config = [
     eslint.configs.recommended,

--- a/packages/cspell-eslint-plugin/src/common/options.cts
+++ b/packages/cspell-eslint-plugin/src/common/options.cts
@@ -206,3 +206,19 @@ export type ScopeSelectorEntry = [ScopeSelector, boolean];
  * A list of scope selectors.
  */
 export type ScopeSelectorList = ScopeSelectorEntry[];
+
+/**
+ * Helper to define the options for the cspell-eslint-plugin.
+ * @param options - The options to define.
+ */
+export function defineCSpellPluginOptions(options: Partial<Options>): Partial<Options> {
+    return options;
+}
+
+/**
+ * Helper to define the CSpell config section of the cspell-eslint-plugin.
+ * @param cfg - The CSpell config to define.
+ */
+export function defineCSpellConfig(cfg: CSpellOptions): CSpellOptions {
+    return cfg;
+}

--- a/packages/cspell-eslint-plugin/src/common/options.test.mts
+++ b/packages/cspell-eslint-plugin/src/common/options.test.mts
@@ -3,7 +3,13 @@ import assert from 'node:assert';
 import type { CSpellSettings } from '@cspell/cspell-types';
 import { describe, test } from 'mocha';
 
-import { defaultOptions, type Options } from './options.cjs';
+import {
+    type CSpellOptions,
+    defaultOptions,
+    defineCSpellConfig,
+    defineCSpellPluginOptions,
+    type Options,
+} from './options.cjs';
 
 describe('options', () => {
     test('Options are compatible with cspell-types', () => {
@@ -18,5 +24,24 @@ describe('options', () => {
         assert(options.cspell);
         const settings: CSpellSettings = options.cspell;
         assert(settings, 'it is expected to compile.');
+    });
+
+    test('defineCSpellPluginOptions', () => {
+        // identity
+        const options: Partial<Options> = defineCSpellPluginOptions({
+            cspell: { words: ['word'] },
+            autoFix: true,
+            generateSuggestions: false,
+            numSuggestions: 5,
+        });
+        assert(defineCSpellPluginOptions(options) === options, 'it is expected to be the same object.');
+    });
+
+    test('defineCSpellConfig', () => {
+        // identity
+        const config: CSpellOptions = defineCSpellConfig({
+            words: ['word'],
+        });
+        assert(defineCSpellConfig(config) === config, 'it is expected to be the same object.');
     });
 });

--- a/packages/cspell-eslint-plugin/src/plugin/index.cts
+++ b/packages/cspell-eslint-plugin/src/plugin/index.cts
@@ -1,2 +1,3 @@
 export type { Options } from '../common/options.cjs';
+export { defaultOptions, defineCSpellConfig, defineCSpellPluginOptions } from '../common/options.cjs';
 export { configs, plugin as default, meta, rules } from './cspell-eslint-plugin.cjs';

--- a/packages/cspell-eslint-plugin/src/test/dictionary.test.mts
+++ b/packages/cspell-eslint-plugin/src/test/dictionary.test.mts
@@ -1,0 +1,123 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import typeScriptParser from '@typescript-eslint/parser';
+import type { Linter } from 'eslint';
+import { RuleTester } from 'eslint';
+
+import type { Options as RuleOptions } from '../plugin/index.cjs';
+import { defineCSpellConfig, defineCSpellPluginOptions } from '../plugin/index.cjs';
+import Rule from '../plugin/index.cjs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const root = path.resolve(__dirname, '../..');
+const fixturesDir = path.join(root, 'fixtures');
+
+const parsers: Record<string, Linter.Parser | undefined> = {
+    // Note: it is possible for @typescript-eslint/parser to break the path
+    '.ts': typeScriptParser,
+};
+
+type ValidTestCase = RuleTester.ValidTestCase;
+type Options = Partial<RuleOptions>;
+
+const ruleTester = new RuleTester({});
+
+ruleTester.run('cspell', Rule.rules.spellchecker, {
+    valid: [
+        readFix('dictionaries/sample.js', {
+            cspell: defineCSpellConfig({
+                dictionaryDefinitions: [
+                    {
+                        name: 'custom-dict',
+                        supportNonStrictSearches: true,
+                        // cspell: words Codeco
+                        words: ['IPv4', 'IPv6', 'Codeco'],
+                        suggestWords: ['codeco->Codeco'],
+                    },
+                ],
+                dictionaries: ['custom-dict'],
+            }),
+        }),
+    ],
+    invalid: [
+        // cspell:ignore readstring resetmemorycategory retargeting rrotate rshift
+        readInvalid('dictionaries/sample.js', [unknownWord('codeco', 8)], {
+            cspell: defineCSpellConfig({
+                dictionaryDefinitions: [
+                    {
+                        name: 'custom-dict',
+                        supportNonStrictSearches: false,
+                        // cspell: words Codeco
+                        words: ['IPv4', 'IPv6', 'Codeco'],
+                        suggestWords: ['codeco->Codeco'],
+                    },
+                ],
+                dictionaries: ['custom-dict'],
+            }),
+        }),
+    ],
+});
+
+function resolveFix(filename: string): string {
+    return path.resolve(fixturesDir, filename);
+}
+
+type ValidTestCaseEsLint9 = ValidTestCase;
+
+function readFix(filename: string, options?: Options): ValidTestCase {
+    const __filename = resolveFix(filename);
+    const code = fs.readFileSync(__filename, 'utf8');
+
+    const sample: ValidTestCaseEsLint9 = {
+        code,
+        filename: __filename,
+    };
+    if (options) {
+        sample.options = [defineCSpellPluginOptions(options)];
+    }
+
+    const parser = parsers[path.extname(__filename)];
+    if (parser) {
+        sample.languageOptions ??= {};
+        sample.languageOptions.parser = parser;
+    }
+
+    return sample;
+}
+
+interface TestCaseError {
+    message?: string | RegExp | undefined;
+    messageId?: string | undefined;
+    type?: string | undefined;
+    data?: unknown | undefined;
+    line?: number | undefined;
+    column?: number | undefined;
+    endLine?: number | undefined;
+    endColumn?: number | undefined;
+    suggestions?: RuleTester.SuggestionOutput[] | undefined | number;
+}
+
+type InvalidTestCaseError = RuleTester.TestCaseError | TestCaseError;
+
+function readInvalid(filename: string, errors: TestCaseError[], options?: Options) {
+    const sample = readFix(filename, options);
+    return {
+        ...sample,
+        errors: errors.map((err) => csError(err)),
+    };
+}
+
+function unknownWord(word: string, suggestions?: number): InvalidTestCaseError {
+    return ce(`Unknown word: "${word}"`, suggestions);
+}
+
+function ce(message: string, suggestions?: number): RuleTester.TestCaseError {
+    return { message, suggestions } as RuleTester.TestCaseError;
+}
+
+function csError(error: InvalidTestCaseError, suggestions?: number): RuleTester.TestCaseError {
+    if (error && typeof error === 'object') return error as RuleTester.TestCaseError;
+    return ce(error, suggestions);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,18 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
 
+  packages/cspell-eslint-plugin/fixtures/dictionaries:
+    devDependencies:
+      '@cspell/eslint-plugin':
+        specifier: workspace:*
+        version: link:../..
+      es-toolkit:
+        specifier: ^1.38.0
+        version: 1.38.0
+      eslint:
+        specifier: ^8.50.0
+        version: 8.57.0
+
   packages/cspell-eslint-plugin/fixtures/import-support:
     devDependencies:
       '@internal/fixture-test-dictionary':
@@ -5892,6 +5904,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.38.0:
+    resolution: {integrity: sha512-OT3AxczYYd3W50bCj4V0hKoOAfqIy9tof0leNQYekEDxVKir3RTVTJOLij7VAe6fsCNsGhC0JqIkURpMXTCSEA==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -16713,6 +16728,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.38.0: {}
 
   es6-error@4.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'packages/*'
   - 'packages/*/scripts'
   - 'packages/*/example-code'
+  - 'packages/cspell-eslint-plugin/fixtures/dictionaries'
   - 'packages/cspell-eslint-plugin/fixtures/import-support'
   - 'packages/cspell-eslint-plugin/fixtures/simple'
   - 'rfc/*'


### PR DESCRIPTION
Add helper methods:
- `defineCSpellPluginOptions`
- `defineCSpellConfig`

Add some examples for `supportNonStrictSearches`