### PR TITLE
fix: add --no-dictionary option to lint command

### DIFF
--- a/packages/cspell/src/__snapshots__/app.test.ts.snap
+++ b/packages/cspell/src/__snapshots__/app.test.ts.snap
@@ -4677,6 +4677,8 @@ exports[`Validate cli > app help [ 'lint', '--help', '--verbose' ] 1`] = `
   "  --no-validate-directives       Do not validate in-document CSpell directives.",
   "  --default-configuration        Load the default configuration and",
   "                                 dictionaries.",
+  "  --no-dictionary <name>         Disable a dictionary by name. Can be used",
+  "                                 multiple times.",
   "  --skip-validation              Collect and process documents, but do not spell",
   "                                 check.",
   "  --issues-summary-report        Output a summary of issues found.",
@@ -4797,6 +4799,21 @@ exports[`Validate cli > app help [ 'trace', '--help' ] 1`] = `
 
 exports[`Validate cli > app help [ 'trace', '--help' ] 2`] = `""`;
 
+exports[`Validate cli > app lint 'lint --dictionary=!words' Expect Error: [Function CheckFailed] 1`] = `[]`;
+
+exports[`Validate cli > app lint 'lint --dictionary=!words' Expect Error: [Function CheckFailed] 2`] = `
+"error	1/1 README.md 0.00ms X
+error
+log	README.md:7:3 - Unknown word (winkelcentrum)
+log
+log	README.md:8:3 - Unknown word (winkelstraat)
+log
+error	CSpell: Files checked: 1, Issues found: 2 in 1 file.
+error"
+`;
+
+exports[`Validate cli > app lint 'lint --dictionary=!words' Expect Error: [Function CheckFailed] 3`] = `""`;
+
 exports[`Validate cli > app lint 'lint --disable-dictionary --enable-dictionary' Expect Error: undefined 1`] = `[]`;
 
 exports[`Validate cli > app lint 'lint --disable-dictionary --enable-dictionary' Expect Error: undefined 2`] = `
@@ -4822,6 +4839,21 @@ error"
 `;
 
 exports[`Validate cli > app lint 'lint --disable-dictionary' Expect Error: [Function CheckFailed] 3`] = `""`;
+
+exports[`Validate cli > app lint 'lint --no-dictionary=words' Expect Error: [Function CheckFailed] 1`] = `[]`;
+
+exports[`Validate cli > app lint 'lint --no-dictionary=words' Expect Error: [Function CheckFailed] 2`] = `
+"error	1/1 README.md 0.00ms X
+error
+log	README.md:7:3 - Unknown word (winkelcentrum)
+log
+log	README.md:8:3 - Unknown word (winkelstraat)
+log
+error	CSpell: Files checked: 1, Issues found: 2 in 1 file.
+error"
+`;
+
+exports[`Validate cli > app lint 'lint --no-dictionary=words' Expect Error: [Function CheckFailed] 3`] = `""`;
 
 exports[`Validate cli > app suggest [ 'sug' ] 1`] = `
 [

--- a/packages/cspell/src/app.test.ts
+++ b/packages/cspell/src/app.test.ts
@@ -168,6 +168,7 @@ describe('Validate cli', () => {
 
     const argDict = (dict: string) => `--dictionary=${dict}`;
     const argDDict = (dict: string) => `--disable-dictionary=${dict}`;
+    const argNDict = (dict: string) => `--no-dictionary=${dict}`;
 
     beforeEach(() => {
         mockCreateInterface.mockClear();
@@ -300,6 +301,8 @@ describe('Validate cli', () => {
     test.each`
         msg                                                | testArgs                                                                 | errorCheck         | eError  | eLog     | eInfo    | notes
         ${'lint --disable-dictionary'}                     | ${[rpFeat('dictionaries'), argDDict('words'), '*.md']}                   | ${app.CheckFailed} | ${true} | ${true}  | ${false} | ${'Disable dictionary words'}
+        ${'lint --dictionary=!words'}                      | ${[rpFeat('dictionaries'), argDict('!words'), '*.md']}                   | ${app.CheckFailed} | ${true} | ${true}  | ${false} | ${'Disable --dictionary=!words'}
+        ${'lint --no-dictionary=words'}                    | ${[rpFeat('dictionaries'), argNDict('words'), '*.md']}                   | ${app.CheckFailed} | ${true} | ${true}  | ${false} | ${'Disable --no-dictionary=words'}
         ${'lint --disable-dictionary --enable-dictionary'} | ${[rpFeat('dictionaries'), argDDict('words'), argDict('words'), '*.md']} | ${undefined}       | ${true} | ${false} | ${false} | ${'Disable and reenable dictionary words'}
     `('app lint $msg Expect Error: $errorCheck', async ({ testArgs, errorCheck, eError, eLog, eInfo }: TestCase) => {
         chalk.level = 1;

--- a/packages/cspell/src/commandHelpers.ts
+++ b/packages/cspell/src/commandHelpers.ts
@@ -12,6 +12,18 @@ export function collect(value: string | string[], previous: string[] | undefined
 }
 
 /**
+ * Collects string values into an array, prefixing each value with the given prefix.
+ * @param prefix the prefix to add to each value.
+ * @returns a function that collects values with the given prefix.
+ */
+export function prefixCollect(prefix: string): (value: string | string[], previous: string[] | undefined) => string[] {
+    return (value: string | string[], previous: string[] | undefined): string[] => {
+        const values = (Array.isArray(value) ? value : [value]).map((v) => prefix + v);
+        return previous ? [...previous, ...values] : values;
+    };
+}
+
+/**
  * Create Option - a helper function to create a commander option.
  * @param name - the name of the option
  * @param description - the description of the option

--- a/packages/cspell/src/commandLint.ts
+++ b/packages/cspell/src/commandLint.ts
@@ -1,7 +1,7 @@
 import type { AddHelpTextContext, Command, CommandOptions } from 'commander';
 
 import * as App from './application.mjs';
-import { collect, crOpt } from './commandHelpers.js';
+import { collect, crOpt, prefixCollect } from './commandHelpers.js';
 import type { LinterCliCommandOptions } from './options.js';
 import { cvtLinterCliCommandOptionsToLinterCliOptions, type LinterCliOptions, ReportChoicesAll } from './options.js';
 import { DEFAULT_CACHE_LOCATION } from './util/cache/index.js';
@@ -172,6 +172,13 @@ export function commandLint(prog: Command, opts: CommandOptions): Command {
         .addOption(crOpt('--default-configuration', 'Load the default configuration and dictionaries.').hideHelp())
         .addOption(crOpt('--no-default-configuration', 'Do not load the default configuration and dictionaries.'))
         .option('--dictionary <name>', 'Enable a dictionary by name.', collect)
+        .addOption(
+            crOpt(
+                '--no-dictionary <name>',
+                'Disable a dictionary by name. Can be used multiple times.',
+                prefixCollect('!'),
+            ).hideHelp(),
+        )
         .option('--disable-dictionary <name>', 'Disable a dictionary by name.', collect)
         .option('--reporter <module|path>', 'Specify one or more reporters to use.', collect)
         .addOption(crOpt('--report <level>', 'Set how unknown words are reported').choices(ReportChoicesAll))

--- a/packages/cspell/src/commandTrace.ts
+++ b/packages/cspell/src/commandTrace.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import { Option as CommanderOption } from 'commander';
 
 import * as App from './application.mjs';
-import { collect } from './commandHelpers.js';
+import { collect, prefixCollect } from './commandHelpers.js';
 import { console } from './console.js';
 import { isDictionaryPathFormat } from './emitters/DictionaryPathFormat.js';
 import { emitTraceResults } from './emitters/traceEmitter.js';
@@ -102,13 +102,6 @@ export function commandTrace(prog: Command): Command {
                 throw new CheckFailed('no matches', 1);
             }
         });
-}
-
-function prefixCollect(prefix: string): (value: string | string[], previous: string[] | undefined) => string[] {
-    return (value: string | string[], previous: string[] | undefined): string[] => {
-        const values = (Array.isArray(value) ? value : [value]).map((v) => prefix + v);
-        return previous ? [...previous, ...values] : values;
-    };
 }
 
 function filterTraceResults(results: App.TraceResult[], options: TraceCommandOptions): App.TraceResult[] {


### PR DESCRIPTION
## Pull request overview

This PR adds the `--no-dictionary` option to the lint command and refactors the `prefixCollect` helper function for reuse across commands.

**Changes:**
- Moved `prefixCollect` function from `commandTrace.ts` to `commandHelpers.ts` for reuse
- Added `--no-dictionary` option to the lint command (hidden, as an alias for `--disable-dictionary`)
- Added comprehensive tests for the new option including `--dictionary=!words` and `--no-dictionary=words` syntax
