### PR TITLE
fix(docs): replace `.json` with `package.json` in configuration docs

### DIFF
--- a/website/docs/Configuration/index.mdx
+++ b/website/docs/Configuration/index.mdx
@@ -124,7 +124,7 @@ Or you can specify a path to a config file with the `--config <path>` argument o
 ## `package.json`
 
 It is possible to store CSpell configuration in the `package.json` file of a project. CSpell looks
-for the configuration in the `cspell` field of the `.json` file.
+for the configuration in the `cspell` field of the `package.json` file.
 
 ```js
 {


### PR DESCRIPTION
## Fix

In the `package.json` configuration section, the sentence referred to 
"the `.json` file" instead of "the `package.json` file".

Before: "CSpell looks for the configuration in the `cspell` field of the `.json` file."
After:  "CSpell looks for the configuration in the `cspell` field of the `package.json` file."