### PR TITLE
docs: add support for .ts and .mts config files

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -75,6 +75,10 @@ CSpell can use JSON, Yaml, and JavaScript files for configuration. It automatica
 - `cspell.config.cjs`
 - `.cspell.config.js`
 - `cspell.config.js`
+- `.cspell.config.ts`
+- `cspell.config.ts`
+- `.cspell.config.mts`
+- `cspell.config.mts`
 - `.cspell.config.toml`
 - `cspell.config.toml`
 - `.config/.cspell.json`
@@ -99,6 +103,10 @@ CSpell can use JSON, Yaml, and JavaScript files for configuration. It automatica
 - `.config/cspell.config.cjs`
 - `.config/.cspell.config.js`
 - `.config/cspell.config.js`
+- `.config/.cspell.config.ts`
+- `.config/cspell.config.ts`
+- `.config/.cspell.config.mts`
+- `.config/cspell.config.mts`
 - `config/.cspell.config.toml`
 - `config/cspell.config.toml`
 - `.vscode/.cspell.json`
@@ -143,6 +151,26 @@ For now choose to use either JSON or Yaml. Below are examples of each that inclu
     </TabItem>
     <TabItem value="esm" label="cspell.config.mjs">
         ```javascript
+        import { defineConfig } from 'cspell';
+
+        export default defineConfig({
+            version: '0.2',
+            dictionaryDefinitions: [
+                {
+                    name: 'project-words',
+                    path: './project-words.txt',
+                    addWords: true,
+                },
+            ],
+            dictionaries: ['project-words'],
+            ignorePaths: ['node_modules', '/project-words.txt'],
+        });
+        ```
+    </TabItem>
+    <TabItem value="mts" label="cspell.config.mts">
+        ```ts
+        // TypeScript version of the CSpell config.
+        // Requires Node.js >= 22.18 to run natively.
         import { defineConfig } from 'cspell';
 
         export default defineConfig({


### PR DESCRIPTION
Added documentation for using `.ts` and `.mts` CSpell config files, including examples and `Node.js` version notes.