### PR TITLE
fix: Support adding separators when tracing compound words

### DIFF
--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.test.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.test.ts
@@ -119,6 +119,31 @@ describe('Verify building Dictionary', () => {
     });
 });
 
+describe('Validate finding compound words.', () => {
+    const words = [
+        '*apple*',
+        '*apples*',
+        '*ape*',
+        '*able*',
+        '*apple*',
+        '*banana*',
+        '*orange*',
+        '*pear*',
+        '*aim*',
+        '*approach*',
+        '*bear*',
+    ];
+
+    test.each`
+        word             | expected
+        ${'applebanana'} | ${'apple|banana'}
+    `('find $word in word list', ({ word, expected }) => {
+        const dict = createSpellingDictionary(words, 'words', 'test', opts({}));
+        const r = dict.find(word, { compoundSeparator: '|' });
+        expect(r?.found).toBe(expected);
+    });
+});
+
 describe('Validate wordSearchForms', () => {
     test.each`
         word                        | isCaseSensitive | ignoreCase | expected

--- a/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SpellingDictionary.ts
@@ -20,7 +20,13 @@ export interface SearchOptions {
 
 export type SearchOptionsRO = Readonly<SearchOptions>;
 
-export type FindOptions = SearchOptions;
+export interface FindOptions extends SearchOptions {
+    /**
+     * Separate compound words using the specified separator.
+     */
+    compoundSeparator?: string | undefined;
+}
+
 export type FindOptionsRO = Readonly<FindOptions>;
 
 export interface Suggestion {
@@ -112,7 +118,7 @@ export interface SpellingDictionary extends DictionaryInfo {
     readonly containsNoSuggestWords: boolean;
     has(word: string, options?: HasOptionsRO): boolean;
     /** A more detailed search for a word, might take longer than `has` */
-    find(word: string, options?: SearchOptionsRO): FindResult | undefined;
+    find(word: string, options?: FindOptionsRO): FindResult | undefined;
     /**
      * Checks if a word is forbidden.
      * @param word - word to check.

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -2679,7 +2679,13 @@ interface SearchOptions {
    */
   ignoreCase?: boolean | undefined;
 }
-type SearchOptionsRO = Readonly<SearchOptions>;
+interface FindOptions extends SearchOptions {
+  /**
+   * Separate compound words using the specified separator.
+   */
+  compoundSeparator?: string | undefined;
+}
+type FindOptionsRO = Readonly<FindOptions>;
 interface Suggestion {
   word: string;
   isPreferred?: boolean | undefined;
@@ -2753,7 +2759,7 @@ interface SpellingDictionary extends DictionaryInfo {
   readonly containsNoSuggestWords: boolean;
   has(word: string, options?: HasOptionsRO): boolean;
   /** A more detailed search for a word, might take longer than `has` */
-  find(word: string, options?: SearchOptionsRO): FindResult | undefined;
+  find(word: string, options?: FindOptionsRO): FindResult | undefined;
   /**
    * Checks if a word is forbidden.
    * @param word - word to check.
@@ -3719,6 +3725,7 @@ interface TraceOptions {
   locale?: LocaleId;
   ignoreCase?: boolean;
   allowCompoundWords?: boolean;
+  compoundSeparator?: string | undefined;
 }
 interface TraceWordResult extends Array<TraceResult> {
   splits: readonly WordSplits[];

--- a/packages/cspell-lib/src/lib/textValidation/traceWord.test.ts
+++ b/packages/cspell-lib/src/lib/textValidation/traceWord.test.ts
@@ -4,7 +4,6 @@ import { pathPackageFixturesURL } from '../../test-util/test.locations.js';
 import type { TextDocumentRef } from '../Models/TextDocument.js';
 import { searchForConfig } from '../Settings/index.js';
 import { getDictionaryInternal } from '../SpellingDictionary/index.js';
-import { toUri } from '../util/Uri.js';
 import { determineTextDocumentSettings } from './determineTextDocumentSettings.js';
 import type { WordSplits } from './traceWord.js';
 import { traceWord } from './traceWord.js';
@@ -17,7 +16,7 @@ const ac = (...params: Parameters<typeof expect.arrayContaining>) => expect.arra
 const oc = (...params: Parameters<typeof expect.objectContaining>) => expect.objectContaining(...params);
 
 describe('traceWord', async () => {
-    const doc: TextDocumentRef = { uri: toUri(import.meta.url), languageId: 'typescript' };
+    const doc: TextDocumentRef = { uri: import.meta.url, languageId: 'typescript' };
     const fixtureSettings = (await searchForConfig(urlReadme)) || {};
     const baseSettings = await determineTextDocumentSettings(doc, fixtureSettings);
     const dicts = await getDictionaryInternal(baseSettings);
@@ -58,6 +57,65 @@ describe('traceWord', async () => {
         ${'word_word'}    | ${{ ...wft('word'), dictName: 'en_us' }}
         ${'ISpellResult'} | ${{ ...wft('Result'), foundWord: 'result', dictName: 'en_us' }}
         ${'ERRORcode'}    | ${{ ...wft('ERRORcode'), foundWord: 'errorcode', dictName: 'node' }}
+        ${'ERRORcode'}    | ${{ ...wft('ERROR'), foundWord: 'error', dictName: 'en_us' }}
+        ${'apple-pie'}    | ${{ ...wft('pie'), dictName: 'en_us' }}
+        ${"can't"}        | ${{ ...wft("can't"), dictName: 'en_us' }}
+        ${'canNOT'}       | ${{ ...wft('canNOT'), foundWord: 'cannot', dictName: 'en_us' }}
+        ${'baz'}          | ${{ ...wft('baz'), foundWord: 'baz', dictName: '[words]', dictSource: expectedConfigURL.href }}
+    `('traceWord check found $word', ({ word, expected }) => {
+        const r = traceWord(word, dicts, baseSettings);
+        const matching = r.filter((r) => r.word === expected.word && r.found === expected.found);
+        expect(matching).toEqual(ac([oc(expected)]));
+    });
+});
+
+describe('traceWord CPP file', async () => {
+    const doc: TextDocumentRef = {
+        uri: new URL('code.cpp', import.meta.url),
+        languageId: 'cpp',
+        text: '/* This is a CPP file. */',
+    };
+    const fixtureSettings = (await searchForConfig(urlReadme)) || {};
+    const baseSettings = await determineTextDocumentSettings(doc, fixtureSettings);
+    const dicts = await getDictionaryInternal(baseSettings);
+
+    test('traceWord', () => {
+        const r = traceWord('trace', dicts, baseSettings);
+        expect(r.filter((r) => r.found)).toEqual(
+            ac([
+                {
+                    word: 'trace',
+                    found: true,
+                    foundWord: 'trace',
+                    forbidden: false,
+                    noSuggest: false,
+                    dictName: 'en_us',
+                    dictSource: expect.any(String),
+                    configSource: undefined,
+                    errors: undefined,
+                },
+            ]),
+        );
+    });
+
+    test.each`
+        word              | expected
+        ${'word'}         | ${[wft('word')]}
+        ${'word_word'}    | ${[wff('word_word'), wft('word'), wft('word')]}
+        ${'word_nword'}   | ${[wff('word_nword'), wft('word'), wft('nword')] /* cspell:ignore nword */}
+        ${'ISpellResult'} | ${[wff('ISpellResult'), wft('I'), wft('Spell'), wft('Result')]}
+        ${'ERRORcode'}    | ${[wft('ERRORcode'), wft('ERROR'), wft('code')]}
+    `('traceWord splits $word', ({ word, expected }) => {
+        const r = traceWord(word, dicts, baseSettings);
+        expect(r.splits).toEqual(expected);
+    });
+
+    test.each`
+        word              | expected
+        ${'word_word'}    | ${{ ...wft('word'), dictName: 'en_us' }}
+        ${'ISpellResult'} | ${{ ...wft('Result'), foundWord: 'result', dictName: 'en_us' }}
+        ${'errorcode'}    | ${{ ...wft('errorcode'), foundWord: 'error•code', dictName: 'cpp' }}
+        ${'ERRORcode'}    | ${{ ...wft('ERRORcode'), foundWord: 'error•code', dictName: 'cpp' }}
         ${'ERRORcode'}    | ${{ ...wft('ERROR'), foundWord: 'error', dictName: 'en_us' }}
         ${'apple-pie'}    | ${{ ...wft('pie'), dictName: 'en_us' }}
         ${"can't"}        | ${{ ...wft("can't"), dictName: 'en_us' }}

--- a/packages/cspell-lib/src/lib/textValidation/traceWord.ts
+++ b/packages/cspell-lib/src/lib/textValidation/traceWord.ts
@@ -2,6 +2,7 @@ import type { CSpellSettingsWithSourceTrace } from '@cspell/cspell-types';
 
 import { getSources } from '../Settings/index.js';
 import type {
+    FindOptions,
     FindResult,
     HasOptions,
     SpellingDictionary,
@@ -52,6 +53,7 @@ export interface TraceResult extends Array<DictionaryTraceResult> {
 
 export interface TraceOptions extends Pick<CSpellSettingsWithSourceTrace, 'source' | 'allowCompoundWords'> {
     ignoreCase?: boolean;
+    compoundSeparator?: string | undefined;
 }
 
 export function traceWord(
@@ -59,9 +61,10 @@ export function traceWord(
     dictCollection: SpellingDictionaryCollection,
     config: TraceOptions,
 ): TraceResult {
-    const opts: HasOptions = {
+    const opts: FindOptions = {
         ignoreCase: config.ignoreCase ?? true,
         useCompounds: config.allowCompoundWords || false,
+        compoundSeparator: '•',
     };
 
     const splits = split({ text: word, offset: 0 }, 0, checkWord);

--- a/packages/cspell-lib/src/lib/trace.test.ts
+++ b/packages/cspell-lib/src/lib/trace.test.ts
@@ -43,8 +43,8 @@ describe('Verify trace', () => {
         ${'café'}      | ${undefined} | ${undefined} | ${true}    | ${undefined}       | ${'en_us'}         | ${true}    | ${true}  | ${false}  | ${false}  | ${'café'}
         ${'errorcode'} | ${undefined} | ${undefined} | ${true}    | ${undefined}       | ${'en_us'}         | ${true}    | ${false} | ${false}  | ${false}  | ${undefined}
         ${'errorcode'} | ${undefined} | ${undefined} | ${true}    | ${true}            | ${'en_us'}         | ${true}    | ${true}  | ${false}  | ${false}  | ${'error+code'}
-        ${'errorcode'} | ${'cpp'}     | ${undefined} | ${true}    | ${true}            | ${'cpp'}           | ${true}    | ${true}  | ${false}  | ${false}  | ${'errorcode'}
-        ${'errorcode'} | ${'cpp'}     | ${undefined} | ${true}    | ${undefined}       | ${'cpp'}           | ${true}    | ${true}  | ${false}  | ${false}  | ${'errorcode'}
+        ${'errorcode'} | ${'cpp'}     | ${undefined} | ${true}    | ${true}            | ${'cpp'}           | ${true}    | ${true}  | ${false}  | ${false}  | ${'error•code'}
+        ${'errorcode'} | ${'cpp'}     | ${undefined} | ${true}    | ${undefined}       | ${'cpp'}           | ${true}    | ${true}  | ${false}  | ${false}  | ${'error•code'}
         ${'hte'}       | ${undefined} | ${undefined} | ${true}    | ${undefined}       | ${'en_us'}         | ${true}    | ${false} | ${false}  | ${false}  | ${undefined}
         ${'hte'}       | ${undefined} | ${undefined} | ${true}    | ${undefined}       | ${'[flagWords]'}   | ${true}    | ${true}  | ${true}   | ${false}  | ${'hte'}
         ${'Colour'}    | ${undefined} | ${undefined} | ${true}    | ${undefined}       | ${'[ignoreWords]'} | ${true}    | ${true}  | ${false}  | ${true}   | ${'colour'}

--- a/packages/cspell-lib/src/lib/trace.ts
+++ b/packages/cspell-lib/src/lib/trace.ts
@@ -24,6 +24,7 @@ export interface TraceOptions {
     locale?: LocaleId;
     ignoreCase?: boolean;
     allowCompoundWords?: boolean;
+    compoundSeparator?: string | undefined;
 }
 
 export interface TraceWordResult extends Array<TraceResult> {
@@ -49,7 +50,7 @@ export async function* traceWordsAsync(
     settingsOrConfig: CSpellSettings | ICSpellConfigFile,
     options: TraceOptions | undefined,
 ): AsyncIterableIterator<TraceWordResult> {
-    const { languageId, locale: language, ignoreCase = true, allowCompoundWords } = options || {};
+    const { languageId, locale: language, ignoreCase = true, allowCompoundWords, compoundSeparator } = options || {};
 
     const settings = satisfiesCSpellConfigFile(settingsOrConfig)
         ? await resolveConfigFileImports(settingsOrConfig)
@@ -92,7 +93,7 @@ export async function* traceWordsAsync(
     const setOfActiveDicts = new Set(activeDictionaries);
 
     function processWord(word: string): TraceWordResult {
-        const results = traceWord(word, dicts, { ...config, ignoreCase });
+        const results = traceWord(word, dicts, { ...config, ignoreCase, compoundSeparator });
 
         const r = results.map((r) => ({
             ...r,

--- a/packages/cspell-tools/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell-tools/src/__snapshots__/app.test.ts.snap
@@ -36,12 +36,7 @@ exports[`Validate the application > app -V 1`] = `
 }
 `;
 
-exports[`Validate the application > app -V 2`] = `
-"9.4.0
-"
-`;
-
-exports[`Validate the application > app -V 3`] = `""`;
+exports[`Validate the application > app -V 2`] = `""`;
 
 exports[`Validate the application > app compile compound 1`] = `
 "

--- a/packages/cspell-tools/src/app.test.ts
+++ b/packages/cspell-tools/src/app.test.ts
@@ -235,7 +235,9 @@ describe('Validate the application', () => {
         await expect(app.run(commander, argv('-V'))).rejects.toThrow(Commander.CommanderError);
         expect(mock.mock.calls.length).toBe(1);
         expect(consoleSpy.consoleOutput()).toMatchSnapshot();
-        expect(std.stdout).toMatchSnapshot();
+        const versionTest = /^\d+\.\d+\.\d+.*/;
+        const version = std.stdout.trim();
+        expect(versionTest.test(version)).toBe(true);
         expect(std.stderr).toMatchSnapshot();
     });
 

--- a/packages/cspell-trie-lib/api/api.d.ts
+++ b/packages/cspell-trie-lib/api/api.d.ts
@@ -453,7 +453,7 @@ interface ITrie {
   * @returns true if the word was found and is not forbidden.
   */
   hasWord(word: string, caseSensitive: boolean): boolean;
-  findWord(word: string, options?: FindWordOptions): FindFullResult$1;
+  findWord(word: string, options?: FindWordOptionsRO): FindFullResult$1;
   /**
   * Determine if a word is in the forbidden word list.
   * @param word the word to lookup.
@@ -504,6 +504,10 @@ interface FindWordOptions {
   caseSensitive?: boolean;
   useLegacyWordCompounds?: boolean | number;
   checkForbidden?: boolean;
+  /**
+  * Separate compound words with the given string.
+  */
+  compoundSeparator?: string;
 }
 type FindWordOptionsRO = Readonly<FindWordOptions>;
 //#endregion

--- a/packages/cspell-trie-lib/package.json
+++ b/packages/cspell-trie-lib/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "clean": "shx rm -rf dist temp coverage \"*.tsbuildInfo\"",
-    "build": "pnpm run build:lib && pnpm run build:api",
+    "build": "pnpm run build:lib && pnpm run build:api && pnpm run check:types",
     "build:lib": "tsdown",
     "build:api": "shx cp dist/index.d.ts api/api.d.ts",
     "clean-build": "pnpm run clean && pnpm run build",
@@ -41,6 +41,7 @@
     "perf": "pnpm test:perf",
     "test": "vitest run",
     "test:update-snapshot": "vitest run -u",
+    "check:types": "tsc -p .",
     "watch": "tsc -p . -w"
   },
   "repository": {

--- a/packages/cspell-trie-lib/src/lib/ITrie.test.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrie.test.ts
@@ -168,6 +168,38 @@ describe('Validate Trie Class', () => {
         expect(trie.hasWord(word, caseSensitive)).toBe(found);
     });
 
+    test.each`
+        word                      | caseSensitive | found                        | forbidden    | compoundUsed | comment
+        ${'café'}                 | ${true}       | ${'café'}                    | ${undefined} | ${false}     | ${''}
+        ${'Café'}                 | ${true}       | ${false}                     | ${undefined} | ${false}     | ${''}
+        ${'café'}                 | ${false}      | ${'café'}                    | ${undefined} | ${false}     | ${''}
+        ${'Café'}                 | ${false}      | ${false}                     | ${undefined} | ${false}     | ${''}
+        ${'BeginMiddleEnd'}       | ${true}       | ${'Begin|Middle|End'}        | ${false}     | ${true}      | ${''}
+        ${'BeginMiddleMiddleEnd'} | ${true}       | ${'Begin|Middle|Middle|End'} | ${false}     | ${true}      | ${''}
+        ${'BeginEnd'}             | ${true}       | ${'Begin|End'}               | ${false}     | ${true}      | ${''}
+        ${'MiddleEnd'}            | ${true}       | ${false}                     | ${undefined} | ${false}     | ${''}
+        ${'beginend'}             | ${false}      | ${'begin|end'}               | ${false}     | ${true}      | ${'cspell:disable-line'}
+        ${'playtime'}             | ${true}       | ${'play|time'}               | ${true}      | ${true}      | ${''}
+        ${'playtime'}             | ${false}      | ${'play|time'}               | ${true}      | ${true}      | ${''}
+        ${'playmiddletime'}       | ${false}      | ${'play|middle|time'}        | ${false}     | ${true}      | ${'cspell:disable-line'}
+    `('hasWord $word $caseSensitive $found', ({ word, caseSensitive, found, forbidden, compoundUsed }) => {
+        const trie = parseDictionaryLegacy(`
+        # Sample Word List
+        Begin*
+        *End
+        +Middle+
+        café
+        play*
+        *time
+        !playtime
+        `);
+
+        const r = trie.findWord(word, { caseSensitive, compoundSeparator: '|' });
+        expect(r.found).toBe(found);
+        expect(r.forbidden).toBe(forbidden);
+        expect(r.compoundUsed).toBe(compoundUsed);
+    });
+
     // cspell:ignore begintime
     test('hasWord', () => {
         const trie = parseDictionaryLegacy(`

--- a/packages/cspell-trie-lib/src/lib/ITrie.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrie.ts
@@ -59,7 +59,7 @@ export interface ITrie {
      */
     hasWord(word: string, caseSensitive: boolean): boolean;
 
-    findWord(word: string, options?: FindWordOptions): FindFullResult;
+    findWord(word: string, options?: FindWordOptionsRO): FindFullResult;
 
     /**
      * Determine if a word is in the forbidden word list.
@@ -189,7 +189,7 @@ export class ITrieImpl implements ITrie {
         return !!f.found;
     }
 
-    findWord(word: string, options?: FindWordOptions): FindFullResult {
+    findWord(word: string, options?: FindWordOptionsRO): FindFullResult {
         if (options?.useLegacyWordCompounds) {
             const len =
                 options.useLegacyWordCompounds !== true
@@ -198,12 +198,14 @@ export class ITrieImpl implements ITrie {
             const findOptions = this.createFindOptions({
                 legacyMinCompoundLength: len,
                 matchCase: options.caseSensitive || false,
+                compoundSeparator: options.compoundSeparator,
             });
             return findLegacyCompound(this.root, word, findOptions);
         }
         return findWord(this.root, word, {
             matchCase: options?.caseSensitive,
             checkForbidden: options?.checkForbidden,
+            compoundSeparator: options?.compoundSeparator,
         });
     }
 
@@ -303,6 +305,10 @@ export interface FindWordOptions {
     caseSensitive?: boolean;
     useLegacyWordCompounds?: boolean | number;
     checkForbidden?: boolean;
+    /**
+     * Separate compound words with the given string.
+     */
+    compoundSeparator?: string;
 }
 
 export type FindWordOptionsRO = Readonly<FindWordOptions>;

--- a/packages/cspell-trie-lib/src/lib/ITrieNode/FindOptions.ts
+++ b/packages/cspell-trie-lib/src/lib/ITrieNode/FindOptions.ts
@@ -6,6 +6,7 @@ export interface FindOptions {
     compoundMode: CompoundModes;
     legacyMinCompoundLength?: number | undefined;
     checkForbidden?: boolean | undefined;
+    compoundSeparator?: string | undefined;
 }
 
 export type PartialFindOptions = PartialWithUndefined<FindOptions> | undefined;

--- a/packages/cspell-trie-lib/src/lib/TrieNode/find.dutch.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/find.dutch.test.ts
@@ -128,6 +128,26 @@ describe('Validate findWord', () => {
         });
         expect(r).toEqual(expected);
     });
+
+    test.each`
+        word                 | matchCase | expected
+        ${''}                | ${false}  | ${fr({})}
+        ${'nieuwjaarsnacht'} | ${true}   | ${fr({ caseMatched: true, compoundUsed: true, found: 'nieuwjaars.nacht', forbidden: false })}
+        ${'burgersmeester'}  | ${false}  | ${fr({ caseMatched: true, compoundUsed: true, found: 'burgers.meester', forbidden: false })}
+        ${'burgersmeester'}  | ${true}   | ${fr({ caseMatched: true, compoundUsed: true, found: 'burgers.meester', forbidden: false })}
+        ${'buurtsbewoners'}  | ${true}   | ${fr({ caseMatched: true, compoundUsed: true, found: false })}
+    `(
+        `Check misspelled words case insensitive: "$word" $matchCase compoundSeparator`,
+        async ({ word, matchCase, expected }) => {
+            const trie = await pTrie;
+            const r = findWord(trie, word, {
+                matchCase,
+                compoundMode: 'compound',
+                compoundSeparator: '.',
+            });
+            expect(r).toEqual(expected);
+        },
+    );
     // cspell:enable
 });
 

--- a/packages/cspell-trie-lib/src/lib/TrieNode/find.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/find.test.ts
@@ -7,6 +7,10 @@ import { __testing__, createFindOptions, findLegacyCompound, findWord } from './
 
 const findLegacyCompoundWord = __testing__.findLegacyCompoundWord;
 
+function oc(obj: unknown) {
+    return expect.objectContaining(obj);
+}
+
 describe('Validate findWord', () => {
     const trie = dictionary().root;
 
@@ -77,6 +81,11 @@ describe('Validate findWord', () => {
             frCompoundFound('codeErrors', { forbidden: false }),
         ],
         [
+            'codeErrors',
+            { matchCase: true, compoundMode: 'compound', compoundSeparator: '|' },
+            frCompoundFound('code|Errors', { forbidden: false }),
+        ],
+        [
             'codeCodeCodeCodeError',
             { matchCase: true, compoundMode: 'compound' },
             frCompoundFound('codeCodeCodeCodeError', { forbidden: false }),
@@ -105,50 +114,51 @@ describe('Validate Legacy Compound lookup', () => {
     // cspell:ignore walkin walkjay walkedge
     test.each`
         word             | compoundLen | expected
-        ${'talkinglift'} | ${true}     | ${true}
-        ${'joywalk'}     | ${true}     | ${true}
-        ${'jaywalk'}     | ${true}     | ${true}
+        ${'talkinglift'} | ${true}     | ${'talking+lift'}
+        ${'joywalk'}     | ${true}     | ${'joy+walk'}
+        ${'jaywalk'}     | ${true}     | ${'jay+walk'}
         ${'jwalk'}       | ${true}     | ${false}
         ${'awalk'}       | ${true}     | ${false}
-        ${'jayjay'}      | ${true}     | ${true}
+        ${'jayjay'}      | ${true}     | ${'jay+jay'}
         ${'jayjay'}      | ${4}        | ${false}
         ${'jayi'}        | ${3}        | ${false}
         ${'toto'}        | ${true}     | ${false}
-        ${'toto'}        | ${2}        | ${true}
-        ${'toto'}        | ${1}        | ${true}
-        ${'iif'}         | ${1}        | ${true}
+        ${'toto'}        | ${2}        | ${'to+to'}
+        ${'toto'}        | ${1}        | ${'to+to'}
+        ${'iif'}         | ${1}        | ${'iif'}
         ${'uplift'}      | ${true}     | ${false}
-        ${'endless'}     | ${true}     | ${true}
+        ${'endless'}     | ${true}     | ${'end+less'}
         ${'joywalk'}     | ${999}      | ${false}
-        ${'walked'}      | ${true}     | ${true}
+        ${'walked'}      | ${true}     | ${'walked'}
         ${'walkin'}      | ${true}     | ${false}
         ${'walkup'}      | ${true}     | ${false}
-        ${'walkjay'}     | ${true}     | ${true}
+        ${'walkjay'}     | ${true}     | ${'walk+jay'}
         ${'walkjay'}     | ${4}        | ${false}
-        ${'walkedge'}    | ${4}        | ${true}
+        ${'walkedge'}    | ${4}        | ${'walk+edge'}
     `('compound words no case "$word" compoundLen: $compoundLen', ({ word, compoundLen, expected }) => {
         const trie = Trie.create(sampleWords);
-        function has(word: string, compoundLen: true | number): boolean {
+        function find(word: string, compoundLen: true | number) {
             const len = compoundLen === true ? 3 : compoundLen;
-            return !!findLegacyCompoundWord([trie.root], word, len).found;
+            return findLegacyCompoundWord([trie.root], word, len, undefined).found;
         }
-        expect(has(word, compoundLen)).toBe(expected);
+        expect(find(word, compoundLen)).toBe(expected);
     });
 
     // cspell:ignore cafecode codecafe
     test.each`
-        word            | compoundLen | expected
-        ${'codecafe'}   | ${true}     | ${true}
-        ${'codeerrors'} | ${true}     | ${true}
-        ${'cafecode'}   | ${true}     | ${true}
-    `('compound words "$word" compoundLen: $compoundLen', ({ word, compoundLen, expected }) => {
+        word            | compoundLen | compoundSeparator | expected
+        ${'codecafe'}   | ${true}     | ${undefined}      | ${'code+cafe'}
+        ${'codeerrors'} | ${true}     | ${undefined}      | ${'code+errors'}
+        ${'cafecode'}   | ${true}     | ${undefined}      | ${'cafe+code'}
+        ${'cafecode'}   | ${true}     | ${'|'}            | ${'cafe|code'}
+    `('compound words "$word" compoundLen: $compoundLen', ({ word, compoundLen, compoundSeparator, expected }) => {
         const trie = dictionary();
-        function has(word: string, minLegacyCompoundLength: true | number): boolean {
+        function find(word: string, minLegacyCompoundLength: true | number) {
             const len = minLegacyCompoundLength !== true ? minLegacyCompoundLength : 3;
-            const findOptions = createFindOptions({ legacyMinCompoundLength: len });
-            return !!findLegacyCompound(trie.root, word, findOptions).found;
+            const findOptions = createFindOptions({ legacyMinCompoundLength: len, compoundSeparator });
+            return findLegacyCompound(trie.root, word, findOptions).found;
         }
-        expect(has(word, compoundLen)).toBe(expected);
+        expect(find(word, compoundLen)).toBe(expected);
     });
 });
 
@@ -291,7 +301,3 @@ const sampleWords = [
     'joyrode',
     'joystick',
 ];
-
-function oc<T>(t: Partial<T>): T {
-    return expect.objectContaining(t);
-}

--- a/packages/cspell-trie-lib/src/lib/TrieNode/trie-util.test.ts
+++ b/packages/cspell-trie-lib/src/lib/TrieNode/trie-util.test.ts
@@ -13,7 +13,7 @@ import {
     validateTrie,
 } from './trie-util.js';
 
-const oc = <T>(obj: T) => expect.objectContaining(obj);
+const oc = (obj: unknown) => expect.objectContaining(obj);
 
 describe('Validate Util Functions', () => {
     test('createTriFromList', () => {

--- a/packages/cspell-trie-lib/src/lib/distance/weightedMaps.test.ts
+++ b/packages/cspell-trie-lib/src/lib/distance/weightedMaps.test.ts
@@ -15,7 +15,7 @@ import {
 
 const { splitMapSubstrings, splitMap, findTrieCostPrefixes, normalizeDef } = __testing__;
 
-const oc = <T>(obj: T) => expect.objectContaining(obj);
+const oc = (obj: unknown) => expect.objectContaining(obj);
 
 // const u = undefined;  cspell:
 

--- a/packages/cspell-trie-lib/src/lib/suggestions/suggest-en.test.ts
+++ b/packages/cspell-trie-lib/src/lib/suggestions/suggest-en.test.ts
@@ -25,7 +25,7 @@ interface ExpectedSuggestion extends Partial<SuggestionResult> {
     word: string;
 }
 
-const ac = <T>(a: Array<T>) => expect.arrayContaining(a);
+const ac = (a: Array<unknown>) => expect.arrayContaining(a);
 
 const pAffContent = readRawDictionaryFile('hunspell/en_US.aff');
 

--- a/packages/cspell-trie-lib/src/lib/suggestions/suggest-nl.test.ts
+++ b/packages/cspell-trie-lib/src/lib/suggestions/suggest-nl.test.ts
@@ -25,7 +25,7 @@ const pReady = Promise.all([pTrieNL, pAffContent.then((aff) => (affContent = aff
     return undefined;
 });
 
-const ac = <T>(a: Array<T>) => expect.arrayContaining(a);
+const ac = (a: Array<unknown>) => expect.arrayContaining(a);
 
 describe('Validate Dutch Suggestions', () => {
     // cspell:ignore buurtbewoners

--- a/packages/cspell-trie-lib/src/lib/trie.ts
+++ b/packages/cspell-trie-lib/src/lib/trie.ts
@@ -111,8 +111,19 @@ export class Trie {
             const findOptions = this.createFindOptions({
                 legacyMinCompoundLength: len,
                 matchCase: options.caseSensitive,
+                compoundSeparator: options.compoundSeparator,
             });
             return findLegacyCompound(this.root, word, findOptions);
+        }
+        if (options?.compoundSeparator) {
+            return findWord(
+                this.root,
+                word,
+                this.createFindOptions({
+                    matchCase: options.caseSensitive,
+                    compoundSeparator: options.compoundSeparator,
+                }),
+            );
         }
         const findOptions = this.createFindOptionsMatchCase(options?.caseSensitive);
         return findWord(this.root, word, findOptions);

--- a/packages/cspell-trie-lib/src/lib/types.ts
+++ b/packages/cspell-trie-lib/src/lib/types.ts
@@ -88,6 +88,8 @@ export type UndefinedToOptional<T> = RemoveUndefined<MakeOptional<T>>;
 
 export type ArrayItem<T extends Array<unknown>> = T extends Array<infer R> ? R : never;
 
+export type RO<T> = Readonly<T>;
+
 // export type UndefinedToOptional<T> =
 
 /*

--- a/packages/cspell-trie-lib/src/lib/utils/memorizeLastCall.ts
+++ b/packages/cspell-trie-lib/src/lib/utils/memorizeLastCall.ts
@@ -4,7 +4,7 @@ export function memorizeLastCall<P, R>(fn: (p: P) => R): (p: P) => R {
     let lastP: P | undefined = undefined;
     let lastR: R | typeof SymEmpty = SymEmpty;
     function calc(p: P): R {
-        if (lastR !== SymEmpty && lastP === p) return lastR;
+        if (lastP === p && lastR !== SymEmpty) return lastR;
         lastP = p;
         lastR = fn(p);
         return lastR;

--- a/packages/cspell-trie-lib/tsdown.config.ts
+++ b/packages/cspell-trie-lib/tsdown.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'tsdown';
+import { defineConfig, type UserConfig } from 'tsdown';
 
-export default defineConfig({
+const config: UserConfig = defineConfig({
     entry: ['src/index.ts'],
     outDir: 'dist',
     format: ['esm'],
@@ -9,3 +9,5 @@ export default defineConfig({
     sourcemap: true,
     clean: true,
 });
+
+export default config;

--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -5013,8 +5013,8 @@ hello - workspace*           ../../cspell-dict.txt
 exports[`Validate cli > app trace 'trace registered' run with 'trace typescriptconfig --config fixtures/features/ts-config/cspell.config.ts …' 1`] = `[]`;
 
 exports[`Validate cli > app trace 'trace registered' run with 'trace typescriptconfig --config fixtures/features/ts-config/cspell.config.ts …' 2`] = `
-"Word             F Dictionary Dictionary Location
-typescriptconfig * [words]*   fixtures/features/ts-config/cspell.config.ts
-typescriptconfig * cpp        node_modules/@cspell/dict-cpp/dict/cpp.txt.gz
+"Word               F Dictionary Dictionary Location
+typescriptconfig   * [words]*   fixtures/features/ts-config/cspell.config.ts
+type•script•config * cpp        node_modules/@cspell/dict-cpp/dict/cpp.txt.gz
 "
 `;


### PR DESCRIPTION
## Pull request overview

This pull request adds support for compound word separation when tracing words in cspell. When a compound word is found, it can now be displayed with a custom separator (e.g., "type•script•config" instead of "typescriptconfig").

**Changes:**
- Added `compoundSeparator` option to trace and find APIs across multiple layers
- Updated compound word finding logic to return words with separators inserted between compound parts
- Added comprehensive test coverage for the new functionality
- Minor code quality improvements (type parameter cleanup, version test improvement, build configuration)