### PR TITLE
feat: Add command `dictionaries`

### DIFF
--- a/packages/cspell/src/app/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/app/__snapshots__/app.test.ts.snap
@@ -3333,6 +3333,85 @@ error"
 
 exports[`Validate cli > app 'with spelling errors Dutch.txt' Expect Error: [Function CheckFailed] 3`] = `""`;
 
+exports[`Validate cli > app dictionary [ 'dictionaries' ] 1`] = `[]`;
+
+exports[`Validate cli > app dictionary [ 'dictionaries' ] 2`] = `
+"Dictionary                 Dictionary Location
+ada                        node_modules/@cspell/dict-ada/dict/ada.txt
+al                         node_modules/@cspell/dict-al/dict/al.txt
+aws*                       node_modules/@cspell/dict-aws/dict/aws.txt
+bash                       node_modules/@cspell/dict-shell/dict/bash-words.txt
+coding-compound-terms*     node_modules/.../dict/coding-compound-terms.txt
+companies*                 node_modules/@cspell/.../dict/companies.txt
+computing-acronyms*        node_modules/@cspell/.../dict/computing-acronyms.txt
+cpp                        node_modules/@cspell/dict-cpp/dict/cpp.txt
+cpp-legacy                 node_modules/@cspell/dict-cpp/dict/cpp-legacy.txt
+cpp-refined                node_modules/@cspell/dict-cpp/dict/cpp-refined.txt
+cryptocurrencies*          node_modules/@cspell/.../dict/cryptocurrencies.txt
+cryptocurrencies-legacy    node_modules/.../dict/cryptocurrencies-legacy.txt
+csharp                     node_modules/@cspell/dict-csharp/csharp.txt.gz
+css                        node_modules/@cspell/dict-css/dict/css.txt
+dart                       node_modules/@cspell/dict-dart/dart.txt.gz
+data-science               node_modules/@cspell/.../dict/data-science.txt
+data-science-models        node_modules/@cspell/.../dict/data-science-models.txt
+data-science-tools         node_modules/@cspell/.../dict/data-science-tools.txt
+django                     node_modules/@cspell/dict-django/dict/django.txt
+docker                     node_modules/@cspell/dict-docker/docker-words.txt.gz
+dotnet                     node_modules/@cspell/dict-dotnet/dict/dotnet.txt
+elixir                     node_modules/@cspell/dict-elixir/dict/elixir.txt
+en_us                      node_modules/@cspell/dict-en_us/en_US.trie.gz
+en-common-misspellings
+en-gb                      node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
+en-gb-common-misspellings
+en-us-common-misspellings
+filetypes*                 node_modules/@cspell/dict-filetypes/filetypes.txt.gz
+flutter                    node_modules/@cspell/dict-flutter/flutter.txt.gz
+fonts                      node_modules/@cspell/dict-fonts/dict/fonts.txt
+fsharp                     node_modules/@cspell/dict-fsharp/dict/fsharp.txt
+fullstack                  node_modules/@cspell/.../dict/fullstack.txt
+game-development           node_modules/@cspell/.../dict/game-development.txt
+gaming-terms               node_modules/@cspell/.../dict/gaming-terms.txt
+git
+golang                     node_modules/@cspell/dict-golang/dict/go.txt
+google                     node_modules/@cspell/dict-google/dict/google.txt
+haskell                    node_modules/@cspell/dict-haskell/dict/haskell.txt
+html                       node_modules/@cspell/dict-html/dict/html.txt
+html-symbol-entities       node_modules/@cspell/.../entities.txt.gz
+java                       node_modules/@cspell/dict-java/dict/java.trie
+julia                      node_modules/@cspell/dict-julia/dict/julia.txt
+k8s                        node_modules/@cspell/dict-k8s/dict/k8s.txt
+kotlin                     node_modules/@cspell/dict-kotlin/dict/kotlin.txt
+latex                      node_modules/@cspell/dict-latex/dict/latex.txt
+lorem-ipsum                node_modules/@cspell/dict-lorem-ipsum/dict/lorem.txt
+lua                        node_modules/@cspell/dict-lua/dict/lua.txt
+makefile                   node_modules/@cspell/dict-makefile/dict/makefile.txt
+monkeyc                    node_modules/.../dict-monkeyc/monkeyc_keywords.txt.gz
+networking-terms           node_modules/@cspell/.../dict/networkingTerms.txt
+node                       node_modules/@cspell/dict-node/dict/node.txt
+npm                        node_modules/@cspell/dict-npm/dict/npm.txt
+php                        node_modules/@cspell/dict-php/dict/php.txt
+powershell                 node_modules/@cspell/.../dict/powershell.txt
+public-licenses*           node_modules/@cspell/.../public-licenses.txt.gz
+python                     node_modules/@cspell/dict-python/dict/python.txt
+python-common              node_modules/@cspell/.../dict/python-common.txt
+r                          node_modules/@cspell/dict-r/r.txt.gz
+ruby                       node_modules/@cspell/dict-ruby/dict/ruby.txt
+rust                       node_modules/@cspell/dict-rust/dict/rust.txt
+scala                      node_modules/@cspell/dict-scala/dict/scala.txt
+shellscript                node_modules/@cspell/.../dict/shell-all-words.txt
+software-term-suggestions*
+software-tools*            node_modules/@cspell/.../dict/software-tools.txt
+softwareTerms*             node_modules/@cspell/.../dict/softwareTerms.txt
+sql                        node_modules/@cspell/dict-sql/sql.txt.gz
+svelte                     node_modules/@cspell/dict-svelte/dict/svelte.txt
+swift                      node_modules/@cspell/dict-swift/swift.txt.gz
+terraform                  node_modules/@cspell/.../dict/terraform.txt
+typescript                 node_modules/@cspell/.../dict/typescript.txt
+web-services*              node_modules/@cspell/.../dict/webServices.txt
+workspace*                 ../../cspell-dict.txt
+"
+`;
+
 exports[`Validate cli > app help [ '--help' ] 1`] = `
 [
   "Usage: cspell [options] [command]",
@@ -3384,6 +3463,29 @@ exports[`Validate cli > app help [ 'check', '--help' ] 1`] = `
 `;
 
 exports[`Validate cli > app help [ 'check', '--help' ] 2`] = `""`;
+
+exports[`Validate cli > app help [ 'dictionaries', '--help' ] 1`] = `
+[
+  "Usage: cspell dictionaries [options]",
+  "",
+  "List dictionaries",
+  "",
+  "Options:",
+  "  -c, --config <cspell.json>  Configuration file to use.  By default cspell",
+  "                              looks for cspell.json in the current directory.",
+  "  --path-format <format>      Configure how to display the dictionary path.",
+  "                              (choices: "hide", "short", "long", "full",",
+  "                              default: Display most of the path.)",
+  "  --color                     Force color.",
+  "  --no-color                  Turn off color.",
+  "  --no-default-configuration  Do not load the default configuration and",
+  "                              dictionaries.",
+  "  -h, --help                  display help for command",
+  "",
+]
+`;
+
+exports[`Validate cli > app help [ 'dictionaries', '--help' ] 2`] = `""`;
 
 exports[`Validate cli > app help [ 'init', '--help' ] 1`] = `
 [
@@ -3937,224 +4039,6 @@ error"
 
 exports[`Validate cli > app lint 'lint --disable-dictionary' Expect Error: [Function CheckFailed] 3`] = `""`;
 
-exports[`Validate cli > app success 'suggest' run with [ 'suggest', 'café', '--num-suggestions=1', '--no-include-ties' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'suggest' run with [ 'suggest', 'café', '--num-suggestions=1', '--no-include-ties' ] 2`] = `
-"café:
-
- - café
-"
-`;
-
-exports[`Validate cli > app success 'trace café' run with [ 'trace', 'café' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'trace café' run with [ 'trace', 'café' ] 2`] = `
-"Word F Dictionary           Dictionary Location
-café - [flagWords]*         From Settings \`flagWords\`
-café - [ignoreWords]*       From Settings \`ignoreWords\`
-café - [suggestWords]*      From Settings \`suggestWords\`
-café - [words]*             From Settings \`words\`
-café - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
-café - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
-café - companies*           node_modules/@cspell/.../dict/companies.txt
-café - computing-acronyms*  node_modules/@cspell/.../dict/computing-acronyms.txt
-café - cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
-café * en_us*               node_modules/@cspell/dict-en_us/en_US.trie.gz
-café - en-common-misspelli* node_modules/@cspell/.../dict-en.yaml
-café * en-gb                node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
-café - filetypes*           node_modules/@cspell/dict-filetypes/filetypes.txt.gz
-café - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
-café - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
-café - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
-café - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
-café - web-services*        node_modules/@cspell/.../dict/webServices.txt
-café - workspace*           ../../cspell-dict.txt
-"
-`;
-
-exports[`Validate cli > app success 'trace hello --all' run with [ 'trace', 'hello', '--all' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'trace hello --all' run with [ 'trace', 'hello', '--all' ] 2`] = `
-"Word  F Dictionary           Dictionary Location
-hello - [flagWords]*         From Settings \`flagWords\`
-hello - [ignoreWords]*       From Settings \`ignoreWords\`
-hello - [suggestWords]*      From Settings \`suggestWords\`
-hello - [words]*             From Settings \`words\`
-hello - ada                  node_modules/@cspell/dict-ada/dict/ada.txt
-hello - al                   node_modules/@cspell/dict-al/dict/al.txt
-hello - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
-hello - bash                 node_modules/@cspell/dict-shell/dict/bash-words.txt
-hello - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
-hello - companies*           node_modules/@cspell/.../dict/companies.txt
-hello - computing-acronyms*  node_modules/.../dict/computing-acronyms.txt
-hello * cpp                  node_modules/@cspell/dict-cpp/dict/cpp.txt
-hello - cpp-legacy           node_modules/@cspell/dict-cpp/dict/cpp-legacy.txt
-hello - cpp-refined          node_modules/@cspell/dict-cpp/dict/cpp-refined.txt
-hello * cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
-hello - cryptocurrencies-le  node_modules/.../dict/cryptocurrencies-legacy.txt
-hello - csharp               node_modules/@cspell/dict-csharp/csharp.txt.gz
-hello - css                  node_modules/@cspell/dict-css/dict/css.txt
-hello - dart                 node_modules/@cspell/dict-dart/dart.txt.gz
-hello - data-science         node_modules/@cspell/.../dict/data-science.txt
-hello - data-science-models  node_modules/.../dict/data-science-models.txt
-hello - data-science-tools   node_modules/.../dict/data-science-tools.txt
-hello - django               node_modules/@cspell/dict-django/dict/django.txt
-hello - docker               node_modules/.../dict-docker/docker-words.txt.gz
-hello - dotnet               node_modules/@cspell/dict-dotnet/dict/dotnet.txt
-hello - elixir               node_modules/@cspell/dict-elixir/dict/elixir.txt
-hello * en_us*               node_modules/@cspell/dict-en_us/en_US.trie.gz
-hello - en-common-misspelli* node_modules/@cspell/.../dict-en.yaml
-hello * en-gb                node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
-hello - en-gb-common-misspe  node_modules/@cspell/.../dict-en-gb.yaml
-hello - en-us-common-misspe  node_modules/@cspell/.../dict-en-us.yaml
-hello - filetypes*           node_modules/.../dict-filetypes/filetypes.txt.gz
-hello - flutter              node_modules/@cspell/dict-flutter/flutter.txt.gz
-hello - fonts                node_modules/@cspell/dict-fonts/dict/fonts.txt
-hello - fsharp               node_modules/@cspell/dict-fsharp/dict/fsharp.txt
-hello - fullstack            node_modules/@cspell/.../dict/fullstack.txt
-hello - game-development     node_modules/@cspell/.../dict/game-development.txt
-hello - gaming-terms         node_modules/@cspell/.../dict/gaming-terms.txt
-hello - git                  node_modules/@cspell/dict-git/cspell-ext.json
-hello * golang               node_modules/@cspell/dict-golang/dict/go.txt
-hello - google               node_modules/@cspell/dict-google/dict/google.txt
-hello - haskell              node_modules/@cspell/dict-haskell/dict/haskell.txt
-hello - html                 node_modules/@cspell/dict-html/dict/html.txt
-hello - html-symbol-entitie  node_modules/@cspell/.../entities.txt.gz
-hello - java                 node_modules/@cspell/dict-java/dict/java.trie
-hello - julia                node_modules/@cspell/dict-julia/dict/julia.txt
-hello - k8s                  node_modules/@cspell/dict-k8s/dict/k8s.txt
-hello - kotlin               node_modules/@cspell/dict-kotlin/dict/kotlin.txt
-hello - latex                node_modules/@cspell/dict-latex/dict/latex.txt
-hello - lorem-ipsum          node_modules/@cspell/.../dict/lorem.txt
-hello - lua                  node_modules/@cspell/dict-lua/dict/lua.txt
-hello - makefile             node_modules/@cspell/.../dict/makefile.txt
-hello - monkeyc              node_modules/@cspell/.../monkeyc_keywords.txt.gz
-hello - networking-terms     node_modules/@cspell/.../dict/networkingTerms.txt
-hello * node                 node_modules/@cspell/dict-node/dict/node.txt
-hello - npm                  node_modules/@cspell/dict-npm/dict/npm.txt
-hello - php                  node_modules/@cspell/dict-php/dict/php.txt
-hello - powershell           node_modules/@cspell/.../dict/powershell.txt
-hello - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
-hello - python               node_modules/@cspell/dict-python/dict/python.txt
-hello - python-common        node_modules/@cspell/.../dict/python-common.txt
-hello - r                    node_modules/@cspell/dict-r/r.txt.gz
-hello - ruby                 node_modules/@cspell/dict-ruby/dict/ruby.txt
-hello - rust                 node_modules/@cspell/dict-rust/dict/rust.txt
-hello - scala                node_modules/@cspell/dict-scala/dict/scala.txt
-hello - shellscript          node_modules/@cspell/.../dict/shell-all-words.txt
-hello - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
-hello - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
-hello - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
-hello - sql                  node_modules/@cspell/dict-sql/sql.txt.gz
-hello - svelte               node_modules/@cspell/dict-svelte/dict/svelte.txt
-hello - swift                node_modules/@cspell/dict-swift/swift.txt.gz
-hello - terraform            node_modules/@cspell/.../dict/terraform.txt
-hello - typescript           node_modules/@cspell/.../dict/typescript.txt
-hello - web-services*        node_modules/@cspell/.../dict/webServices.txt
-hello - workspace*           ../../cspell-dict.txt
-"
-`;
-
-exports[`Validate cli > app success 'trace hello --color' run with [ 'trace', 'hello', '--color' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'trace hello --color' run with [ 'trace', 'hello', '--color' ] 2`] = `
-"[1m[4mWord[24m[22m  [1m[4mF[24m[22m [1m[4mDictionary[24m[22m           [1m[4mDictionary Location[24m[22m
-[32mhello[39m [2m-[22m [93m[flagWords]*[39m         [37mFrom Settings \`flagWords\`[39m
-[32mhello[39m [2m-[22m [93m[ignoreWords]*[39m       [37mFrom Settings \`ignoreWords\`[39m
-[32mhello[39m [2m-[22m [93m[suggestWords]*[39m      [37mFrom Settings \`suggestWords\`[39m
-[32mhello[39m [2m-[22m [93m[words]*[39m             [37mFrom Settings \`words\`[39m
-[32mhello[39m [2m-[22m [93maws*[39m                 [37mnode_modules/@cspell/dict-aws/dict/aws.txt[39m
-[32mhello[39m [2m-[22m [93mcoding-compound-ter*[39m [37mnode_modules/.../dict/coding-compound-terms.txt[39m
-[32mhello[39m [2m-[22m [93mcompanies*[39m           [37mnode_modules/@cspell/.../dict/companies.txt[39m
-[32mhello[39m [2m-[22m [93mcomputing-acronyms*[39m  [37mnode_modules/.../dict/computing-acronyms.txt[39m
-[32mhello[39m [97m*[39m [38;5;179mcpp [39m                 [37mnode_modules/@cspell/dict-cpp/dict/cpp.txt[39m
-[32mhello[39m [97m*[39m [93mcryptocurrencies*[39m    [37mnode_modules/@cspell/.../dict/cryptocurrencies.txt[39m
-[32mhello[39m [97m*[39m [93men_us*[39m               [37mnode_modules/@cspell/dict-en_us/en_US.trie.gz[39m
-[32mhello[39m [2m-[22m [93men-common-misspelli*[39m [37mnode_modules/@cspell/.../dict-en.yaml[39m
-[32mhello[39m [97m*[39m [38;5;179men-gb [39m               [37mnode_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz[39m
-[32mhello[39m [2m-[22m [93mfiletypes*[39m           [37mnode_modules/.../dict-filetypes/filetypes.txt.gz[39m
-[32mhello[39m [97m*[39m [38;5;179mgolang [39m              [37mnode_modules/@cspell/dict-golang/dict/go.txt[39m
-[32mhello[39m [97m*[39m [38;5;179mnode [39m                [37mnode_modules/@cspell/dict-node/dict/node.txt[39m
-[32mhello[39m [2m-[22m [93mpublic-licenses*[39m     [37mnode_modules/@cspell/.../public-licenses.txt.gz[39m
-[32mhello[39m [2m-[22m [93msoftware-term-sugge*[39m [37mnode_modules/@cspell/.../cspell-corrections.yaml[39m
-[32mhello[39m [2m-[22m [93msoftware-tools*[39m      [37mnode_modules/@cspell/.../dict/software-tools.txt[39m
-[32mhello[39m [2m-[22m [93msoftwareTerms*[39m       [37mnode_modules/@cspell/.../dict/softwareTerms.txt[39m
-[32mhello[39m [2m-[22m [93mweb-services*[39m        [37mnode_modules/@cspell/.../dict/webServices.txt[39m
-[32mhello[39m [2m-[22m [93mworkspace*[39m           [37m../../cspell-dict.txt[39m
-"
-`;
-
-exports[`Validate cli > app success 'trace hello --no-color' run with [ 'trace', 'hello', '--no-color' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'trace hello --no-color' run with [ 'trace', 'hello', '--no-color' ] 2`] = `
-"Word  F Dictionary           Dictionary Location
-hello - [flagWords]*         From Settings \`flagWords\`
-hello - [ignoreWords]*       From Settings \`ignoreWords\`
-hello - [suggestWords]*      From Settings \`suggestWords\`
-hello - [words]*             From Settings \`words\`
-hello - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
-hello - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
-hello - companies*           node_modules/@cspell/.../dict/companies.txt
-hello - computing-acronyms*  node_modules/.../dict/computing-acronyms.txt
-hello * cpp                  node_modules/@cspell/dict-cpp/dict/cpp.txt
-hello * cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
-hello * en_us*               node_modules/@cspell/dict-en_us/en_US.trie.gz
-hello - en-common-misspelli* node_modules/@cspell/.../dict-en.yaml
-hello * en-gb                node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
-hello - filetypes*           node_modules/.../dict-filetypes/filetypes.txt.gz
-hello * golang               node_modules/@cspell/dict-golang/dict/go.txt
-hello * node                 node_modules/@cspell/dict-node/dict/node.txt
-hello - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
-hello - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
-hello - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
-hello - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
-hello - web-services*        node_modules/@cspell/.../dict/webServices.txt
-hello - workspace*           ../../cspell-dict.txt
-"
-`;
-
-exports[`Validate cli > app success 'trace hello --only-found' run with [ 'trace', 'hello', '--only-found' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'trace hello --only-found' run with [ 'trace', 'hello', '--only-found' ] 2`] = `
-"Word  F Dictionary        Dictionary Location
-hello * cpp               node_modules/@cspell/dict-cpp/dict/cpp.txt
-hello * cryptocurrencies* node_modules/@cspell/.../dict/cryptocurrencies.txt
-hello * en_us*            node_modules/@cspell/dict-en_us/en_US.trie.gz
-hello * en-gb             node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
-hello * golang            node_modules/@cspell/dict-golang/dict/go.txt
-hello * node              node_modules/@cspell/dict-node/dict/node.txt
-"
-`;
-
-exports[`Validate cli > app success 'trace hello' run with [ 'trace', '--locale=en-gb', 'hello' ] 1`] = `[]`;
-
-exports[`Validate cli > app success 'trace hello' run with [ 'trace', '--locale=en-gb', 'hello' ] 2`] = `
-"Word  F Dictionary           Dictionary Location
-hello - [flagWords]*         From Settings \`flagWords\`
-hello - [ignoreWords]*       From Settings \`ignoreWords\`
-hello - [suggestWords]*      From Settings \`suggestWords\`
-hello - [words]*             From Settings \`words\`
-hello - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
-hello - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
-hello - companies*           node_modules/@cspell/.../dict/companies.txt
-hello - computing-acronyms*  node_modules/.../dict/computing-acronyms.txt
-hello * cpp                  node_modules/@cspell/dict-cpp/dict/cpp.txt
-hello * cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
-hello * en_us                node_modules/@cspell/dict-en_us/en_US.trie.gz
-hello * en-gb*               node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
-hello - en-gb-common-misspe* node_modules/@cspell/.../dict-en-gb.yaml
-hello - filetypes*           node_modules/.../dict-filetypes/filetypes.txt.gz
-hello * golang               node_modules/@cspell/dict-golang/dict/go.txt
-hello * node                 node_modules/@cspell/dict-node/dict/node.txt
-hello - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
-hello - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
-hello - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
-hello - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
-hello - web-services*        node_modules/@cspell/.../dict/webServices.txt
-hello - workspace*           ../../cspell-dict.txt
-"
-`;
-
 exports[`Validate cli > app suggest [ 'sug' ] 1`] = `
 [
   "Usage: cspell suggestions|sug [options] [words...]",
@@ -4373,5 +4257,223 @@ exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-us' ] 2`] = `""`;
 
 exports[`Validate cli > app suggest [ 'sug', 'mexico', '-d=en-us' ] 3`] = `
 "Unknown dictionary: "en-us"
+"
+`;
+
+exports[`Validate cli > app trace 'suggest' run with [ 'suggest', 'café', '--num-suggestions=1', '--no-include-ties' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'suggest' run with [ 'suggest', 'café', '--num-suggestions=1', '--no-include-ties' ] 2`] = `
+"café:
+
+ - café
+"
+`;
+
+exports[`Validate cli > app trace 'trace café' run with [ 'trace', 'café' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'trace café' run with [ 'trace', 'café' ] 2`] = `
+"Word F Dictionary           Dictionary Location
+café - [flagWords]*         From Settings \`flagWords\`
+café - [ignoreWords]*       From Settings \`ignoreWords\`
+café - [suggestWords]*      From Settings \`suggestWords\`
+café - [words]*             From Settings \`words\`
+café - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
+café - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
+café - companies*           node_modules/@cspell/.../dict/companies.txt
+café - computing-acronyms*  node_modules/@cspell/.../dict/computing-acronyms.txt
+café - cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
+café * en_us*               node_modules/@cspell/dict-en_us/en_US.trie.gz
+café - en-common-misspelli* node_modules/@cspell/.../dict-en.yaml
+café * en-gb                node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
+café - filetypes*           node_modules/@cspell/dict-filetypes/filetypes.txt.gz
+café - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
+café - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
+café - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
+café - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
+café - web-services*        node_modules/@cspell/.../dict/webServices.txt
+café - workspace*           ../../cspell-dict.txt
+"
+`;
+
+exports[`Validate cli > app trace 'trace hello --all' run with [ 'trace', 'hello', '--all' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'trace hello --all' run with [ 'trace', 'hello', '--all' ] 2`] = `
+"Word  F Dictionary           Dictionary Location
+hello - [flagWords]*         From Settings \`flagWords\`
+hello - [ignoreWords]*       From Settings \`ignoreWords\`
+hello - [suggestWords]*      From Settings \`suggestWords\`
+hello - [words]*             From Settings \`words\`
+hello - ada                  node_modules/@cspell/dict-ada/dict/ada.txt
+hello - al                   node_modules/@cspell/dict-al/dict/al.txt
+hello - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
+hello - bash                 node_modules/@cspell/dict-shell/dict/bash-words.txt
+hello - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
+hello - companies*           node_modules/@cspell/.../dict/companies.txt
+hello - computing-acronyms*  node_modules/.../dict/computing-acronyms.txt
+hello * cpp                  node_modules/@cspell/dict-cpp/dict/cpp.txt
+hello - cpp-legacy           node_modules/@cspell/dict-cpp/dict/cpp-legacy.txt
+hello - cpp-refined          node_modules/@cspell/dict-cpp/dict/cpp-refined.txt
+hello * cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
+hello - cryptocurrencies-le  node_modules/.../dict/cryptocurrencies-legacy.txt
+hello - csharp               node_modules/@cspell/dict-csharp/csharp.txt.gz
+hello - css                  node_modules/@cspell/dict-css/dict/css.txt
+hello - dart                 node_modules/@cspell/dict-dart/dart.txt.gz
+hello - data-science         node_modules/@cspell/.../dict/data-science.txt
+hello - data-science-models  node_modules/.../dict/data-science-models.txt
+hello - data-science-tools   node_modules/.../dict/data-science-tools.txt
+hello - django               node_modules/@cspell/dict-django/dict/django.txt
+hello - docker               node_modules/.../dict-docker/docker-words.txt.gz
+hello - dotnet               node_modules/@cspell/dict-dotnet/dict/dotnet.txt
+hello - elixir               node_modules/@cspell/dict-elixir/dict/elixir.txt
+hello * en_us*               node_modules/@cspell/dict-en_us/en_US.trie.gz
+hello - en-common-misspelli* node_modules/@cspell/.../dict-en.yaml
+hello * en-gb                node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
+hello - en-gb-common-misspe  node_modules/@cspell/.../dict-en-gb.yaml
+hello - en-us-common-misspe  node_modules/@cspell/.../dict-en-us.yaml
+hello - filetypes*           node_modules/.../dict-filetypes/filetypes.txt.gz
+hello - flutter              node_modules/@cspell/dict-flutter/flutter.txt.gz
+hello - fonts                node_modules/@cspell/dict-fonts/dict/fonts.txt
+hello - fsharp               node_modules/@cspell/dict-fsharp/dict/fsharp.txt
+hello - fullstack            node_modules/@cspell/.../dict/fullstack.txt
+hello - game-development     node_modules/@cspell/.../dict/game-development.txt
+hello - gaming-terms         node_modules/@cspell/.../dict/gaming-terms.txt
+hello - git                  node_modules/@cspell/dict-git/cspell-ext.json
+hello * golang               node_modules/@cspell/dict-golang/dict/go.txt
+hello - google               node_modules/@cspell/dict-google/dict/google.txt
+hello - haskell              node_modules/@cspell/dict-haskell/dict/haskell.txt
+hello - html                 node_modules/@cspell/dict-html/dict/html.txt
+hello - html-symbol-entitie  node_modules/@cspell/.../entities.txt.gz
+hello - java                 node_modules/@cspell/dict-java/dict/java.trie
+hello - julia                node_modules/@cspell/dict-julia/dict/julia.txt
+hello - k8s                  node_modules/@cspell/dict-k8s/dict/k8s.txt
+hello - kotlin               node_modules/@cspell/dict-kotlin/dict/kotlin.txt
+hello - latex                node_modules/@cspell/dict-latex/dict/latex.txt
+hello - lorem-ipsum          node_modules/@cspell/.../dict/lorem.txt
+hello - lua                  node_modules/@cspell/dict-lua/dict/lua.txt
+hello - makefile             node_modules/@cspell/.../dict/makefile.txt
+hello - monkeyc              node_modules/@cspell/.../monkeyc_keywords.txt.gz
+hello - networking-terms     node_modules/@cspell/.../dict/networkingTerms.txt
+hello * node                 node_modules/@cspell/dict-node/dict/node.txt
+hello - npm                  node_modules/@cspell/dict-npm/dict/npm.txt
+hello - php                  node_modules/@cspell/dict-php/dict/php.txt
+hello - powershell           node_modules/@cspell/.../dict/powershell.txt
+hello - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
+hello - python               node_modules/@cspell/dict-python/dict/python.txt
+hello - python-common        node_modules/@cspell/.../dict/python-common.txt
+hello - r                    node_modules/@cspell/dict-r/r.txt.gz
+hello - ruby                 node_modules/@cspell/dict-ruby/dict/ruby.txt
+hello - rust                 node_modules/@cspell/dict-rust/dict/rust.txt
+hello - scala                node_modules/@cspell/dict-scala/dict/scala.txt
+hello - shellscript          node_modules/@cspell/.../dict/shell-all-words.txt
+hello - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
+hello - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
+hello - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
+hello - sql                  node_modules/@cspell/dict-sql/sql.txt.gz
+hello - svelte               node_modules/@cspell/dict-svelte/dict/svelte.txt
+hello - swift                node_modules/@cspell/dict-swift/swift.txt.gz
+hello - terraform            node_modules/@cspell/.../dict/terraform.txt
+hello - typescript           node_modules/@cspell/.../dict/typescript.txt
+hello - web-services*        node_modules/@cspell/.../dict/webServices.txt
+hello - workspace*           ../../cspell-dict.txt
+"
+`;
+
+exports[`Validate cli > app trace 'trace hello --color' run with [ 'trace', 'hello', '--color' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'trace hello --color' run with [ 'trace', 'hello', '--color' ] 2`] = `
+"[1m[4mWord[24m[22m  [1m[4mF[24m[22m [1m[4mDictionary[24m[22m           [1m[4mDictionary Location[24m[22m
+[32mhello[39m [2m-[22m [93m[flagWords]*[39m         [37mFrom Settings \`flagWords\`[39m
+[32mhello[39m [2m-[22m [93m[ignoreWords]*[39m       [37mFrom Settings \`ignoreWords\`[39m
+[32mhello[39m [2m-[22m [93m[suggestWords]*[39m      [37mFrom Settings \`suggestWords\`[39m
+[32mhello[39m [2m-[22m [93m[words]*[39m             [37mFrom Settings \`words\`[39m
+[32mhello[39m [2m-[22m [93maws*[39m                 [37mnode_modules/@cspell/dict-aws/dict/aws.txt[39m
+[32mhello[39m [2m-[22m [93mcoding-compound-ter*[39m [37mnode_modules/.../dict/coding-compound-terms.txt[39m
+[32mhello[39m [2m-[22m [93mcompanies*[39m           [37mnode_modules/@cspell/.../dict/companies.txt[39m
+[32mhello[39m [2m-[22m [93mcomputing-acronyms*[39m  [37mnode_modules/.../dict/computing-acronyms.txt[39m
+[32mhello[39m [97m*[39m [38;5;179mcpp [39m                 [37mnode_modules/@cspell/dict-cpp/dict/cpp.txt[39m
+[32mhello[39m [97m*[39m [93mcryptocurrencies*[39m    [37mnode_modules/@cspell/.../dict/cryptocurrencies.txt[39m
+[32mhello[39m [97m*[39m [93men_us*[39m               [37mnode_modules/@cspell/dict-en_us/en_US.trie.gz[39m
+[32mhello[39m [2m-[22m [93men-common-misspelli*[39m [37mnode_modules/@cspell/.../dict-en.yaml[39m
+[32mhello[39m [97m*[39m [38;5;179men-gb [39m               [37mnode_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz[39m
+[32mhello[39m [2m-[22m [93mfiletypes*[39m           [37mnode_modules/.../dict-filetypes/filetypes.txt.gz[39m
+[32mhello[39m [97m*[39m [38;5;179mgolang [39m              [37mnode_modules/@cspell/dict-golang/dict/go.txt[39m
+[32mhello[39m [97m*[39m [38;5;179mnode [39m                [37mnode_modules/@cspell/dict-node/dict/node.txt[39m
+[32mhello[39m [2m-[22m [93mpublic-licenses*[39m     [37mnode_modules/@cspell/.../public-licenses.txt.gz[39m
+[32mhello[39m [2m-[22m [93msoftware-term-sugge*[39m [37mnode_modules/@cspell/.../cspell-corrections.yaml[39m
+[32mhello[39m [2m-[22m [93msoftware-tools*[39m      [37mnode_modules/@cspell/.../dict/software-tools.txt[39m
+[32mhello[39m [2m-[22m [93msoftwareTerms*[39m       [37mnode_modules/@cspell/.../dict/softwareTerms.txt[39m
+[32mhello[39m [2m-[22m [93mweb-services*[39m        [37mnode_modules/@cspell/.../dict/webServices.txt[39m
+[32mhello[39m [2m-[22m [93mworkspace*[39m           [37m../../cspell-dict.txt[39m
+"
+`;
+
+exports[`Validate cli > app trace 'trace hello --no-color' run with [ 'trace', 'hello', '--no-color' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'trace hello --no-color' run with [ 'trace', 'hello', '--no-color' ] 2`] = `
+"Word  F Dictionary           Dictionary Location
+hello - [flagWords]*         From Settings \`flagWords\`
+hello - [ignoreWords]*       From Settings \`ignoreWords\`
+hello - [suggestWords]*      From Settings \`suggestWords\`
+hello - [words]*             From Settings \`words\`
+hello - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
+hello - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
+hello - companies*           node_modules/@cspell/.../dict/companies.txt
+hello - computing-acronyms*  node_modules/.../dict/computing-acronyms.txt
+hello * cpp                  node_modules/@cspell/dict-cpp/dict/cpp.txt
+hello * cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
+hello * en_us*               node_modules/@cspell/dict-en_us/en_US.trie.gz
+hello - en-common-misspelli* node_modules/@cspell/.../dict-en.yaml
+hello * en-gb                node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
+hello - filetypes*           node_modules/.../dict-filetypes/filetypes.txt.gz
+hello * golang               node_modules/@cspell/dict-golang/dict/go.txt
+hello * node                 node_modules/@cspell/dict-node/dict/node.txt
+hello - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
+hello - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
+hello - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
+hello - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
+hello - web-services*        node_modules/@cspell/.../dict/webServices.txt
+hello - workspace*           ../../cspell-dict.txt
+"
+`;
+
+exports[`Validate cli > app trace 'trace hello --only-found' run with [ 'trace', 'hello', '--only-found' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'trace hello --only-found' run with [ 'trace', 'hello', '--only-found' ] 2`] = `
+"Word  F Dictionary        Dictionary Location
+hello * cpp               node_modules/@cspell/dict-cpp/dict/cpp.txt
+hello * cryptocurrencies* node_modules/@cspell/.../dict/cryptocurrencies.txt
+hello * en_us*            node_modules/@cspell/dict-en_us/en_US.trie.gz
+hello * en-gb             node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
+hello * golang            node_modules/@cspell/dict-golang/dict/go.txt
+hello * node              node_modules/@cspell/dict-node/dict/node.txt
+"
+`;
+
+exports[`Validate cli > app trace 'trace hello' run with [ 'trace', '--locale=en-gb', 'hello' ] 1`] = `[]`;
+
+exports[`Validate cli > app trace 'trace hello' run with [ 'trace', '--locale=en-gb', 'hello' ] 2`] = `
+"Word  F Dictionary           Dictionary Location
+hello - [flagWords]*         From Settings \`flagWords\`
+hello - [ignoreWords]*       From Settings \`ignoreWords\`
+hello - [suggestWords]*      From Settings \`suggestWords\`
+hello - [words]*             From Settings \`words\`
+hello - aws*                 node_modules/@cspell/dict-aws/dict/aws.txt
+hello - coding-compound-ter* node_modules/.../dict/coding-compound-terms.txt
+hello - companies*           node_modules/@cspell/.../dict/companies.txt
+hello - computing-acronyms*  node_modules/.../dict/computing-acronyms.txt
+hello * cpp                  node_modules/@cspell/dict-cpp/dict/cpp.txt
+hello * cryptocurrencies*    node_modules/@cspell/.../dict/cryptocurrencies.txt
+hello * en_us                node_modules/@cspell/dict-en_us/en_US.trie.gz
+hello * en-gb*               node_modules/@cspell/dict-en-gb-mit/en_GB.trie.gz
+hello - en-gb-common-misspe* node_modules/@cspell/.../dict-en-gb.yaml
+hello - filetypes*           node_modules/.../dict-filetypes/filetypes.txt.gz
+hello * golang               node_modules/@cspell/dict-golang/dict/go.txt
+hello * node                 node_modules/@cspell/dict-node/dict/node.txt
+hello - public-licenses*     node_modules/@cspell/.../public-licenses.txt.gz
+hello - software-term-sugge* node_modules/@cspell/.../cspell-corrections.yaml
+hello - software-tools*      node_modules/@cspell/.../dict/software-tools.txt
+hello - softwareTerms*       node_modules/@cspell/.../dict/softwareTerms.txt
+hello - web-services*        node_modules/@cspell/.../dict/webServices.txt
+hello - workspace*           ../../cspell-dict.txt
 "
 `;

--- a/packages/cspell/src/app/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/app/__snapshots__/app.test.ts.snap
@@ -3354,6 +3354,7 @@ exports[`Validate cli > app help [ '--help' ] 1`] = `
   "  init [options]                        Initialize a CSpell configuration file.",
   "  link                                  Link dictionaries and other settings to",
   "                                        the cspell global config.",
+  "  dictionaries [options]                List dictionaries",
   "  help [command]                        display help for command",
   "",
 ]

--- a/packages/cspell/src/app/app.mts
+++ b/packages/cspell/src/app/app.mts
@@ -3,6 +3,7 @@ import { Option as CommanderOption, program } from 'commander';
 import { satisfies as semverSatisfies } from 'semver';
 
 import { commandCheck } from './commandCheck.js';
+import { commandDictionaries } from './commandDictionaries.js';
 import { commandInit } from './commandInit.js';
 import { commandLink } from './commandLink.js';
 import { commandLint } from './commandLint.js';
@@ -38,6 +39,7 @@ export async function run(command?: Command, argv?: string[]): Promise<void> {
     commandSuggestion(prog).addOption(optionFlags);
     commandInit(prog).addOption(optionFlags);
     commandLink(prog);
+    commandDictionaries(prog);
 
     prog.exitOverride();
     await prog.parseAsync(args);

--- a/packages/cspell/src/app/app.test.ts
+++ b/packages/cspell/src/app/app.test.ts
@@ -265,6 +265,7 @@ describe('Validate cli', () => {
         ${['suggest', '--help']}
         ${['link', '--help']}
         ${['check', '--help']}
+        ${['dictionaries', '--help']}
     `('app help $cmdArgs', async ({ cmdArgs }) => {
         chalk.level = 1;
         const commander = getCommander();
@@ -334,7 +335,19 @@ describe('Validate cli', () => {
         ${'trace café'}               | ${['trace', 'café'.normalize('NFD')]}
         ${'trace hello'}              | ${['trace', '--locale=en-gb', 'hello']}
         ${'suggest'}                  | ${['suggest', 'café'.normalize('NFD'), '--num-suggestions=1', '--no-include-ties']}
-    `('app success $msg run with $testArgs', async ({ testArgs }: TestCase) => {
+    `('app trace $msg run with $testArgs', async ({ testArgs }: TestCase) => {
+        chalk.level = 0;
+        const commander = getCommander();
+        const args = argv(...testArgs);
+        await app.run(commander, args);
+        expect(captureStdout.text).toMatchSnapshot();
+        expect(normalizeLogCalls(log.mock.calls)).toMatchSnapshot();
+    });
+
+    test.each`
+        testArgs
+        ${['dictionaries']}
+    `('app dictionary $testArgs', async ({ testArgs }: TestCase) => {
         chalk.level = 0;
         const commander = getCommander();
         const args = argv(...testArgs);

--- a/packages/cspell/src/app/application.mts
+++ b/packages/cspell/src/app/application.mts
@@ -18,7 +18,14 @@ import type { TimedSuggestionsForWordResult } from './emitters/suggestionsEmitte
 import { getFeatureFlags, parseFeatureFlags } from './featureFlags/index.js';
 import { extractUnknownWordsConfig, LintRequest, runLint } from './lint/index.js';
 import { CSpellReporterConfiguration } from './models.js';
-import type { BaseOptions, LegacyOptions, LinterCliOptions, SuggestionOptions, TraceOptions } from './options.js';
+import type {
+    BaseOptions,
+    DictionariesOptions,
+    LegacyOptions,
+    LinterCliOptions,
+    SuggestionOptions,
+    TraceOptions,
+} from './options.js';
 import { fixLegacy } from './options.js';
 import { simpleRepl } from './repl/index.js';
 import { readConfig } from './util/configFileHelper.js';
@@ -130,4 +137,31 @@ function registerApplicationFeatureFlags(): FeatureFlags {
 export function parseApplicationFeatureFlags(flags: string[] | undefined): FeatureFlags {
     const ff = registerApplicationFeatureFlags();
     return parseFeatureFlags(flags, ff);
+}
+
+export interface ListDictionariesResult {
+    name: string;
+    description?: string | undefined;
+    path?: string | undefined;
+    enabled: boolean;
+}
+
+export async function listDictionaries(options: DictionariesOptions): Promise<ListDictionariesResult[]> {
+    const configFile = await readConfig(options.config, undefined);
+    const loadDefault = options.defaultConfiguration ?? configFile.config.loadDefaultConfiguration ?? true;
+
+    const config = mergeSettings(
+        await getDefaultSettings(loadDefault),
+        await getGlobalSettingsAsync(),
+        configFile.config,
+    );
+
+    const enabledDictionaries = new Set(config.dictionaries || []);
+
+    return (config.dictionaryDefinitions || []).map((dict) => ({
+        name: dict.name,
+        description: dict.description,
+        enabled: enabledDictionaries.has(dict.name),
+        path: dict.path,
+    }));
 }

--- a/packages/cspell/src/app/commandDictionaries.ts
+++ b/packages/cspell/src/app/commandDictionaries.ts
@@ -1,0 +1,50 @@
+import type { Command } from 'commander';
+import { Option as CommanderOption } from 'commander';
+
+import * as App from './application.mjs';
+import { emitListDictionariesResults } from './emitters/dictionaryListEmitter.js';
+import { isDictionaryPathFormat } from './emitters/DictionaryPathFormat.js';
+import type { DictionariesOptions } from './options.js';
+import { canUseColor } from './util/canUseColor.js';
+
+// interface InitOptions extends Options {}
+
+export function commandDictionaries(prog: Command): Command {
+    return prog
+        .command('dictionaries')
+        .description(`List dictionaries`)
+        .option(
+            '-c, --config <cspell.json>',
+            'Configuration file to use.  By default cspell looks for cspell.json in the current directory.',
+        )
+        .addOption(
+            new CommanderOption('--path-format <format>', 'Configure how to display the dictionary path.')
+                .choices(['hide', 'short', 'long', 'full'])
+                .default('long', 'Display most of the path.'),
+        )
+        .addOption(new CommanderOption('--color', 'Force color.').default(undefined))
+        .addOption(new CommanderOption('--no-color', 'Turn off color.').default(undefined))
+        .addOption(
+            new CommanderOption(
+                '--default-configuration',
+                'Load the default configuration and dictionaries.',
+            ).hideHelp(),
+        )
+        .addOption(
+            new CommanderOption(
+                '--no-default-configuration',
+                'Do not load the default configuration and dictionaries.',
+            ),
+        )
+        .action(async (options: DictionariesOptions) => {
+            const dictionaryPathFormat = isDictionaryPathFormat(options.pathFormat) ? options.pathFormat : 'long';
+
+            const useColor = canUseColor(options.color);
+            const listResult = await App.listDictionaries(options);
+            emitListDictionariesResults(listResult, {
+                cwd: process.cwd(),
+                dictionaryPathFormat,
+                color: useColor,
+            });
+        });
+}

--- a/packages/cspell/src/app/emitters/dictionaryListEmitter.ts
+++ b/packages/cspell/src/app/emitters/dictionaryListEmitter.ts
@@ -1,0 +1,84 @@
+import * as iPath from 'node:path';
+
+import chalk from 'chalk';
+
+import type { ListDictionariesResult } from '../application.mjs';
+import { console } from '../console.js';
+import { TableRow, tableToLines } from '../util/table.js';
+import type { DictionaryPathFormat } from './DictionaryPathFormat.js';
+import { formatDictionaryLocation, type PathInterface } from './helpers.js';
+
+export interface EmitDictOptions {
+    /** current working directory */
+    cwd: string;
+    lineWidth?: number;
+    dictionaryPathFormat: DictionaryPathFormat;
+    iPath?: PathInterface;
+    color?: boolean | undefined;
+}
+
+const maxWidth = 120;
+
+const colWidthDictionaryName = 40;
+
+export function emitListDictionariesResults(results: ListDictionariesResult[], options: EmitDictOptions): void {
+    const report = calcListDictsResultsReport(results, options);
+    console.log(report.table);
+    if (report.errors) {
+        console.error('Errors:');
+        console.error(report.errors);
+    }
+}
+
+export function calcListDictsResultsReport(
+    results: ListDictionariesResult[],
+    options: EmitDictOptions,
+): { table: string; errors: string } {
+    if (options.color === true) {
+        chalk.level = 2;
+    } else if (options.color === false) {
+        chalk.level = 0;
+    }
+    const col = new Intl.Collator();
+    results.sort((a, b) => col.compare(a.name, b.name));
+
+    const header = emitHeader(options.dictionaryPathFormat !== 'hide');
+    const rows = results.map((r) => emitDictResult(r, options));
+
+    const t = tableToLines({
+        header,
+        rows,
+        terminalWidth: options.lineWidth || process.stdout.columns || maxWidth,
+        deliminator: ' ',
+    });
+
+    return {
+        table: t.map((line) => line.trimEnd()).join('\n'),
+        errors: '',
+    };
+}
+
+function emitHeader(location: boolean): string[] {
+    const headers = ['Dictionary'];
+
+    location && headers.push('Dictionary Location');
+
+    return headers;
+}
+
+function emitDictResult(r: ListDictionariesResult, options: EmitDictOptions): TableRow {
+    const a = r.enabled ? '*' : ' ';
+    const dictName = r.name.slice(0, colWidthDictionaryName - 1) + a;
+    const dictColor = r.enabled ? chalk.yellowBright : chalk.rgb(200, 128, 50);
+    const n = dictColor(dictName);
+    const c = colorize(chalk.white);
+    return [
+        n,
+        (widthSrc) =>
+            c((r.path && formatDictionaryLocation(r.path, widthSrc ?? maxWidth, { iPath, ...options })) || ''),
+    ];
+}
+
+function colorize(fn: (s: string) => string): (s: string) => string {
+    return (s: string) => (s ? fn(s) : '');
+}

--- a/packages/cspell/src/app/emitters/helpers.test.ts
+++ b/packages/cspell/src/app/emitters/helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+
+import { trimMidPath } from './helpers.js';
+
+describe('helpers', () => {
+    test.each`
+        path                      | width | expected
+        ${''}                     | ${20} | ${''}
+        ${'0123456789'}           | ${7}  | ${'01...89'}
+        ${'0123/56789'}           | ${7}  | ${'01...89'}
+        ${'0123/56789'}           | ${9}  | ${'.../56789'}
+        ${'0123/56789/1234/6789'} | ${20} | ${'0123/56789/1234/6789'}
+        ${'0123/89/77/1234/6789'} | ${19} | ${'0123/.../1234/6789'}
+        ${'0123/8/7/1gh1234/689'} | ${19} | ${'0123/8/7/.../689'}
+    `('trimMidPath', ({ path, width, expected }) => {
+        expect(trimMidPath(path, width, '/')).toBe(expected);
+    });
+});

--- a/packages/cspell/src/app/emitters/helpers.ts
+++ b/packages/cspell/src/app/emitters/helpers.ts
@@ -1,0 +1,85 @@
+import type { DictionaryPathFormat } from './DictionaryPathFormat.js';
+
+export interface PathInterface {
+    relative(from: string, to: string): string;
+    basename(path: string): string;
+    sep: string;
+}
+
+export function trimMidPath(s: string, w: number, sep: string): string {
+    if (s.length <= w) return s;
+    const parts = s.split(sep);
+    if (parts[parts.length - 1].length > w) return trimMid(s, w);
+
+    function join(left: number, right: number) {
+        // if (left === right) return parts.join(sep);
+        return [...parts.slice(0, left), '...', ...parts.slice(right)].join(sep);
+    }
+
+    let left = 0,
+        right = parts.length,
+        last = '';
+    for (let i = 0; i < parts.length; ++i) {
+        const incLeft = i & 1 ? 1 : 0;
+        const incRight = incLeft ? 0 : -1;
+        const next = join(left + incLeft, right + incRight);
+        if (next.length > w) break;
+        left += incLeft;
+        right += incRight;
+        last = next;
+    }
+    for (let i = left + 1; i < right; ++i) {
+        const next = join(i, right);
+        if (next.length > w) break;
+        last = next;
+    }
+    for (let i = right - 1; i > left; --i) {
+        const next = join(left, i);
+        if (next.length > w) break;
+        last = next;
+    }
+    return last || trimMid(s, w);
+}
+
+export function trimMid(s: string, w: number): string {
+    s = s.trim();
+    if (s.length <= w) {
+        return s;
+    }
+    const l = Math.floor((w - 3) / 2);
+    const r = Math.ceil((w - 3) / 2);
+    return s.slice(0, l) + '...' + s.slice(-r);
+}
+
+export function formatDictionaryLocation(
+    dictSource: string,
+    maxWidth: number,
+    {
+        cwd,
+        dictionaryPathFormat: format,
+        iPath,
+    }: {
+        cwd: string;
+        dictionaryPathFormat: DictionaryPathFormat;
+        iPath: PathInterface;
+    },
+): string {
+    let relPath = cwd ? iPath.relative(cwd, dictSource) : dictSource;
+    const idxNodeModule = relPath.lastIndexOf('node_modules');
+    const isNodeModule = idxNodeModule >= 0;
+    if (format === 'hide') return '';
+    if (format === 'short') {
+        const prefix = isNodeModule
+            ? '[node_modules]/'
+            : relPath.startsWith('..' + iPath.sep + '..')
+              ? '.../'
+              : relPath.startsWith('..' + iPath.sep)
+                ? '../'
+                : '';
+        return prefix + iPath.basename(dictSource);
+    }
+    if (format === 'full') return dictSource;
+    relPath = isNodeModule ? relPath.slice(idxNodeModule) : relPath;
+    const usePath = relPath.length < dictSource.length ? relPath : dictSource;
+    return trimMidPath(usePath, maxWidth, iPath.sep);
+}

--- a/packages/cspell/src/app/emitters/traceEmitter.test.ts
+++ b/packages/cspell/src/app/emitters/traceEmitter.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import type { TraceResult } from '../application.mjs';
 import { console } from '../console.js';
-import { __testing__, calcTraceResultsReport, emitTraceResults } from './traceEmitter.js';
+import { calcTraceResultsReport, emitTraceResults } from './traceEmitter.js';
 
 const compareStr = Intl.Collator().compare;
 
@@ -111,21 +111,6 @@ errorcode  * project-words     D:/this_is_a_very/long/path/project-words.txt
 errorcode  - softwareTerms*    D:/this_is_a_very/long/path/node_modules/@cspell/dict-software-terms/dict/softwareTerms.txt`,
             ),
         );
-    });
-});
-
-describe('trimMidPath', () => {
-    test.each`
-        path                      | width | expected
-        ${''}                     | ${20} | ${''}
-        ${'0123456789'}           | ${7}  | ${'01...89'}
-        ${'0123/56789'}           | ${7}  | ${'01...89'}
-        ${'0123/56789'}           | ${9}  | ${'.../56789'}
-        ${'0123/56789/1234/6789'} | ${20} | ${'0123/56789/1234/6789'}
-        ${'0123/89/77/1234/6789'} | ${19} | ${'0123/.../1234/6789'}
-        ${'0123/8/7/1gh1234/689'} | ${19} | ${'0123/8/7/.../689'}
-    `('trimMidPath', ({ path, width, expected }) => {
-        expect(__testing__.trimMidPath(path, width, '/')).toBe(expected);
     });
 });
 

--- a/packages/cspell/src/app/emitters/traceEmitter.ts
+++ b/packages/cspell/src/app/emitters/traceEmitter.ts
@@ -6,12 +6,7 @@ import type { TraceResult } from '../application.mjs';
 import { console } from '../console.js';
 import { TableRow, tableToLines } from '../util/table.js';
 import type { DictionaryPathFormat } from './DictionaryPathFormat.js';
-
-interface PathInterface {
-    relative(from: string, to: string): string;
-    basename(path: string): string;
-    sep: string;
-}
+import { formatDictionaryLocation, type PathInterface } from './helpers.js';
 
 export interface EmitTraceOptions {
     /** current working directory */
@@ -110,16 +105,6 @@ function emitErrors(results: TraceResult[]): string[] {
     });
 }
 
-function trimMid(s: string, w: number): string {
-    s = s.trim();
-    if (s.length <= w) {
-        return s;
-    }
-    const l = Math.floor((w - 3) / 2);
-    const r = Math.ceil((w - 3) / 2);
-    return s.slice(0, l) + '...' + s.slice(-r);
-}
-
 function calcFoundChar(r: TraceResult): string {
     const errors = r.errors?.map((e) => e.message)?.join('\n\t') || '';
 
@@ -138,78 +123,6 @@ function calcFoundChar(r: TraceResult): string {
     return color(char);
 }
 
-function formatDictionaryLocation(
-    dictSource: string,
-    maxWidth: number,
-    {
-        cwd,
-        dictionaryPathFormat: format,
-        iPath,
-    }: {
-        cwd: string;
-        dictionaryPathFormat: DictionaryPathFormat;
-        iPath: PathInterface;
-    },
-): string {
-    let relPath = cwd ? iPath.relative(cwd, dictSource) : dictSource;
-    const idxNodeModule = relPath.lastIndexOf('node_modules');
-    const isNodeModule = idxNodeModule >= 0;
-    if (format === 'hide') return '';
-    if (format === 'short') {
-        const prefix = isNodeModule
-            ? '[node_modules]/'
-            : relPath.startsWith('..' + iPath.sep + '..')
-              ? '.../'
-              : relPath.startsWith('..' + iPath.sep)
-                ? '../'
-                : '';
-        return prefix + iPath.basename(dictSource);
-    }
-    if (format === 'full') return dictSource;
-    relPath = isNodeModule ? relPath.slice(idxNodeModule) : relPath;
-    const usePath = relPath.length < dictSource.length ? relPath : dictSource;
-    return trimMidPath(usePath, maxWidth, iPath.sep);
-}
-
 function colorize(fn: (s: string) => string): (s: string) => string {
     return (s: string) => (s ? fn(s) : '');
 }
-
-function trimMidPath(s: string, w: number, sep: string): string {
-    if (s.length <= w) return s;
-    const parts = s.split(sep);
-    if (parts[parts.length - 1].length > w) return trimMid(s, w);
-
-    function join(left: number, right: number) {
-        // if (left === right) return parts.join(sep);
-        return [...parts.slice(0, left), '...', ...parts.slice(right)].join(sep);
-    }
-
-    let left = 0,
-        right = parts.length,
-        last = '';
-    for (let i = 0; i < parts.length; ++i) {
-        const incLeft = i & 1 ? 1 : 0;
-        const incRight = incLeft ? 0 : -1;
-        const next = join(left + incLeft, right + incRight);
-        if (next.length > w) break;
-        left += incLeft;
-        right += incRight;
-        last = next;
-    }
-    for (let i = left + 1; i < right; ++i) {
-        const next = join(i, right);
-        if (next.length > w) break;
-        last = next;
-    }
-    for (let i = right - 1; i > left; --i) {
-        const next = join(left, i);
-        if (next.length > w) break;
-        last = next;
-    }
-    return last || trimMid(s, w);
-}
-
-export const __testing__ = {
-    trimMidPath,
-};

--- a/packages/cspell/src/app/options.ts
+++ b/packages/cspell/src/app/options.ts
@@ -171,6 +171,28 @@ export interface SuggestionOptions extends BaseOptions {
     repl?: boolean;
 }
 
+export interface DictionariesOptions {
+    /**
+     * Path to configuration file.
+     */
+    config?: string;
+
+    /**
+     * Load the default configuration
+     * @default true
+     */
+    defaultConfiguration?: boolean;
+
+    /**
+     * Use color in the output.
+     * `true` to force color, `false` to turn off color.
+     * `undefined` to use color if the output is a TTY.
+     */
+    color?: boolean | undefined;
+
+    pathFormat?: 'hide' | 'short' | 'long' | 'full';
+}
+
 export interface LegacyOptions {
     local?: string;
 }


### PR DESCRIPTION
Add new `dictionaries` command to the cli

```
Usage: cspell dictionaries [options]

List dictionaries

Options:
  -c, --config <cspell.json>  Configuration file to use.  By default cspell
                              looks for cspell.json in the current directory.
  --path-format <format>      Configure how to display the dictionary path.
                              (choices: "hide", "short", "long", "full",
                              default: Display most of the path.)
  --color                     Force color.
  --no-color                  Turn off color.
  --no-default-configuration  Do not load the default configuration and
                              dictionaries.
  -h, --help                  display help for command
```
