### PR TITLE
fix: Add support for codeowners file type #8203

### DIFF
--- a/packages/cspell-filetypes/src/definitions.ts
+++ b/packages/cspell-filetypes/src/definitions.ts
@@ -13,7 +13,7 @@ export const definitions: FileTypeDefinitions = [
     { id: 'cache_files', extensions: [], filenames: ['.DS_Store', '.cspellcache', '.eslintcache'] },
     { id: 'clojure', extensions: ['.clj', '.cljc', '.cljs', '.cljx', '.clojure', '.edn'] },
     { id: 'cmake', extensions: ['.cmake'], filenames: ['CMakeLists.txt'] },
-    { id: 'codeowners', filenames: ['codeowners'] },
+    { id: 'codeowners', extensions: [], filenames: ['codeowners'] },
     { id: 'coffeescript', extensions: ['.coffee', '.cson', '.iced'] },
     {
         id: 'cpp',


### PR DESCRIPTION
Closes #8203 

This adds support for identifying codeowners files which are used by github/gitlab.