### PR TITLE
refactor: Refactor internal settings

### DIFF
--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -2900,18 +2900,7 @@ type OptionalKeys<T> = Exclude<{ [P in keyof T]: T[P] extends Exclude<T[P], unde
 */
 type OptionalOrUndefined<T> = { [P in keyof T]: P extends OptionalKeys<T> ? T[P] | undefined : T[P] };
 //#endregion
-//#region src/lib/Models/CSpellSettingsInternalDef.d.ts
-declare const SymbolCSpellSettingsInternal: unique symbol;
-interface CSpellSettingsInternal extends Omit<AdvancedCSpellSettingsWithSourceTrace, "dictionaryDefinitions"> {
-  [SymbolCSpellSettingsInternal]: true;
-  dictionaryDefinitions?: DictionaryDefinitionInternal[];
-}
-interface CSpellSettingsInternalFinalized extends CSpellSettingsInternal {
-  parserFn: Parser | undefined;
-  finalized: true;
-  ignoreRegExpList: RegExp[];
-  includeRegExpList: RegExp[];
-}
+//#region src/lib/Settings/internal/InternalDictionaryDef.d.ts
 type DictionaryDefinitionCustomUniqueFields = Omit<DictionaryDefinitionCustom, keyof DictionaryDefinitionPreferred>;
 type DictionaryDefinitionInternal = DictionaryFileDefinitionInternal | DictionaryDefinitionInlineInternal | DictionaryDefinitionSimpleInternal;
 type DictionaryDefinitionInlineInternal = DictionaryDefinitionInline & {
@@ -2931,40 +2920,18 @@ interface DictionaryFileDefinitionInternal extends Readonly<DictionaryDefinition
   readonly __source?: string | undefined;
 }
 //#endregion
-//#region src/lib/SpellingDictionary/Dictionaries.d.ts
-declare function refreshDictionaryCache(maxAge?: number): Promise<void>;
-//#endregion
-//#region src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.d.ts
-type LoadOptions = DictionaryDefinitionInternal;
-//#endregion
-//#region src/lib/SpellingDictionary/SpellingDictionaryError.d.ts
-declare class SpellingDictionaryLoadError extends Error {
-  readonly uri: string;
-  readonly options: LoadOptions;
-  readonly cause: Error;
-  readonly name: string;
-  constructor(uri: string, options: LoadOptions, cause: Error, message: string);
+//#region src/lib/Settings/internal/CSpellSettingsInternalDef.d.ts
+declare const SymbolCSpellSettingsInternal: unique symbol;
+interface CSpellSettingsInternal extends Omit<AdvancedCSpellSettingsWithSourceTrace, "dictionaryDefinitions"> {
+  [SymbolCSpellSettingsInternal]: true;
+  dictionaryDefinitions?: DictionaryDefinitionInternal[];
 }
-declare function isSpellingDictionaryLoadError(e: Error): e is SpellingDictionaryLoadError;
-//#endregion
-//#region src/lib/getDictionary.d.ts
-/**
-* Load a dictionary collection defined by the settings.
-* @param settings - that defines the dictionaries and the ones to load.
-* @returns a dictionary collection that represents all the enabled dictionaries.
-*/
-declare function getDictionary(settings: CSpellUserSettings): Promise<SpellingDictionaryCollection>;
-//#endregion
-//#region src/lib/perf/timer.d.ts
-interface PerfTimer {
-  readonly name: string;
-  readonly startTime: number;
-  readonly elapsed: number;
-  start(): void;
-  end(): void;
+interface CSpellSettingsInternalFinalized extends CSpellSettingsInternal {
+  parserFn: Parser | undefined;
+  finalized: true;
+  ignoreRegExpList: RegExp[];
+  includeRegExpList: RegExp[];
 }
-type TimeNowFn = () => number;
-declare function createPerfTimer(name: string, onEnd?: (elapsed: number, name: string) => void, timeNowFn?: TimeNowFn): PerfTimer;
 //#endregion
 //#region src/lib/Settings/CSpellSettingsServer.d.ts
 type CSpellSettingsWST$1 = AdvancedCSpellSettingsWithSourceTrace;
@@ -3246,6 +3213,41 @@ declare class ImportError extends Error {
 //#region src/lib/Settings/DefaultSettings.d.ts
 declare function getDefaultSettings(useDefaultDictionaries?: boolean): Promise<CSpellSettingsInternal>;
 declare function getDefaultBundledSettingsAsync(): Promise<CSpellSettingsInternal>;
+//#endregion
+//#region src/lib/SpellingDictionary/Dictionaries.d.ts
+declare function refreshDictionaryCache(maxAge?: number): Promise<void>;
+//#endregion
+//#region src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.d.ts
+type LoadOptions = DictionaryDefinitionInternal;
+//#endregion
+//#region src/lib/SpellingDictionary/SpellingDictionaryError.d.ts
+declare class SpellingDictionaryLoadError extends Error {
+  readonly uri: string;
+  readonly options: LoadOptions;
+  readonly cause: Error;
+  readonly name: string;
+  constructor(uri: string, options: LoadOptions, cause: Error, message: string);
+}
+declare function isSpellingDictionaryLoadError(e: Error): e is SpellingDictionaryLoadError;
+//#endregion
+//#region src/lib/getDictionary.d.ts
+/**
+* Load a dictionary collection defined by the settings.
+* @param settings - that defines the dictionaries and the ones to load.
+* @returns a dictionary collection that represents all the enabled dictionaries.
+*/
+declare function getDictionary(settings: CSpellUserSettings): Promise<SpellingDictionaryCollection>;
+//#endregion
+//#region src/lib/perf/timer.d.ts
+interface PerfTimer {
+  readonly name: string;
+  readonly startTime: number;
+  readonly elapsed: number;
+  start(): void;
+  end(): void;
+}
+type TimeNowFn = () => number;
+declare function createPerfTimer(name: string, onEnd?: (elapsed: number, name: string) => void, timeNowFn?: TimeNowFn): PerfTimer;
 //#endregion
 //#region src/lib/Settings/link.d.ts
 interface ListGlobalImportsResult {

--- a/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.test.ts
@@ -6,7 +6,6 @@ import { CSpellConfigFileInMemory } from 'cspell-config-lib';
 import { describe, expect, test } from 'vitest';
 
 import { pathPackageRoot, pathPackageSamples } from '../../test-util/test.locations.js';
-import { createCSpellSettingsInternal as csi } from '../Models/CSpellSettingsInternalDef.js';
 import { toURL } from '../util/url.js';
 import { calcOverrideSettings } from './calcOverrideSettings.js';
 import { checkFilenameMatchesGlob } from './checkFilenameMatchesGlob.js';
@@ -24,6 +23,7 @@ import {
 import type { CSpellSettingsWST } from './Controller/configLoader/types.js';
 import { getMergeStats, getSources, mergeSettings } from './CSpellSettingsServer.js';
 import { _defaultSettings, getDefaultBundledSettingsAsync } from './DefaultSettings.js';
+import { createCSpellSettingsInternal as csi } from './internal/index.js';
 
 const samplesDir = pathPackageSamples;
 const pathSrc = path.join(pathPackageRoot, 'src');

--- a/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.ts
+++ b/packages/cspell-lib/src/lib/Settings/CSpellSettingsServer.ts
@@ -11,14 +11,14 @@ import type {
 } from '@cspell/cspell-types';
 
 import { onClearCache } from '../events/index.js';
-import type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef.js';
-import { cleanCSpellSettingsInternal as csi, isCSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef.js';
 import { autoResolveWeak, AutoResolveWeakCache } from '../util/AutoResolve.js';
 import type { OptionalOrUndefined } from '../util/types.js';
 import { toFileUrl } from '../util/url.js';
 import * as util from '../util/util.js';
 import { configSettingsFileVersion0_1, ENV_CSPELL_GLOB_ROOT } from './constants.js';
-import { calcDictionaryDefsToLoad, mapDictDefsToInternal } from './DictionarySettings.js';
+import { calcDictionaryDefsToLoad, mapDictDefsToInternal } from './internal/DictionarySettings.js';
+import type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from './internal/index.js';
+import { cleanCSpellSettingsInternal as csi, isCSpellSettingsInternal } from './internal/index.js';
 import { mergeList, mergeListUnique } from './mergeList.js';
 import { resolvePatterns } from './patterns.js';
 import { CwdUrlResolver } from './resolveCwd.js';

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/configLoader.ts
@@ -12,7 +12,6 @@ import { URI, Utils as UriUtils } from 'vscode-uri';
 import { onClearCache } from '../../../events/index.js';
 import type { VFileSystem } from '../../../fileSystem.js';
 import { getVirtualFS } from '../../../fileSystem.js';
-import { createCSpellSettingsInternal as csi } from '../../../Models/CSpellSettingsInternalDef.js';
 import { srcDirectory } from '../../../pkg-info.mjs';
 import type { CacheStats } from '../../../util/AutoResolve.js';
 import { autoResolve, AutoResolveCache, autoResolveWeak } from '../../../util/AutoResolve.js';
@@ -37,6 +36,7 @@ import {
 } from '../../constants.js';
 import { getMergeStats, mergeSettings, toInternalSettings } from '../../CSpellSettingsServer.js';
 import { getGlobalConfig } from '../../GlobalSettings.js';
+import { createCSpellSettingsInternal as csi } from '../../internal/index.js';
 import { ImportError } from '../ImportError.js';
 import type { LoaderResult } from '../pnpLoader.js';
 import { pnpLoader } from '../pnpLoader.js';

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/defaultSettings.ts
@@ -1,5 +1,5 @@
-import { createCSpellSettingsInternal as csi } from '../../../Models/CSpellSettingsInternalDef.js';
 import { currentSettingsFileVersion } from '../../constants.js';
+import { createCSpellSettingsInternal as csi } from '../../internal/index.js';
 import type { CSpellSettingsI } from './types.js';
 
 export const defaultSettings: CSpellSettingsI = csi({

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/normalizeRawSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/normalizeRawSettings.ts
@@ -7,7 +7,7 @@ import { resolveFile } from '../../../util/resolveFile.js';
 import type { OptionalOrUndefined, RemoveUndefined } from '../../../util/types.js';
 import { resolveFileWithURL, toFilePathOrHref } from '../../../util/url.js';
 import * as util from '../../../util/util.js';
-import { mapDictDefsToInternal } from '../../DictionarySettings.js';
+import { mapDictDefsToInternal } from '../../internal/DictionarySettings.js';
 import { toGlobDef } from './toGlobDef.js';
 
 interface NormalizableFields {

--- a/packages/cspell-lib/src/lib/Settings/Controller/configLoader/types.ts
+++ b/packages/cspell-lib/src/lib/Settings/Controller/configLoader/types.ts
@@ -1,6 +1,6 @@
 import type { CSpellSettingsWithSourceTrace } from '@cspell/cspell-types';
 
-import type { CSpellSettingsInternal } from '../../../Models/CSpellSettingsInternalDef.js';
+import type { CSpellSettingsInternal } from '../../internal/index.js';
 
 export type CSpellSettingsWST = CSpellSettingsWithSourceTrace;
 export type CSpellSettingsI = CSpellSettingsInternal;

--- a/packages/cspell-lib/src/lib/Settings/DefaultSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/DefaultSettings.ts
@@ -1,14 +1,14 @@
 import type { PredefinedPatterns, RegExpPatternDefinition } from '@cspell/cspell-types';
 import { parsers } from 'cspell-grammar';
 
-import type { CSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef.js';
-import { createCSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef.js';
 import { PatternRegExp } from '../Models/PatternRegExp.js';
 import { srcDirectory } from '../pkg-info.mjs';
 import { resolveFile } from '../util/resolveFile.js';
 import { defaultConfigFileModuleRef } from './constants.js';
 import { readSettings } from './Controller/configLoader/index.js';
 import { mergeSettings } from './CSpellSettingsServer.js';
+import type { CSpellSettingsInternal } from './internal/index.js';
+import { createCSpellSettingsInternal } from './internal/index.js';
 import * as LanguageSettings from './LanguageSettings.js';
 import * as RegPat from './RegExpPatterns.js';
 

--- a/packages/cspell-lib/src/lib/Settings/TextDocumentSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/TextDocumentSettings.ts
@@ -1,8 +1,8 @@
 import type { CSpellSettings, CSpellUserSettings } from '@cspell/cspell-types';
 
-import type { CSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef.js';
 import { mergeSettings, toInternalSettings } from './CSpellSettingsServer.js';
 import { getInDocumentSettings } from './InDocSettings.js';
+import type { CSpellSettingsInternal } from './internal/index.js';
 import { calcSettingsForLanguageId } from './LanguageSettings.js';
 
 export function combineTextAndLanguageSettings(

--- a/packages/cspell-lib/src/lib/Settings/index.ts
+++ b/packages/cspell-lib/src/lib/Settings/index.ts
@@ -33,3 +33,19 @@ export {
     mergeSettings,
 } from './CSpellSettingsServer.js';
 export { defaultSettingsLoader, getDefaultBundledSettingsAsync, getDefaultSettings } from './DefaultSettings.js';
+export type {
+    CSpellSettingsInternal,
+    CSpellSettingsInternalFinalized,
+    DictionaryDefinitionInlineInternal,
+    DictionaryDefinitionInternal,
+    DictionaryDefinitionSimpleInternal,
+    DictionaryFileDefinitionInternal,
+} from './internal/index.js';
+export {
+    calcDictionaryDefsToLoad,
+    createCSpellSettingsInternal,
+    filterDictDefsToLoad,
+    isDictionaryDefinitionInlineInternal,
+    isDictionaryFileDefinitionInternal,
+    mapDictDefToInternal,
+} from './internal/index.js';

--- a/packages/cspell-lib/src/lib/Settings/internal/CSpellSettingsInternalDef.ts
+++ b/packages/cspell-lib/src/lib/Settings/internal/CSpellSettingsInternalDef.ts
@@ -1,0 +1,46 @@
+import type {
+    AdvancedCSpellSettingsWithSourceTrace,
+    CSpellSettingsWithSourceTrace,
+    Parser,
+} from '@cspell/cspell-types';
+
+import type { OptionalOrUndefined } from '../../util/types.js';
+import { clean } from '../../util/util.js';
+import type { DictionaryDefinitionInternal } from './InternalDictionaryDef.js';
+
+export const SymbolCSpellSettingsInternal: unique symbol = Symbol('CSpellSettingsInternal');
+
+export interface CSpellSettingsInternal extends Omit<AdvancedCSpellSettingsWithSourceTrace, 'dictionaryDefinitions'> {
+    [SymbolCSpellSettingsInternal]: true;
+    dictionaryDefinitions?: DictionaryDefinitionInternal[];
+}
+
+export interface CSpellSettingsInternalFinalized extends CSpellSettingsInternal {
+    parserFn: Parser | undefined;
+    finalized: true;
+    ignoreRegExpList: RegExp[];
+    includeRegExpList: RegExp[];
+}
+
+export function cleanCSpellSettingsInternal(
+    parts?: OptionalOrUndefined<Partial<CSpellSettingsInternal>>,
+): CSpellSettingsInternal {
+    return parts
+        ? Object.assign(clean(parts), { [SymbolCSpellSettingsInternal]: true })
+        : { [SymbolCSpellSettingsInternal]: true };
+}
+
+export function createCSpellSettingsInternal(
+    parts?: OptionalOrUndefined<Partial<CSpellSettingsInternal>>,
+): CSpellSettingsInternal {
+    return cleanCSpellSettingsInternal({ ...parts });
+}
+
+export function isCSpellSettingsInternal(
+    cs:
+        | CSpellSettingsInternal
+        | CSpellSettingsWithSourceTrace
+        | OptionalOrUndefined<CSpellSettingsInternal | CSpellSettingsWithSourceTrace>,
+): cs is CSpellSettingsInternal {
+    return !!(<CSpellSettingsInternal>cs)[SymbolCSpellSettingsInternal];
+}

--- a/packages/cspell-lib/src/lib/Settings/internal/DictionarySettings.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/internal/DictionarySettings.test.ts
@@ -7,11 +7,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { DictionaryDefinition, DictionaryDefinitionLegacy } from '@cspell/cspell-types';
 import { describe, expect, test } from 'vitest';
 
-import { isDictionaryDefinitionInlineInternal } from '../Models/CSpellSettingsInternalDef.js';
-import { isDefined } from '../util/util.js';
-import { getDefaultBundledSettingsAsync } from './DefaultSettings.js';
-import { createDictionaryReferenceCollection as createRefCol } from './DictionaryReferenceCollection.js';
+import { isDefined } from '../../util/util.js';
+import { getDefaultBundledSettingsAsync } from '../DefaultSettings.js';
+import { createDictionaryReferenceCollection as createRefCol } from '../DictionaryReferenceCollection.js';
 import * as DictSettings from './DictionarySettings.js';
+import { isDictionaryDefinitionInlineInternal } from './InternalDictionaryDef.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -138,5 +138,12 @@ describe('Validate DictionarySettings', () => {
         ${DictSettings.mapDictDefToInternal({ name: 'def', path: './dict.txt' }, pathToFileURL(__filename))} | ${true}
     `('isDictionaryDefinitionInternal', ({ def, expected }) => {
         expect(DictSettings.isDictionaryDefinitionInternal(def)).toBe(expected);
+    });
+
+    test.each`
+        def                                                                                                  | expected
+        ${DictSettings.mapDictDefToInternal({ name: 'def', path: './dict.txt' }, pathToFileURL(__filename))} | ${{ name: 'def', path: expect.stringContaining('dict.txt') }}
+    `('toJSON', ({ def, expected }) => {
+        expect(def.toJSON()).toEqual(expected);
     });
 });

--- a/packages/cspell-lib/src/lib/Settings/internal/DictionarySettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/internal/DictionarySettings.ts
@@ -12,20 +12,20 @@ import type {
 import type { WeightMap } from 'cspell-trie-lib';
 import { mapDictionaryInformationToWeightMap } from 'cspell-trie-lib';
 
+import { createAutoResolveWeakWeakCache } from '../../util/AutoResolve.js';
+import { resolveRelativeTo } from '../../util/resolveFile.js';
+import type { RequireOptional, UnionFields } from '../../util/types.js';
+import { toFilePathOrHref } from '../../util/url.js';
+import { clean } from '../../util/util.js';
+import type { DictionaryReferenceCollection } from '../DictionaryReferenceCollection.js';
+import { createDictionaryReferenceCollection } from '../DictionaryReferenceCollection.js';
+import type { CSpellSettingsInternal } from './CSpellSettingsInternalDef.js';
 import type {
-    CSpellSettingsInternal,
     DictionaryDefinitionInternal,
     DictionaryDefinitionInternalWithSource,
     DictionaryFileDefinitionInternalWithSource,
-} from '../Models/CSpellSettingsInternalDef.js';
-import { isDictionaryDefinitionInlineInternal } from '../Models/CSpellSettingsInternalDef.js';
-import { createAutoResolveWeakWeakCache } from '../util/AutoResolve.js';
-import { resolveRelativeTo } from '../util/resolveFile.js';
-import type { RequireOptional, UnionFields } from '../util/types.js';
-import { toFilePathOrHref } from '../util/url.js';
-import { clean } from '../util/util.js';
-import type { DictionaryReferenceCollection } from './DictionaryReferenceCollection.js';
-import { createDictionaryReferenceCollection } from './DictionaryReferenceCollection.js';
+} from './InternalDictionaryDef.js';
+import { isDictionaryDefinitionInlineInternal } from './InternalDictionaryDef.js';
 
 export type DefMapArrayItem = [string, DictionaryDefinitionInternal];
 
@@ -169,11 +169,14 @@ class _DictionaryDefinitionInternalWithSource implements DictionaryFileDefinitio
     readonly ignoreForbiddenWords?: boolean;
     readonly scope?: CustomDictionaryScope | CustomDictionaryScope[];
     readonly __source: string;
-    private ddi: DDI;
+    #ddi: DDI;
+    #def: DictionaryDefinition;
+
     constructor(
         def: DictionaryDefinition,
         readonly sourceURL: URL,
     ) {
+        this.#def = def;
         this.__source = sourceURL.href;
         // this bit of assignment is to have the compiler help use if any new fields are added.
         const defAll: DictDef = def;
@@ -218,7 +221,7 @@ class _DictionaryDefinitionInternalWithSource implements DictionaryFileDefinitio
         };
 
         Object.assign(this, clean(ddi));
-        this.ddi = ddi;
+        this.#ddi = ddi;
         this.name = ddi.name;
         this.file = ddi.file;
         this.path = ddi.path;
@@ -232,6 +235,10 @@ class _DictionaryDefinitionInternalWithSource implements DictionaryFileDefinitio
     }
 
     toJSON() {
-        return this.ddi;
+        return this.#ddi;
+    }
+
+    __getOriginalDefinition() {
+        return this.#def;
     }
 }

--- a/packages/cspell-lib/src/lib/Settings/internal/InternalDictionaryDef.ts
+++ b/packages/cspell-lib/src/lib/Settings/internal/InternalDictionaryDef.ts
@@ -1,32 +1,12 @@
 import type {
-    AdvancedCSpellSettingsWithSourceTrace,
-    CSpellSettingsWithSourceTrace,
     DictionaryDefinition,
     DictionaryDefinitionAugmented,
     DictionaryDefinitionCustom,
     DictionaryDefinitionInline,
     DictionaryDefinitionPreferred,
     DictionaryDefinitionSimple,
-    Parser,
 } from '@cspell/cspell-types';
 import type { WeightMap } from 'cspell-trie-lib';
-
-import type { OptionalOrUndefined } from '../util/types.js';
-import { clean } from '../util/util.js';
-
-export const SymbolCSpellSettingsInternal: unique symbol = Symbol('CSpellSettingsInternal');
-
-export interface CSpellSettingsInternal extends Omit<AdvancedCSpellSettingsWithSourceTrace, 'dictionaryDefinitions'> {
-    [SymbolCSpellSettingsInternal]: true;
-    dictionaryDefinitions?: DictionaryDefinitionInternal[];
-}
-
-export interface CSpellSettingsInternalFinalized extends CSpellSettingsInternal {
-    parserFn: Parser | undefined;
-    finalized: true;
-    ignoreRegExpList: RegExp[];
-    includeRegExpList: RegExp[];
-}
 
 type DictionaryDefinitionCustomUniqueFields = Omit<DictionaryDefinitionCustom, keyof DictionaryDefinitionPreferred>;
 
@@ -65,29 +45,6 @@ export interface DictionaryFileDefinitionInternalWithSource extends DictionaryFi
 export type DictionaryDefinitionInternalWithSource = DictionaryDefinitionInternal & {
     readonly __source: string;
 };
-
-export function cleanCSpellSettingsInternal(
-    parts?: OptionalOrUndefined<Partial<CSpellSettingsInternal>>,
-): CSpellSettingsInternal {
-    return parts
-        ? Object.assign(clean(parts), { [SymbolCSpellSettingsInternal]: true })
-        : { [SymbolCSpellSettingsInternal]: true };
-}
-
-export function createCSpellSettingsInternal(
-    parts?: OptionalOrUndefined<Partial<CSpellSettingsInternal>>,
-): CSpellSettingsInternal {
-    return cleanCSpellSettingsInternal({ ...parts });
-}
-
-export function isCSpellSettingsInternal(
-    cs:
-        | CSpellSettingsInternal
-        | CSpellSettingsWithSourceTrace
-        | OptionalOrUndefined<CSpellSettingsInternal | CSpellSettingsWithSourceTrace>,
-): cs is CSpellSettingsInternal {
-    return !!(<CSpellSettingsInternal>cs)[SymbolCSpellSettingsInternal];
-}
 
 export function isDictionaryDefinitionInlineInternal(
     def: DictionaryDefinitionInternal | DictionaryDefinitionInline | DictionaryDefinition,

--- a/packages/cspell-lib/src/lib/Settings/internal/index.ts
+++ b/packages/cspell-lib/src/lib/Settings/internal/index.ts
@@ -1,0 +1,14 @@
+export type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from './CSpellSettingsInternalDef.js';
+export {
+    cleanCSpellSettingsInternal,
+    createCSpellSettingsInternal,
+    isCSpellSettingsInternal,
+} from './CSpellSettingsInternalDef.js';
+export { calcDictionaryDefsToLoad, filterDictDefsToLoad, mapDictDefToInternal } from './DictionarySettings.js';
+export type {
+    DictionaryDefinitionInlineInternal,
+    DictionaryDefinitionInternal,
+    DictionaryDefinitionSimpleInternal,
+    DictionaryFileDefinitionInternal,
+} from './InternalDictionaryDef.js';
+export { isDictionaryDefinitionInlineInternal, isDictionaryFileDefinitionInternal } from './InternalDictionaryDef.js';

--- a/packages/cspell-lib/src/lib/Settings/sanitizeSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/sanitizeSettings.ts
@@ -9,9 +9,9 @@ import type {
     Source,
 } from '@cspell/cspell-types';
 
-import type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef.js';
 import type { Handlers } from '../util/clone.js';
 import { cloneInto, copy0, copy1, skip } from '../util/clone.js';
+import type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from './internal/index.js';
 
 type CloneableSettings = CSpellSettingsWithSourceTrace | CSpellSettingsInternal | CSpellSettingsInternalFinalized;
 

--- a/packages/cspell-lib/src/lib/Settings/util/settingsToJson.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/util/settingsToJson.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+
+import { walkToJSONObj } from './settingsToJson.js';
+
+describe('walkToJSONObj', () => {
+    test.each`
+        value        | expected
+        ${null}      | ${null}
+        ${undefined} | ${undefined}
+        ${true}      | ${true}
+        ${false}     | ${false}
+        ${42}        | ${42}
+        ${'hello'}   | ${'hello'}
+        ${/abc/i}    | ${'/abc/i'}
+        ${18n}       | ${18n}
+    `('walkToJSONObj basic $value', ({ value, expected }) => {
+        const result = walkToJSONObj(value);
+        expect(result).toBe(expected);
+    });
+
+    test.each`
+        value                  | expected
+        ${new String('hello')} | ${roundTripJSON(new String('hello'))}
+    `('walkToJSONObj  edge cases $value', ({ value, expected }) => {
+        const result = walkToJSONObj(value);
+        expect(result).toBe(expected);
+    });
+
+    test.each`
+        value         | expected
+        ${myFunc}     | ${undefined}
+        ${() => true} | ${undefined}
+        ${Date}       | ${undefined}
+        ${String}     | ${undefined}
+    `('walkToJSONObj function edge cases $value', ({ value, expected }) => {
+        const result = walkToJSONObj(value);
+        expect(result).toBe(expected);
+    });
+
+    function myFunc() {
+        return 'test';
+    }
+});
+
+function roundTripJSON(value: unknown): unknown {
+    return JSON.parse(JSON.stringify(value));
+}

--- a/packages/cspell-lib/src/lib/Settings/util/settingsToJson.ts
+++ b/packages/cspell-lib/src/lib/Settings/util/settingsToJson.ts
@@ -1,0 +1,49 @@
+/* eslint-disable unicorn/no-null */
+
+interface ToJSON {
+    toJSON(): unknown;
+}
+
+export function walkToJSONObj(value: unknown): unknown {
+    switch (typeof value) {
+        case 'string':
+        case 'number':
+        case 'boolean':
+        case 'undefined': {
+            return value;
+        }
+        case 'object': {
+            if (value === null) {
+                return null;
+            }
+            if ('toJSON' in value && typeof (value as ToJSON).toJSON === 'function') {
+                return (value as ToJSON).toJSON();
+            }
+            if (value instanceof RegExp) {
+                return value.toString();
+            }
+            if (value instanceof Map) {
+                return [...value.entries()].map(([key, val]) => [walkToJSONObj(key), walkToJSONObj(val)] as const);
+            }
+            if (value instanceof Set) {
+                return [...value.values()].map(walkToJSONObj);
+            }
+            if (value instanceof String) {
+                return value.toString();
+            }
+            if (Array.isArray(value)) {
+                return value.map(walkToJSONObj);
+            }
+            return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, walkToJSONObj(val)] as const));
+        }
+        case 'bigint': {
+            return value; // return as is for now
+        }
+        case 'function': {
+            return undefined; // `[function ${value.name || 'anonymous'}]`;
+        }
+        default: {
+            return undefined;
+        }
+    }
+}

--- a/packages/cspell-lib/src/lib/SpellingDictionary/Dictionaries.test.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/Dictionaries.test.ts
@@ -5,10 +5,10 @@ import type { CSpellUserSettings } from '@cspell/cspell-types';
 import { describe, expect, test } from 'vitest';
 
 import { pathPackageRoot } from '../../test-util/test.locations.js';
-import { createCSpellSettingsInternal as csi } from '../Models/CSpellSettingsInternalDef.js';
 import { createDictionaryReferenceCollection } from '../Settings/DictionaryReferenceCollection.js';
-import { filterDictDefsToLoad, mapDictDefToInternal } from '../Settings/DictionarySettings.js';
 import { getDefaultBundledSettingsAsync, loadConfig } from '../Settings/index.js';
+import { createCSpellSettingsInternal as csi } from '../Settings/index.js';
+import { filterDictDefsToLoad, mapDictDefToInternal } from '../Settings/index.js';
 import * as Dictionaries from './Dictionaries.js';
 import { isSpellingDictionaryLoadError } from './SpellingDictionaryError.js';
 

--- a/packages/cspell-lib/src/lib/SpellingDictionary/Dictionaries.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/Dictionaries.ts
@@ -8,8 +8,8 @@ import {
     createSuggestDictionary,
 } from 'cspell-dictionary';
 
-import type { CSpellSettingsInternal, DictionaryDefinitionInternal } from '../Models/CSpellSettingsInternalDef.js';
-import { calcDictionaryDefsToLoad } from '../Settings/DictionarySettings.js';
+import type { CSpellSettingsInternal, DictionaryDefinitionInternal } from '../Settings/index.js';
+import { calcDictionaryDefsToLoad } from '../Settings/index.js';
 import { isDefined } from '../util/util.js';
 import { loadDictionary, refreshCacheEntries } from './DictionaryLoader.js';
 

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.test.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.test.ts
@@ -9,8 +9,8 @@ import type {
     DictionaryDefinitionInlineInternal,
     DictionaryDefinitionInternal,
     DictionaryFileDefinitionInternal,
-} from '../../Models/CSpellSettingsInternalDef.js';
-import { mapDictDefToInternal } from '../../Settings/DictionarySettings.js';
+} from '../../Settings/index.js';
+import { mapDictDefToInternal } from '../../Settings/index.js';
 import { clean } from '../../util/util.js';
 import type { LoadOptions } from './DictionaryLoader.js';
 import { DictionaryLoader } from './DictionaryLoader.js';

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
@@ -11,17 +11,14 @@ import {
 import type { Stats, TextFileResource, VFileSystem } from 'cspell-io';
 import { compareStats, toFileURL, urlBasename } from 'cspell-io';
 
+import { measurePerfFn } from '../../perf/index.js';
 import type {
     DictionaryDefinitionInlineInternal,
     DictionaryDefinitionInternal,
     DictionaryDefinitionSimpleInternal,
     DictionaryFileDefinitionInternal,
-} from '../../Models/CSpellSettingsInternalDef.js';
-import {
-    isDictionaryDefinitionInlineInternal,
-    isDictionaryFileDefinitionInternal,
-} from '../../Models/CSpellSettingsInternalDef.js';
-import { measurePerfFn } from '../../perf/index.js';
+} from '../../Settings/index.js';
+import { isDictionaryDefinitionInlineInternal, isDictionaryFileDefinitionInternal } from '../../Settings/index.js';
 import { AutoResolveWeakCache, AutoResolveWeakWeakCache } from '../../util/AutoResolve.js';
 import { toError } from '../../util/errors.js';
 import { SimpleCache } from '../../util/simpleCache.js';

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryLoader.test.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryLoader.test.ts
@@ -5,11 +5,8 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, test, vi } from 'vitest';
 
 import { pathPackageRoot, pathPackageSamples } from '../../test-util/test.locations.js';
-import type {
-    DictionaryDefinitionInternal,
-    DictionaryFileDefinitionInternal,
-} from '../Models/CSpellSettingsInternalDef.js';
-import { mapDictDefToInternal } from '../Settings/DictionarySettings.js';
+import type { DictionaryDefinitionInternal, DictionaryFileDefinitionInternal } from '../Settings/index.js';
+import { mapDictDefToInternal } from '../Settings/index.js';
 import { clean } from '../util/util.js';
 import type { LoadOptions } from './DictionaryLoader.js';
 import { loadDictionary, refreshCacheEntries } from './DictionaryLoader.js';

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryLoader.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryLoader.ts
@@ -2,7 +2,7 @@ import type { SpellingDictionary } from 'cspell-dictionary';
 
 import type { VFileSystem } from '../fileSystem.js';
 import { getFileSystem } from '../fileSystem.js';
-import type { DictionaryDefinitionInternal } from '../Models/CSpellSettingsInternalDef.js';
+import type { DictionaryDefinitionInternal } from '../Settings/index.js';
 import { DictionaryLoader } from './DictionaryController/index.js';
 export type { LoadOptions } from './DictionaryController/index.js';
 

--- a/packages/cspell-lib/src/lib/spellCheckFile.test.ts
+++ b/packages/cspell-lib/src/lib/spellCheckFile.test.ts
@@ -11,7 +11,7 @@ import { pathPackageSamples, pathRepoTestFixtures } from '../test-util/index.mjs
 import { extendExpect } from '../test-util/test.matchers.mjs';
 import type { Document } from './Document/index.js';
 import { fileToDocument, fileToTextDocument } from './Document/resolveDocument.js';
-import type { CSpellSettingsInternal } from './Models/CSpellSettingsInternalDef.js';
+import type { CSpellSettingsInternal } from './Settings/index.js';
 import type { SpellCheckFileOptions, SpellCheckFileResult } from './spellCheckFile.js';
 import { determineFinalDocumentSettings, spellCheckDocument, spellCheckFile } from './spellCheckFile.js';
 import * as Uri from './util/Uri.js';

--- a/packages/cspell-lib/src/lib/textValidation/determineTextDocumentSettings.ts
+++ b/packages/cspell-lib/src/lib/textValidation/determineTextDocumentSettings.ts
@@ -3,8 +3,8 @@ import * as path from 'node:path';
 import type { CSpellUserSettings } from '@cspell/cspell-types';
 
 import { getLanguagesForBasename } from '../fileTypes.js';
-import type { CSpellSettingsInternal } from '../Models/CSpellSettingsInternalDef.js';
 import type { TextDocument, TextDocumentRef } from '../Models/TextDocument.js';
+import type { CSpellSettingsInternal } from '../Settings/index.js';
 import { calcOverrideSettings, getDefaultSettings, getGlobalSettingsAsync, mergeSettings } from '../Settings/index.js';
 import { combineTextAndLanguageSettings } from '../Settings/TextDocumentSettings.js';
 import { uriToFilePath } from '../util/Uri.js';

--- a/packages/cspell-lib/src/lib/textValidation/docValidator.ts
+++ b/packages/cspell-lib/src/lib/textValidation/docValidator.ts
@@ -14,13 +14,13 @@ import type { ICSpellConfigFile } from 'cspell-config-lib';
 import { satisfiesCSpellConfigFile } from 'cspell-config-lib';
 
 import { getGlobMatcherForExcluding } from '../globs/getGlobMatcher.js';
-import type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef.js';
 import type { ExtendedSuggestion } from '../Models/Suggestion.js';
 import type { TextDocument, TextDocumentLine, TextDocumentRef } from '../Models/TextDocument.js';
 import { documentUriToURL, updateTextDocument } from '../Models/TextDocument.js';
 import type { ValidationIssue } from '../Models/ValidationIssue.js';
 import { createPerfTimer, measurePerf } from '../perf/index.js';
 import type { ImportFileRefWithError } from '../Settings/index.js';
+import type { CSpellSettingsInternal, CSpellSettingsInternalFinalized } from '../Settings/index.js';
 import {
     extractImportErrors,
     finalizeSettings,

--- a/packages/cspell-lib/src/lib/textValidation/settingsToValidateOptions.ts
+++ b/packages/cspell-lib/src/lib/textValidation/settingsToValidateOptions.ts
@@ -1,4 +1,4 @@
-import type { CSpellSettingsInternalFinalized } from '../Models/CSpellSettingsInternalDef.js';
+import type { CSpellSettingsInternalFinalized } from '../Settings/index.js';
 import type { ValidationOptions } from './ValidationTypes.js';
 
 export function settingsToValidateOptions(settings: CSpellSettingsInternalFinalized): ValidationOptions {

--- a/packages/cspell-lib/src/lib/textValidation/textValidator.test.ts
+++ b/packages/cspell-lib/src/lib/textValidation/textValidator.test.ts
@@ -3,8 +3,8 @@ import { type CSpellUserSettings, type TextOffset, unknownWordsChoices } from '@
 import { createInlineSpellingDictionary, createSuggestDictionary } from 'cspell-dictionary';
 import { describe, expect, test } from 'vitest';
 
-import { createCSpellSettingsInternal as csi } from '../Models/CSpellSettingsInternalDef.js';
 import { finalizeSettings } from '../Settings/index.js';
+import { createCSpellSettingsInternal as csi } from '../Settings/index.js';
 import type { SpellingDictionaryOptions } from '../SpellingDictionary/index.js';
 import { createCollection, createSpellingDictionary, getDictionaryInternal } from '../SpellingDictionary/index.js';
 import { FreqCounter } from '../util/FreqCounter.js';

--- a/packages/cspell-lib/src/lib/trace.ts
+++ b/packages/cspell-lib/src/lib/trace.ts
@@ -4,8 +4,8 @@ import { satisfiesCSpellConfigFile } from 'cspell-config-lib';
 import { genSequence } from 'gensequence';
 
 import type { LanguageId } from './fileTypes.js';
-import type { CSpellSettingsInternal } from './Models/CSpellSettingsInternalDef.js';
 import { toInternalSettings } from './Settings/CSpellSettingsServer.js';
+import type { CSpellSettingsInternal } from './Settings/index.js';
 import { finalizeSettings, mergeSettings, resolveConfigFileImports } from './Settings/index.js';
 import { calcSettingsForLanguageId } from './Settings/LanguageSettings.js';
 import type { SpellingDictionaryCollection } from './SpellingDictionary/index.js';


### PR DESCRIPTION
## Pull request overview

This pull request refactors the internal settings structure by reorganizing code from `Models/CSpellSettingsInternalDef.js` into a new `Settings/internal/` directory structure. This improves code organization by collocating internal settings definitions with other settings-related code.

**Changes:**
- Created new `Settings/internal/` directory with split files: `CSpellSettingsInternalDef.ts`, `InternalDictionaryDef.ts`, and `DictionarySettings.ts` (with improved private field syntax)
- Updated all import paths across the codebase from `Models/CSpellSettingsInternalDef` to `Settings/internal/` or `Settings/index`
- Added new utility function `walkToJSONObj` for JSON serialization (with comprehensive tests) and `__getOriginalDefinition()` method for accessing original dictionary definitions
