### PR TITLE
fix: Fix CStyleHexValue to handle BigInt values.

### DIFF
--- a/packages/cspell-lib/src/lib/Settings/RegExpPatterns.ts
+++ b/packages/cspell-lib/src/lib/Settings/RegExpPatterns.ts
@@ -6,7 +6,7 @@ export const regExMatchCommonHexFormats: RegExp =
     /(?:#[0-9a-f]{3,8})|(?:0x[0-9a-f]+)|(?:\\u[0-9a-f]{4})|(?:\\x\{[0-9a-f]{4}\})/gi;
 export const regExCommitHash: RegExp = /\b(?![a-f]+\b)(?:0x)?[0-9a-f]{7,}\b/gi; // Match Commit Hashes that contain at least one digit.
 export const regExCommitHashLink: RegExp = /\[[0-9a-f]{7,}\]/gi; // Match Commit Hash Markdown link: [abcdef0].
-export const regExCStyleHexValue: RegExp = /\b0x[0-9a-f_]+\b/gi;
+export const regExCStyleHexValue: RegExp = /\b0x[0-9a-f_]+n?\b/gi;
 export const regExCSSHexValue: RegExp = /#[0-9a-f]{3,8}\b/gi;
 export const regExUUID: RegExp = /\b[0-9a-fx]{8}-[0-9a-fx]{4}-[0-9a-fx]{4}-[0-9a-fx]{4}-[0-9a-fx]{12}\b/gi; // x - represents placeholder values
 export const regExUnicodeRef: RegExp = /\bU\+[0-9a-f]{4,5}(?:-[0-9a-f]{4,5})?/gi;


### PR DESCRIPTION
Example: `0xffff_ffff_ffffn`