### PR TITLE
fix: Allow init of `cspell.config.yml` files

### DIFF
--- a/packages/cspell/src/app/commandInit.ts
+++ b/packages/cspell/src/app/commandInit.ts
@@ -11,7 +11,7 @@ export function commandInit(prog: Command): Command {
         .option('-o, --output <path>', 'Define where to write file.')
         .addOption(
             crOpt('--format <format>', 'Define the format of the file.')
-                .choices(['yaml', 'json', 'jsonc'])
+                .choices(['yaml', 'yml', 'json', 'jsonc'])
                 .default('yaml'),
         )
         .option('--import <path|package>', 'Import a configuration file or dictionary package.', collect)

--- a/packages/cspell/src/app/config/configInit.ts
+++ b/packages/cspell/src/app/config/configInit.ts
@@ -48,8 +48,6 @@ version: '0.2'
 `;
 
 export async function configInit(options: InitOptions): Promise<void> {
-    console.error('Init %o', options);
-
     const rw = createReaderWriter();
     const url = determineFileNameURL(options);
     const configFile = await createConfigFile(rw, url, options);
@@ -119,6 +117,9 @@ function determineDefaultFileName(options: InitOptions): string {
         }
         case 'yaml': {
             return 'cspell.config.yaml';
+        }
+        case 'yml': {
+            return 'cspell.config.yml';
         }
     }
     throw new Error(`Unsupported format: ${options.format}`);

--- a/packages/cspell/src/app/config/options.ts
+++ b/packages/cspell/src/app/config/options.ts
@@ -1,7 +1,7 @@
 export interface InitOptions {
     output?: string;
     import?: string[];
-    format?: 'yaml' | 'json' | 'jsonc';
+    format?: 'yaml' | 'yml' | 'json' | 'jsonc';
     locale?: string;
     comments?: boolean;
     schema?: boolean;


### PR DESCRIPTION
Add `yml` to the init command format list.

```
cspell init --format=yml
```

It will create a `cspell.config.yml` file.
