### PR TITLE
fix: report errors in spelling result.

### DIFF
--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -3597,6 +3597,8 @@ declare class DocumentValidator {
   private genSuggestions;
   private adjustSuggestions;
   getFinalizedDocSettings(): CSpellSettingsInternal;
+  getConfigErrors(): ImportFileRefWithError[] | undefined;
+  getDictionaryErrors(): Map<string, Error[]> | undefined;
   /**
   * Returns true if the final result of the configuration calculation results
   * in the document being enabled. Note: in some cases, checking the document
@@ -3730,6 +3732,8 @@ interface SpellCheckFileResult {
   issues: ValidationIssue[];
   checked: boolean;
   errors: Error[] | undefined;
+  configErrors?: ImportFileRefWithError[] | undefined;
+  dictionaryErrors?: Map<string, Error[]> | undefined;
   perf?: SpellCheckFilePerf;
 }
 /**

--- a/packages/cspell-lib/fixtures/import-errors/README.md
+++ b/packages/cspell-lib/fixtures/import-errors/README.md
@@ -1,0 +1,1 @@
+# Handling Import Errors

--- a/packages/cspell-lib/fixtures/import-errors/cspell.config.yaml
+++ b/packages/cspell-lib/fixtures/import-errors/cspell.config.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+
+# The version of the configuration file format.
+version: '0.2'
+# The locale to use when spell checking. (e.g., en, en-GB, de-DE
+language: en
+import:
+  - ./missing-import.yaml
+  - ./missing-dict.yaml

--- a/packages/cspell-lib/fixtures/import-errors/file.txt
+++ b/packages/cspell-lib/fixtures/import-errors/file.txt
@@ -1,0 +1,1 @@
+# This file as some errrros

--- a/packages/cspell-lib/fixtures/import-errors/missing-dict.yaml
+++ b/packages/cspell-lib/fixtures/import-errors/missing-dict.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+
+# The version of the configuration file format.
+version: '0.2'
+# The locale to use when spell checking. (e.g., en, en-GB, de-DE
+language: en
+# Configuration or packages to import.
+import:
+  - ./cspell.config.yaml
+
+dictionaryDefinitions:
+  - name: my-dict
+    path: ./missing.txt
+
+dictionaries:
+  - my-dict

--- a/packages/cspell-lib/fixtures/import-errors/missing-import.yaml
+++ b/packages/cspell-lib/fixtures/import-errors/missing-import.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+
+# The version of the configuration file format.
+version: '0.2'
+# The locale to use when spell checking. (e.g., en, en-GB, de-DE
+language: en
+# Configuration or packages to import.
+import:
+  - ./missing.config.yaml

--- a/packages/cspell-lib/src/lib/spellCheckFile.ts
+++ b/packages/cspell-lib/src/lib/spellCheckFile.ts
@@ -7,6 +7,7 @@ import { isBinaryDoc } from './Document/isBinaryDoc.js';
 import { documentToTextDocument, resolveDocument } from './Document/resolveDocument.js';
 import { createTextDocument } from './Models/TextDocument.js';
 import { createPerfTimer } from './perf/index.js';
+import type { ImportFileRefWithError } from './Settings/index.js';
 import { cloneSettingsForExport } from './Settings/sanitizeSettings.js';
 import { determineTextDocumentSettings } from './textValidation/determineTextDocumentSettings.js';
 import type { DocumentValidatorOptions } from './textValidation/index.js';
@@ -54,6 +55,8 @@ export interface SpellCheckFileResult {
     issues: ValidationIssue[];
     checked: boolean;
     errors: Error[] | undefined;
+    configErrors?: ImportFileRefWithError[] | undefined;
+    dictionaryErrors?: Map<string, Error[]> | undefined;
     perf?: SpellCheckFilePerf;
 }
 
@@ -198,6 +201,8 @@ async function spellCheckFullDocument(
             issues: [],
             checked: false,
             errors: docValidator.errors,
+            configErrors: docValidator.getConfigErrors(),
+            dictionaryErrors: docValidator.getDictionaryErrors(),
             perf,
         };
     }
@@ -216,6 +221,8 @@ async function spellCheckFullDocument(
         issues,
         checked: docValidator.shouldCheckDocument(),
         errors: undefined,
+        configErrors: docValidator.getConfigErrors(),
+        dictionaryErrors: docValidator.getDictionaryErrors(),
         perf,
     };
     timer.end();

--- a/packages/cspell/src/cspell-api/cspell-api.ts
+++ b/packages/cspell/src/cspell-api/cspell-api.ts
@@ -1,0 +1,18 @@
+import { spellCheckDocument, spellCheckDocumentRPC } from 'cspell-lib';
+import type { CSpellRPCApi } from 'cspell-lib/cspell-rpc';
+
+export interface CSpellAPI extends Pick<CSpellRPCApi, 'spellCheckDocument'> {}
+
+const usePRC = false;
+
+const api = {
+    spellCheckDocument,
+} as const;
+
+export const apiRPC: CSpellAPI = {
+    spellCheckDocument: spellCheckDocumentRPC,
+} as const;
+
+export function getCSpellAPI(): Promise<CSpellAPI> {
+    return Promise.resolve(usePRC ? apiRPC : api);
+}

--- a/packages/cspell/src/cspell-api/index.ts
+++ b/packages/cspell/src/cspell-api/index.ts
@@ -1,0 +1,2 @@
+export type { CSpellAPI } from './cspell-api.js';
+export { getCSpellAPI } from './cspell-api.js';

--- a/packages/cspell/src/lint/lint.ts
+++ b/packages/cspell/src/lint/lint.ts
@@ -274,7 +274,7 @@ export async function runLint(cfg: LintRequest): Promise<RunResult> {
             reporter.info(`Config Files Found:\n    ${relativeToCwd(configInfo.source)}\n`, MessageTypes.Info);
         }
 
-        const configErrors = await countConfigErrors(configInfo, processFileOptions);
+        const configErrors = countConfigErrors(configInfo, processFileOptions);
         if (configErrors && cfg.options.exitCode !== false && !cfg.options.continueOnError) {
             return runResult({ errors: configErrors });
         }

--- a/packages/cspell/src/lint/processFile.ts
+++ b/packages/cspell/src/lint/processFile.ts
@@ -5,20 +5,15 @@ import type {
     CSpellSettings,
     CSpellSettingsWithSourceTrace,
     Document,
+    ImportFileRefWithError,
     Issue,
     SpellCheckFileResult,
     TextDocumentOffset,
     ValidationIssue,
 } from 'cspell-lib';
-import {
-    extractDependencies,
-    extractImportErrors,
-    getDictionary,
-    MessageTypes,
-    spellCheckDocument,
-    Text as cspellText,
-} from 'cspell-lib';
+import { extractDependencies, extractImportErrors, MessageTypes, Text as cspellText } from 'cspell-lib';
 
+import { getCSpellAPI } from '../cspell-api/index.js';
 import type { CSpellLintResultCache } from '../util/cache/CSpellLintResultCache.js';
 import type { ConfigInfo } from '../util/configFileHelper.js';
 import { toError } from '../util/errors.js';
@@ -53,6 +48,8 @@ export async function processFile(
     if (prefetch?.fileResult) return prefetch.fileResult;
 
     const { reporter, cfg, configInfo } = processFileOptions;
+
+    const { spellCheckDocument } = await getCSpellAPI();
 
     const getElapsedTimeMs = getTimeMeasurer();
     const reportIssueOptions = prefetch?.reportIssueOptions;
@@ -119,7 +116,8 @@ export async function processFile(
         spellResult.settingsUsed || configInfo.config,
         reportIssueOptions,
     );
-    result.configErrors += await reportConfigurationErrors(config, processFileOptions);
+
+    result.configErrors += reportSpellingResultConfigErrors(spellResult, processFileOptions);
 
     reportCheckResult(result, doc, spellResult, config, processFileOptions);
 
@@ -179,12 +177,13 @@ function calcDependencies(config: CSpellSettings): ConfigDependencies {
     return { files: [...configFiles, ...dictionaryFiles] };
 }
 
-export async function reportConfigurationErrors(
-    config: CSpellSettings,
-    processFileOptions: ProcessFileOptions,
-): Promise<number> {
-    const { reporter, configErrors } = processFileOptions;
+function reportConfigurationErrors(config: CSpellSettings, processFileOptions: ProcessFileOptions): number {
     const errors = extractImportErrors(config);
+    return reportImportErrors(errors, processFileOptions);
+}
+
+function reportImportErrors(errors: ImportFileRefWithError[], processFileOptions: ProcessFileOptions): number {
+    const { reporter, configErrors } = processFileOptions;
     let count = 0;
     errors.forEach((ref) => {
         const key = ref.error.toString();
@@ -194,10 +193,19 @@ export async function reportConfigurationErrors(
         reporter.error('Configuration', ref.error);
     });
 
-    const dictCollection = await getDictionary(config);
-    dictCollection.dictionaries.forEach((dict) => {
-        const dictErrors = dict.getErrors?.() || [];
-        const msg = `Dictionary Error with (${dict.name})`;
+    return count;
+}
+
+function reportSpellingResultConfigErrors(
+    spellResult: Partial<SpellCheckFileResult>,
+    processFileOptions: ProcessFileOptions,
+): number {
+    const { reporter, configErrors } = processFileOptions;
+    let count = reportImportErrors(spellResult.configErrors || [], processFileOptions);
+
+    const dictionaryErrors = [...(spellResult.dictionaryErrors || [])];
+    for (const [dictName, dictErrors] of dictionaryErrors) {
+        const msg = `Dictionary Error with (${dictName})`;
         dictErrors.forEach((error) => {
             const key = msg + error.toString();
             if (configErrors.has(key)) return;
@@ -205,11 +213,11 @@ export async function reportConfigurationErrors(
             count += 1;
             reporter.error(msg, error);
         });
-    });
+    }
 
     return count;
 }
 
-export function countConfigErrors(configInfo: ConfigInfo, processFileOptions: ProcessFileOptions): Promise<number> {
+export function countConfigErrors(configInfo: ConfigInfo, processFileOptions: ProcessFileOptions): number {
     return reportConfigurationErrors(configInfo.config, processFileOptions);
 }


### PR DESCRIPTION
## Pull request overview

This PR enhances error reporting in spell check results by including configuration and dictionary errors directly in the `SpellCheckFileResult` object. Previously, errors were only extracted from configuration during the lint process; now they're also captured from the spell checking itself.

**Changes:**
- Added `configErrors` and `dictionaryErrors` fields to `SpellCheckFileResult` interface
- Refactored error reporting to extract errors from spell check results instead of re-computing them from configuration
- Created a new `cspell-api` module to abstract spell checking implementation
- Added comprehensive test coverage with fixture files demonstrating error scenarios
