### PR TITLE
chore: lock vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.33.0",
     "vite": "^6.3.5",
-    "vitest": "^3.1.4"
+    "vitest": "~3.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@20.17.57)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0)
       vitest:
-        specifier: ^3.1.4
+        specifier: ~3.1.4
         version: 3.1.4(@types/debug@4.1.12)(@types/node@20.17.57)(jiti@2.4.2)(terser@5.40.0)(yaml@2.8.0)
 
   examples/dynamic-dictionaries:


### PR DESCRIPTION
vitest 3.2.0 is buggy.