### PR TITLE
fix: Add `btrie` path to dictionary definition

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -200,9 +200,9 @@
       "type": "object"
     },
     "CustomDictionaryPath": {
-      "$ref": "#/definitions/FsDictionaryPath",
-      "description": "A File System Path to a dictionary file.",
-      "markdownDescription": "A File System Path to a dictionary file."
+      "description": "A path or url to a custom dictionary file.",
+      "markdownDescription": "A path or url to a custom dictionary file.",
+      "type": "string"
     },
     "CustomDictionaryScope": {
       "description": "Specifies the scope of a dictionary.",
@@ -239,7 +239,7 @@
     "DictionaryDefinitionAlternate": {
       "additionalProperties": false,
       "deprecated": true,
-      "deprecationMessage": "Use {@link DictionaryDefinitionPreferred } instead.",
+      "deprecationMessage": "Use {@link DictionaryDefinitionPreferred } instead.\nThis will be removed in a future release.",
       "description": "Only for legacy dictionary definitions.",
       "markdownDescription": "Only for legacy dictionary definitions.",
       "properties": {
@@ -304,6 +304,12 @@
       "description": "Used to provide extra data related to the dictionary",
       "markdownDescription": "Used to provide extra data related to the dictionary",
       "properties": {
+        "btrie": {
+          "$ref": "#/definitions/DictionaryPathToBTrie",
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0"
+        },
         "description": {
           "description": "Optional description of the contents / purpose of the dictionary.",
           "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
@@ -329,8 +335,8 @@
         },
         "path": {
           "$ref": "#/definitions/DictionaryPath",
-          "description": "Path to the file.",
-          "markdownDescription": "Path to the file."
+          "description": "Path or url to the dictionary file.",
+          "markdownDescription": "Path or url to the dictionary file."
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -371,6 +377,12 @@
           "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
           "type": "boolean"
         },
+        "btrie": {
+          "$ref": "#/definitions/DictionaryPathToBTrie",
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0"
+        },
         "description": {
           "description": "Optional description of the contents / purpose of the dictionary.",
           "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
@@ -393,8 +405,8 @@
         },
         "path": {
           "$ref": "#/definitions/CustomDictionaryPath",
-          "description": "Path to custom dictionary text file.",
-          "markdownDescription": "Path to custom dictionary text file."
+          "description": "A file path or url to a custom dictionary file.",
+          "markdownDescription": "A file path or url to a custom dictionary file."
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -695,6 +707,12 @@
     "DictionaryDefinitionPreferred": {
       "additionalProperties": false,
       "properties": {
+        "btrie": {
+          "$ref": "#/definitions/DictionaryPathToBTrie",
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0"
+        },
         "description": {
           "description": "Optional description of the contents / purpose of the dictionary.",
           "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
@@ -717,8 +735,8 @@
         },
         "path": {
           "$ref": "#/definitions/DictionaryPath",
-          "description": "Path to the file.",
-          "markdownDescription": "Path to the file."
+          "description": "Path or url to the dictionary file.",
+          "markdownDescription": "Path or url to the dictionary file."
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -870,8 +888,14 @@
       "type": "string"
     },
     "DictionaryPath": {
-      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
-      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
+      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:txt|trie|btrie|dic)(?:\\.gz)?$`",
+      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:txt|trie|btrie|dic)(?:\\.gz)?$`",
+      "type": "string"
+    },
+    "DictionaryPathToBTrie": {
+      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:btrie)(?:\\.gz)?$`",
+      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:btrie)(?:\\.gz)?$`",
+      "since": "9.6.0",
       "type": "string"
     },
     "DictionaryRef": {
@@ -947,11 +971,6 @@
         }
       },
       "type": "object"
-    },
-    "FsDictionaryPath": {
-      "description": "A File System Path. Relative paths are relative to the configuration file.",
-      "markdownDescription": "A File System Path. Relative paths are relative to the configuration file.",
-      "type": "string"
     },
     "FsPath": {
       "description": "A File System Path. Relative paths are relative to the configuration file.",

--- a/packages/cspell-eslint-plugin/src/generated/schema.cts
+++ b/packages/cspell-eslint-plugin/src/generated/schema.cts
@@ -127,8 +127,8 @@ export const optionsSchema: Rule.RuleMetaData['schema'] = {
                     "type": "string"
                   },
                   "path": {
-                    "description": "Path to the file.",
-                    "markdownDescription": "Path to the file.",
+                    "description": "Path or url to the dictionary file.",
+                    "markdownDescription": "Path or url to the dictionary file.",
                     "type": "string"
                   },
                   "supportNonStrictSearches": {

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -1022,8 +1022,17 @@ interface DictionaryDefinitionBase {
   supportNonStrictSearches?: boolean | undefined;
 }
 interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase {
-  /** Path to the file. */
+  /**
+  * Path or url to the dictionary file.
+  */
   path: DictionaryPath;
+  /**
+  * An alternative path to a bTrie dictionary file.
+  * It will be used in place of `path` if the version of CSpell being used
+  * supports btrie files.
+  * @since 9.6.0
+  */
+  btrie?: DictionaryPathToBTrie | undefined;
   /**
   * Only for legacy dictionary definitions.
   * @deprecated true
@@ -1032,10 +1041,25 @@ interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase {
   */
   file?: undefined;
 }
+interface HiddenPaths {
+  /**
+  * @hide
+  */
+  path?: string | undefined;
+  /**
+  * @hide
+  */
+  btrie?: string | undefined;
+  /**
+  * @hide
+  */
+  file?: undefined;
+}
+interface DictionaryDefinitionBaseWithPathsHidden extends DictionaryDefinitionBase, HiddenPaths {}
 /**
 * An Empty Dictionary Definition
 */
-interface DictionaryDefinitionSimple extends DictionaryDefinitionBase {
+interface DictionaryDefinitionSimple extends DictionaryDefinitionBaseWithPathsHidden {
   /**
   * @hide
   */
@@ -1056,14 +1080,6 @@ interface DictionaryDefinitionSimple extends DictionaryDefinitionBase {
   * @hide
   */
   type?: DictionaryFileTypes | undefined;
-  /**
-  * @hide
-  */
-  path?: string | undefined;
-  /**
-  * @hide
-  */
-  file?: undefined;
 }
 /**
 * Used to provide extra data related to the dictionary
@@ -1077,6 +1093,11 @@ interface HiddenFields {
   * @hide
   */
   path?: undefined;
+  /**
+  * Not used
+  * @hide
+  */
+  btrie?: string | undefined;
   /**
   * Not used
   * @hide
@@ -1134,12 +1155,9 @@ type DictionaryDefinitionInline = DictionaryDefinitionInlineWords | DictionaryDe
 * Only for legacy dictionary definitions.
 * @deprecated true
 * @deprecationMessage Use {@link DictionaryDefinitionPreferred} instead.
+* This will be removed in a future release.
 */
-interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase {
-  /**
-  * @hidden
-  */
-  path?: undefined;
+interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase, Omit<HiddenPaths, "file"> {
   /**
   * Path to the file, only for legacy dictionary definitions.
   * @deprecated true
@@ -1153,9 +1171,11 @@ interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase {
 }
 /**
 * @deprecated true
+* @deprecationMessage Use {@link DictionaryDefinitionPreferred} instead.
+* This will be removed in a future release.
 * @hidden
 */
-interface DictionaryDefinitionLegacy extends DictionaryDefinitionBase {
+interface DictionaryDefinitionLegacy extends DictionaryDefinitionBase, Omit<HiddenPaths, "file" | "path"> {
   /** Path to the file, if undefined the path to the extension dictionaries is assumed. */
   path?: FsDictionaryPath;
   /**
@@ -1194,7 +1214,9 @@ type CustomDictionaryScope = "user" | "workspace" | "folder";
 * Note: only plain text files with one word per line are supported at this moment.
 */
 interface DictionaryDefinitionCustom extends DictionaryDefinitionPreferred {
-  /** Path to custom dictionary text file. */
+  /**
+  * A file path or url to a custom dictionary file.
+  */
   path: CustomDictionaryPath;
   /**
   * Defines the scope for when words will be added to the dictionary.
@@ -1228,13 +1250,19 @@ type ReplaceMap = ReplaceEntry[];
 type FsDictionaryPath = string;
 /**
 * A File System Path to a dictionary file.
-* Pattern: `^.*\.(?:txt|trie|dic)(?:\.gz)?$`
+* Pattern: `^.*\.(?:txt|trie|btrie|dic)(?:\.gz)?$`
 */
 type DictionaryPath = string;
 /**
 * A File System Path to a dictionary file.
+* Pattern: `^.*\.(?:btrie)(?:\.gz)?$`
+* @since 9.6.0
 */
-type CustomDictionaryPath = FsDictionaryPath;
+type DictionaryPathToBTrie = string;
+/**
+* A path or url to a custom dictionary file.
+*/
+type CustomDictionaryPath = string;
 /**
 * Reference to a dictionary by name.
 * One of:

--- a/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DictionarySettings.ts
@@ -199,6 +199,7 @@ class _DictionaryDefinitionInternalWithSource implements DictionaryFileDefinitio
             name,
             file: undefined,
             path: resolvedPath,
+            btrie: undefined,
             addWords,
             description,
             dictionaryInformation,

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -200,9 +200,9 @@
       "type": "object"
     },
     "CustomDictionaryPath": {
-      "$ref": "#/definitions/FsDictionaryPath",
-      "description": "A File System Path to a dictionary file.",
-      "markdownDescription": "A File System Path to a dictionary file."
+      "description": "A path or url to a custom dictionary file.",
+      "markdownDescription": "A path or url to a custom dictionary file.",
+      "type": "string"
     },
     "CustomDictionaryScope": {
       "description": "Specifies the scope of a dictionary.",
@@ -239,7 +239,7 @@
     "DictionaryDefinitionAlternate": {
       "additionalProperties": false,
       "deprecated": true,
-      "deprecationMessage": "Use {@link DictionaryDefinitionPreferred } instead.",
+      "deprecationMessage": "Use {@link DictionaryDefinitionPreferred } instead.\nThis will be removed in a future release.",
       "description": "Only for legacy dictionary definitions.",
       "markdownDescription": "Only for legacy dictionary definitions.",
       "properties": {
@@ -304,6 +304,12 @@
       "description": "Used to provide extra data related to the dictionary",
       "markdownDescription": "Used to provide extra data related to the dictionary",
       "properties": {
+        "btrie": {
+          "$ref": "#/definitions/DictionaryPathToBTrie",
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0"
+        },
         "description": {
           "description": "Optional description of the contents / purpose of the dictionary.",
           "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
@@ -329,8 +335,8 @@
         },
         "path": {
           "$ref": "#/definitions/DictionaryPath",
-          "description": "Path to the file.",
-          "markdownDescription": "Path to the file."
+          "description": "Path or url to the dictionary file.",
+          "markdownDescription": "Path or url to the dictionary file."
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -371,6 +377,12 @@
           "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
           "type": "boolean"
         },
+        "btrie": {
+          "$ref": "#/definitions/DictionaryPathToBTrie",
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0"
+        },
         "description": {
           "description": "Optional description of the contents / purpose of the dictionary.",
           "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
@@ -393,8 +405,8 @@
         },
         "path": {
           "$ref": "#/definitions/CustomDictionaryPath",
-          "description": "Path to custom dictionary text file.",
-          "markdownDescription": "Path to custom dictionary text file."
+          "description": "A file path or url to a custom dictionary file.",
+          "markdownDescription": "A file path or url to a custom dictionary file."
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -695,6 +707,12 @@
     "DictionaryDefinitionPreferred": {
       "additionalProperties": false,
       "properties": {
+        "btrie": {
+          "$ref": "#/definitions/DictionaryPathToBTrie",
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0"
+        },
         "description": {
           "description": "Optional description of the contents / purpose of the dictionary.",
           "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
@@ -717,8 +735,8 @@
         },
         "path": {
           "$ref": "#/definitions/DictionaryPath",
-          "description": "Path to the file.",
-          "markdownDescription": "Path to the file."
+          "description": "Path or url to the dictionary file.",
+          "markdownDescription": "Path or url to the dictionary file."
         },
         "repMap": {
           "$ref": "#/definitions/ReplaceMap",
@@ -870,8 +888,14 @@
       "type": "string"
     },
     "DictionaryPath": {
-      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
-      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:txt|trie|dic)(?:\\.gz)?$`",
+      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:txt|trie|btrie|dic)(?:\\.gz)?$`",
+      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:txt|trie|btrie|dic)(?:\\.gz)?$`",
+      "type": "string"
+    },
+    "DictionaryPathToBTrie": {
+      "description": "A File System Path to a dictionary file. Pattern: `^.*\\.(?:btrie)(?:\\.gz)?$`",
+      "markdownDescription": "A File System Path to a dictionary file.\nPattern: `^.*\\.(?:btrie)(?:\\.gz)?$`",
+      "since": "9.6.0",
       "type": "string"
     },
     "DictionaryRef": {
@@ -947,11 +971,6 @@
         }
       },
       "type": "object"
-    },
-    "FsDictionaryPath": {
-      "description": "A File System Path. Relative paths are relative to the configuration file.",
-      "markdownDescription": "A File System Path. Relative paths are relative to the configuration file.",
-      "type": "string"
     },
     "FsPath": {
       "description": "A File System Path. Relative paths are relative to the configuration file.",

--- a/packages/cspell-types/src/DictionaryDefinition.ts
+++ b/packages/cspell-types/src/DictionaryDefinition.ts
@@ -85,8 +85,18 @@ export interface DictionaryDefinitionBase {
 }
 
 export interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase {
-    /** Path to the file. */
+    /**
+     * Path or url to the dictionary file.
+     */
     path: DictionaryPath;
+
+    /**
+     * An alternative path to a bTrie dictionary file.
+     * It will be used in place of `path` if the version of CSpell being used
+     * supports btrie files.
+     * @since 9.6.0
+     */
+    btrie?: DictionaryPathToBTrie | undefined;
 
     /**
      * Only for legacy dictionary definitions.
@@ -97,10 +107,29 @@ export interface DictionaryDefinitionPreferred extends DictionaryDefinitionBase 
     file?: undefined;
 }
 
+interface HiddenPaths {
+    /**
+     * @hide
+     */
+    path?: string | undefined;
+
+    /**
+     * @hide
+     */
+    btrie?: string | undefined;
+
+    /**
+     * @hide
+     */
+    file?: undefined;
+}
+
+interface DictionaryDefinitionBaseWithPathsHidden extends DictionaryDefinitionBase, HiddenPaths {}
+
 /**
  * An Empty Dictionary Definition
  */
-export interface DictionaryDefinitionSimple extends DictionaryDefinitionBase {
+export interface DictionaryDefinitionSimple extends DictionaryDefinitionBaseWithPathsHidden {
     /**
      * @hide
      */
@@ -125,16 +154,6 @@ export interface DictionaryDefinitionSimple extends DictionaryDefinitionBase {
      * @hide
      */
     type?: DictionaryFileTypes | undefined;
-
-    /**
-     * @hide
-     */
-    path?: string | undefined;
-
-    /**
-     * @hide
-     */
-    file?: undefined;
 }
 
 /**
@@ -150,6 +169,12 @@ interface HiddenFields {
      * @hide
      */
     path?: undefined;
+
+    /**
+     * Not used
+     * @hide
+     */
+    btrie?: string | undefined;
 
     /**
      * Not used
@@ -230,13 +255,9 @@ export type DictionaryDefinitionInline =
  * Only for legacy dictionary definitions.
  * @deprecated true
  * @deprecationMessage Use {@link DictionaryDefinitionPreferred} instead.
+ * This will be removed in a future release.
  */
-export interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase {
-    /**
-     * @hidden
-     */
-    path?: undefined;
-
+export interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase, Omit<HiddenPaths, 'file'> {
     /**
      * Path to the file, only for legacy dictionary definitions.
      * @deprecated true
@@ -251,9 +272,11 @@ export interface DictionaryDefinitionAlternate extends DictionaryDefinitionBase 
 }
 /**
  * @deprecated true
+ * @deprecationMessage Use {@link DictionaryDefinitionPreferred} instead.
+ * This will be removed in a future release.
  * @hidden
  */
-export interface DictionaryDefinitionLegacy extends DictionaryDefinitionBase {
+export interface DictionaryDefinitionLegacy extends DictionaryDefinitionBase, Omit<HiddenPaths, 'file' | 'path'> {
     /** Path to the file, if undefined the path to the extension dictionaries is assumed. */
     path?: FsDictionaryPath;
     /**
@@ -293,7 +316,9 @@ export type CustomDictionaryScope = 'user' | 'workspace' | 'folder';
  * Note: only plain text files with one word per line are supported at this moment.
  */
 export interface DictionaryDefinitionCustom extends DictionaryDefinitionPreferred {
-    /** Path to custom dictionary text file. */
+    /**
+     * A file path or url to a custom dictionary file.
+     */
     path: CustomDictionaryPath;
 
     /**
@@ -333,14 +358,21 @@ export type FsDictionaryPath = string;
 
 /**
  * A File System Path to a dictionary file.
- * Pattern: `^.*\.(?:txt|trie|dic)(?:\.gz)?$`
+ * Pattern: `^.*\.(?:txt|trie|btrie|dic)(?:\.gz)?$`
  */
 export type DictionaryPath = string;
 
 /**
  * A File System Path to a dictionary file.
+ * Pattern: `^.*\.(?:btrie)(?:\.gz)?$`
+ * @since 9.6.0
  */
-export type CustomDictionaryPath = FsDictionaryPath;
+export type DictionaryPathToBTrie = string;
+
+/**
+ * A path or url to a custom dictionary file.
+ */
+export type CustomDictionaryPath = string;
 
 /**
  * Reference to a dictionary by name.


### PR DESCRIPTION
Make it possible for a dictionary to specify a btrie path in addition to the normal `path`.