### PR TITLE
fix: Add protobuf file extensions to definitions

### DIFF
--- a/packages/cspell-filetypes/src/definitions.ts
+++ b/packages/cspell-filetypes/src/definitions.ts
@@ -183,7 +183,7 @@ export const definitions: FileTypeDefinitions = [
         extensions: ['.cfg', '.conf', '.directory', '.editorconfig', '.gitattributes', '.gitconfig', '.gitmodules', '.npmrc', '.properties', '.repo'],
         filenames: ['.env', 'gitconfig'],
     },
-    { id: 'protobuf', extensions: ['.proto', 'txtpb', '.textproto', '.textpb', '.pbtxt'] },
+    { id: 'protobuf', extensions: ['.proto', '.txtpb', '.textproto', '.textpb', '.pbtxt'] },
     { id: 'puppet', extensions: ['.puppet'] },
     { id: 'purescript', extensions: ['.purs'] },
     { id: 'python', extensions: ['.cpy', '.gyp', '.gypi', '.ipy', '.py', '.pyi', '.pyt', '.pyw', '.rpy'], filenames: ['SConscript', 'SConstruct'] },


### PR DESCRIPTION
Closes #8200 

Add support for protobuf files. Both schema and text formats are included. 

Extensions have followed https://protobuf.dev/reference/protobuf/textformat-spec/