### PR TITLE
fix: show simple typos reporting

### DIFF
--- a/packages/cspell/src/util/reporters.ts
+++ b/packages/cspell/src/util/reporters.ts
@@ -40,13 +40,20 @@ function filterFeatureIssues(
         return true;
     }
     // The reporter doesn't support the `unknownWords` feature. Handle the logic here.
-    let reportIssue = issue.isFlagged;
-    reportIssue ||= !reportOptions.unknownWords || reportOptions.unknownWords === unknownWordsChoices.ReportAll;
-    reportIssue ||= reportOptions.unknownWords === unknownWordsChoices.ReportSimple && issue.hasSimpleSuggestions;
-    reportIssue ||=
-        reportOptions.unknownWords === unknownWordsChoices.ReportCommonTypos && issue.hasPreferredSuggestions;
-
-    return reportIssue || false;
+    if (
+        issue.isFlagged ||
+        !reportOptions.unknownWords ||
+        reportOptions.unknownWords === unknownWordsChoices.ReportAll
+    ) {
+        return true;
+    }
+    if (issue.hasPreferredSuggestions && reportOptions.unknownWords !== unknownWordsChoices.ReportFlagged) {
+        return true;
+    }
+    if (issue.hasSimpleSuggestions && reportOptions.unknownWords === unknownWordsChoices.ReportSimple) {
+        return true;
+    }
+    return false;
 }
 
 function handleIssue(reporter: CSpellReporter, issue: Issue, reportOptions?: ReportIssueOptions | undefined): void {

--- a/packages/cspell/tools/patch-version.mjs
+++ b/packages/cspell/tools/patch-version.mjs
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 
 const urlPackageJson = new URL('../package.json', import.meta.url);
-const urlVersionFile = new URL('../src/app/pkgInfo.ts', import.meta.url);
+const urlVersionFile = new URL('../src/pkgInfo.ts', import.meta.url);
 
 async function readPackageJson() {
     const pkgJson = await fs.readFile(urlPackageJson, 'utf8');


### PR DESCRIPTION
Fix the logic to show an issue when the reporting level is set to `simple`. The code worked because of the assumption that  `hasSimpleSuggestions` would be true if `hasPreferredSuggestions` was true.