### PR TITLE
Fix: follow up missing rename in #5600

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -1115,11 +1115,11 @@
           "type": "string"
         },
         "dictionaries": {
-          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "items": {
             "$ref": "#/definitions/DictionaryReference"
           },
-          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "type": "array"
         },
         "dictionaryDefinitions": {
@@ -1293,11 +1293,11 @@
           "type": "string"
         },
         "dictionaries": {
-          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "items": {
             "$ref": "#/definitions/DictionaryReference"
           },
-          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "type": "array"
         },
         "dictionaryDefinitions": {
@@ -1833,11 +1833,11 @@
       "type": "string"
     },
     "dictionaries": {
-      "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+      "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
       "items": {
         "$ref": "#/definitions/DictionaryReference"
       },
-      "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+      "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
       "type": "array"
     },
     "dictionaryDefinitions": {

--- a/packages/cspell-eslint-plugin/src/generated/schema.cts
+++ b/packages/cspell-eslint-plugin/src/generated/schema.cts
@@ -88,7 +88,7 @@ export const optionsSchema: Rule.RuleMetaData['schema'] = {
           "type": "boolean"
         },
         "dictionaries": {
-          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "items": {
             "anyOf": [
               {
@@ -107,7 +107,7 @@ export const optionsSchema: Rule.RuleMetaData['schema'] = {
             "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
             "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
           },
-          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "type": "array"
         },
         "dictionaryDefinitions": {

--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -1773,7 +1773,7 @@ interface BaseSetting extends InlineDictionary, ExperimentalBaseSettings, Unknow
   * For example, `!typescript` will turn off the dictionary with the name `typescript`.
   *
   * See the [Dictionaries](https://cspell.org/docs/dictionaries/)
-  * and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.
+  * and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.
   */
   dictionaries?: DictionaryReference[];
   /**

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -1115,11 +1115,11 @@
           "type": "string"
         },
         "dictionaries": {
-          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "items": {
             "$ref": "#/definitions/DictionaryReference"
           },
-          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "type": "array"
         },
         "dictionaryDefinitions": {
@@ -1293,11 +1293,11 @@
           "type": "string"
         },
         "dictionaries": {
-          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "items": {
             "$ref": "#/definitions/DictionaryReference"
           },
-          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
           "type": "array"
         },
         "dictionaryDefinitions": {
@@ -1833,11 +1833,11 @@
       "type": "string"
     },
     "dictionaries": {
-      "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+      "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
       "items": {
         "$ref": "#/definitions/DictionaryReference"
       },
-      "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.",
+      "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
       "type": "array"
     },
     "dictionaryDefinitions": {

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -503,7 +503,7 @@ export interface BaseSetting extends InlineDictionary, ExperimentalBaseSettings,
      * For example, `!typescript` will turn off the dictionary with the name `typescript`.
      *
      * See the [Dictionaries](https://cspell.org/docs/dictionaries/)
-     * and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.
+     * and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.
      */
     dictionaries?: DictionaryReference[];
 

--- a/test-fixtures/perf/cspell-glob/data/file-list.txt
+++ b/test-fixtures/perf/cspell-glob/data/file-list.txt
@@ -38,8 +38,8 @@ docs/docs/command-check.md;5;false
 docs/docs/command-check.md;6;false
 docs/docs/dictionaries/searching-dictionaries.md;5;false
 docs/docs/dictionaries/searching-dictionaries.md;6;false
-docs/docs/dictionaries-custom.md;5;false
-docs/docs/dictionaries-custom.md;6;false
+docs/docs/dictionaries/custom-dictionaries.md;5;false
+docs/docs/dictionaries/custom-dictionaries.md;6;false
 docs/docs/dictionaries.md;5;false
 docs/docs/dictionaries.md;6;false
 docs/docs/forbidden-words.md;5;false
@@ -2051,7 +2051,7 @@ docs/configuration/template.md;3;false
 docs/docs/case-sensitive.md;3;false
 docs/docs/command-check.md;3;false
 docs/docs/dictionaries/searching-dictionaries.md;3;false
-docs/docs/dictionaries-custom.md;3;false
+docs/docs/dictionaries/custom-dictionaries.md;3;false
 docs/docs/dictionaries.md;3;false
 docs/docs/forbidden-words.md;3;false
 docs/docs/getting-started.md;3;false

--- a/website/docs/Configuration/auto_properties.md
+++ b/website/docs/Configuration/auto_properties.md
@@ -227,7 +227,7 @@ To remove a dictionary from the list, add `!` before the name.
 For example, `!typescript` will turn off the dictionary with the name `typescript`.
 
 See the [Dictionaries](https://cspell.org/docs/dictionaries/)
-and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.
+and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.
 
 </dd>
 
@@ -5486,7 +5486,7 @@ It is expected to match the name of a dictionary.
 
 Reference to a dictionary by name.
 One of:
--  [DictionaryRef](#dictionaryref) 
+-  [DictionaryRef](#dictionaryref)
 -  [DictionaryNegRef](#dictionarynegref)
 
 </dd>
@@ -6135,7 +6135,7 @@ To remove a dictionary from the list, add `!` before the name.
 For example, `!typescript` will turn off the dictionary with the name `typescript`.
 
 See the [Dictionaries](https://cspell.org/docs/dictionaries/)
-and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.
+and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.
 
 </dd>
 
@@ -6858,7 +6858,7 @@ To remove a dictionary from the list, add `!` before the name.
 For example, `!typescript` will turn off the dictionary with the name `typescript`.
 
 See the [Dictionaries](https://cspell.org/docs/dictionaries/)
-and [Custom Dictionaries](https://cspell.org/docs/dictionaries-custom/) for more details.
+and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.
 
 </dd>
 
@@ -8486,4 +8486,3 @@ Legacy Configuration File Versions.
 </dd>
 
 </dl>
-


### PR DESCRIPTION
This PR is a follow-up to #5600, which renamed several documentation files but left some references still pointing to the old paths.

In #5600, the following file renames were introduced:

```sh
$ git show --format= --diff-filter=R --stat b431dcab # SHA of merged commit of #5600
 website/docs/{dictionaries-custom.md => dictionaries/custom-dictionaries.md} | 3 ++-
 website/docs/{dictionaries.md => dictionaries/index.md}                      | 5 +++--
 website/docs/{command-trace.md => dictionaries/searching-dictionaries.md}    | 3 ++-
 3 files changed, 7 insertions(+), 4 deletions(-)
```

However, some references were not updated.

For example, on the page https://cspell.org/docs/Configuration/properties#settings-dictionaries, the “Custom Dictionaries” link still points to the the pre-rename URL: https://cspell.org/docs/dictionaries-custom/ .

<details>
  <summary>Screenshot</summary>
  <img width="713" height="326" alt="image" src="https://github.com/user-attachments/assets/10562da0-74db-4c4f-8be0-1869833770a0" />
</details>

## What this PR does

This PR completes the remaining renames by updating references via global replacement. The changes include:

### Links in JSON schemas
- `cspell.schema.json`
- `packages/cspell-eslint-plugin/src/generated/schema.cts`
- `packages/cspell-types/cspell.schema.json`

### Links in API JSDoc
- `packages/cspell-lib/api/api.d.ts`
- `packages/cspell-types/src/CSpellSettingsDef.ts`

### Text fixtures
- `test-fixtures/perf/cspell-glob/data/file-list.txt`

The text fixture changes are not required for tests to pass, but are included for consistency and completeness.

### Broken link
- `website/docs/Configuration/auto_properties.md`


## Notes
- The changes are split into two commits, each handling a specific rename for clarity.
- The rename `website/docs/dictionaries.md → dictionaries/index.md` does not require updates to references, so it is not modified here.
