### PR TITLE
chore: fix labeler when it comes from a fork

### DIFF
--- a/.github/workflows/release-drafter-labeler.yml
+++ b/.github/workflows/release-drafter-labeler.yml
@@ -1,11 +1,8 @@
 name: ' 🛝 Release Drafter Labeler'
 
 on:
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
+  pull_request_target:
     types: [opened, reopened, synchronize]
-  # Run on demand
 
 permissions:
   contents: read
@@ -17,13 +14,6 @@ jobs:
       pull-requests: write # for release-drafter/release-drafter to add label to PR
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
       - id: release-drafter-labeler
         uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # cspell:ignore auto* *labeler

--- a/.github/workflows/release-drafter-labeler.yml
+++ b/.github/workflows/release-drafter-labeler.yml
@@ -16,4 +16,6 @@ jobs:
     steps:
       - id: release-drafter-labeler
         uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # cspell:ignore auto* *labeler


### PR DESCRIPTION
Fix Error when running workflow via a PR from a fork.

<img width="917" height="360" alt="image" src="https://github.com/user-attachments/assets/93286a5a-f0bd-4998-94ec-220be4573261" />


The failure is caused by insufficient token permissions for this workflow on `pull_request` events from forks.

**What failed**
- Log: `Resource not accessible by integration - https://docs.github.com/rest/issues/labels#add-labels-to-an-issue`
- Workflow: [` .github/workflows/release-drafter-labeler.yml`](https://github.com/streetsidesoftware/cspell/blob/5a05c8b9a9ffa5a1f6bb5980c7ab7f6a70a597d8/.github/workflows/release-drafter-labeler.yml)
- Failing step: `release-drafter/release-drafter/autolabeler`
- The workflow currently grants:
  - top-level `contents: read`
  - job-level `pull-requests: write`

That permission block is correct for same-repo PRs, but on forked PRs GitHub provides a read-only token to `pull_request` workflows. Because the action tries to add a label to the PR, the API call is rejected.

## Solution

Run the labeler under `pull_request_target` instead of `pull_request`.

That event runs in the base repository context, so `GITHUB_TOKEN` can write labels on the PR.

### Suggested change

Replace:

```yaml
on:
  pull_request:
    types: [opened, reopened, synchronize]
```

with:

```yaml
on:
  pull_request_target:
    types: [opened, reopened, synchronize]
```

## Updated workflow

```yaml
name: ' 🛝 Release Drafter Labeler'

on:
  pull_request_target:
    types: [opened, reopened, synchronize]

permissions:
  contents: read

jobs:
  update_pr_labels:
    if: github.repository_owner == 'streetsidesoftware'
    permissions:
      pull-requests: write
    runs-on: ubuntu-latest
    steps:
      - id: release-drafter-labeler
        uses: release-drafter/release-drafter/autolabeler@c2e2804cc59f45f57076a99af580d0fedb697927
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

## Why this fixes it
The action only needs PR metadata and title/body files from the base repo config; it is not checking out and executing untrusted PR code. That makes `pull_request_target` the appropriate event for this labeling use case.

## Important safety note
Keep the workflow limited to metadata-based actions only. Do **not** add a checkout of PR head code or run PR-provided scripts in this workflow after switching to `pull_request_target`, because that event has elevated permissions.

## Optional hardening
If you want to be extra explicit, you can keep permissions minimal:

```yaml
permissions:
  contents: read
  pull-requests: write
```

and remove the job-level permissions block, or leave the current split as-is.

In short: **change the trigger from `pull_request` to `pull_request_target`** in [` .github/workflows/release-drafter-labeler.yml`](https://github.com/streetsidesoftware/cspell/blob/5a05c8b9a9ffa5a1f6bb5980c7ab7f6a70a597d8/.github/workflows/release-drafter-labeler.yml). That addresses the exact permission error shown in the failing job log.