### PR TITLE
fix: Use glob for ignore filename

### DIFF
--- a/packages/cspell-filetypes/src/definitions.ts
+++ b/packages/cspell-filetypes/src/definitions.ts
@@ -74,7 +74,7 @@ export const definitions: FileTypeDefinitions = [
     { id: 'haxe', extensions: ['.hx'] },
     { id: 'hlsl', extensions: ['.cginc', '.compute', '.fx', '.fxh', '.hlsl', '.hlsli', '.psh', '.vsh'] },
     { id: 'html', extensions: ['.asp', '.aspx', '.ejs', '.htm', '.html', '.jshtm', '.jsp', '.mdoc', '.rhtml', '.shtml', '.volt', '.vue', '.xht', '.xhtml'] },
-    { id: 'ignore', extensions: ['.git-blame-ignore-revs', '.gitignore', '.gitignore_global'], filenames: ['.*ignore'] },
+    { id: 'ignore', extensions: ['.git-blame-ignore-revs', '.gitignore', '.gitignore_global', '.npmignore'], filenames: ['.*ignore'] },
     { id: 'ini', extensions: ['.conf', '.ini'] },
     { id: 'jade', extensions: ['.jade', '.pug'] },
     { id: 'java', extensions: ['.jav', '.java'] },


### PR DESCRIPTION
This ensures that all ignore files are identified as ignore by switching the filename pattern to a glob,

This change enables .dockerignore, .npmignore etc to be detected