### PR TITLE
fix: Wait for the cache to save

### DIFF
--- a/packages/cspell/src/util/cache/file-entry-cache/file-entry-cache.ts
+++ b/packages/cspell/src/util/cache/file-entry-cache/file-entry-cache.ts
@@ -192,7 +192,7 @@ class ImplFileEntryCache implements FileEntryCache {
             }
         }
 
-        this.cache.save();
+        await this.cache.save();
     }
 
     resolveKeyToFile(entryKey: string): string {


### PR DESCRIPTION
This fixes a flaky cache situation caused by not waiting for the cache to save before moving on.