### PR TITLE
fix: Handle Windows UNC Long Path Names

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -39,7 +39,6 @@
         "**/.docusaurus/**",
         "**/.gitignore",
         "**/.vscode/**",
-        "**/{cspell.*,cSpell.*,.cspell.*,cspell.config.*}",
         "**/*.schema.json",
         "**/*.snap",
         "**/*.trie",

--- a/packages/cspell-url/fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats/very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt
+++ b/packages/cspell-url/fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats/very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt
@@ -1,6 +1,0 @@
-This is a test file for testing long path handling in cspell-url and cspell-io utilities.
-
-Reference: https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
-
-The filename is:
-very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt

--- a/packages/cspell-url/fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats/very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt
+++ b/packages/cspell-url/fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats/very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt
@@ -1,0 +1,6 @@
+This is a test file for testing long path handling in cspell-url and cspell-io utilities.
+
+Reference: https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+
+The filename is:
+very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt

--- a/packages/cspell-url/src/FileUrlBuilder.mts
+++ b/packages/cspell-url/src/FileUrlBuilder.mts
@@ -3,7 +3,9 @@ import Path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import {
+    fixLongPathPrefix,
     isFileURL,
+    isUncPath,
     isWindows,
     isWindowsFileUrl,
     isWindowsPathnameWithDriveLatter,
@@ -158,6 +160,9 @@ export class FileUrlBuilder {
         if (typeof filenameOrUrl !== 'string') return filenameOrUrl;
         if (isUrlLike(filenameOrUrl)) return normalizeWindowsUrl(new URL(filenameOrUrl));
         relativeTo ??= this.cwd;
+        if (isWindows && isUncPath(filenameOrUrl)) {
+            return pathToFileURL(fixLongPathPrefix(filenameOrUrl));
+        }
         isWindows && (filenameOrUrl = filenameOrUrl.replaceAll('\\', '/'));
         if (this.isAbsolute(filenameOrUrl) && isFileURL(relativeTo)) {
             const pathname = this.normalizeFilePathForUrl(filenameOrUrl);

--- a/packages/cspell-url/src/FileUrlBuilder.test.mts
+++ b/packages/cspell-url/src/FileUrlBuilder.test.mts
@@ -14,7 +14,7 @@ const packageRoot = fileURLToPath(packageRootUrl);
 const fixtureLongPath = 'fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats';
 const longFilename209 = `\
 very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-\
-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt\
+that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.log\
 `;
 // https://github.com/streetsidesoftware/vscode-spell-checker/issues/4978
 const longFilenameIssue4978 = `\

--- a/packages/cspell-url/src/FileUrlBuilder.test.mts
+++ b/packages/cspell-url/src/FileUrlBuilder.test.mts
@@ -3,9 +3,26 @@ import url, { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { describe, expect, test } from 'vitest';
 
-import { pathWindowsDriveLetterToUpper } from './fileUrl.mts';
+import { addLongPathPrefix, addLongPathPrefixAlt, pathWindowsDriveLetterToUpper } from './fileUrl.mts';
 import type { ParsedPath } from './FileUrlBuilder.mts';
 import { FileUrlBuilder } from './FileUrlBuilder.mts';
+
+const thisFilePath = fileURLToPath(import.meta.url);
+
+const packageRootUrl = new URL('../', import.meta.url);
+const packageRoot = fileURLToPath(packageRootUrl);
+const fixtureLongPath = 'fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats';
+const longFilename209 = `\
+very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-\
+that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt\
+`;
+// https://github.com/streetsidesoftware/vscode-spell-checker/issues/4978
+const longFilenameIssue4978 = `\
+Engineering/Programming/Aerials/LCS Y2020/y2020_controller/local_builds/2512/251216/RNE_Aerial_Dev/162221_5cf5637b6_cmorris\
+/23461B-001_ID025_Aux_Control_Platform_Leveling_Y2020_TTC2310/23461B-001_ID025_Aux_Control_Platform_Leveling_Y2020_TTC2310_controller.log\
+`;
+
+// cspell:ignore cmorris
 
 describe('FileUrlBuilder', () => {
     test('FileUrlBuilder', () => {
@@ -74,14 +91,31 @@ describe('FileUrlBuilder', () => {
     });
 
     test.each`
-        filePath                                  | expected
-        ${'.'}                                    | ${pathWindowsDriveLetterToUpper(process.cwd() + Path.sep)}
-        ${'e:/path/to/file.txt'}                  | ${'E:/path/to/file.txt'.split('/').join(Path.sep)}
-        ${'file:///e:/user/test/project/deeper/'} | ${'E:/user/test/project/deeper/'.split('/').join(Path.sep)}
-        ${'vscode:///e:/user/test/project/'}      | ${'vscode:///e:/user/test/project/'}
+        filePath                                                             | expected
+        ${'.'}                                                               | ${pathWindowsDriveLetterToUpper(process.cwd() + Path.sep)}
+        ${'e:/path/to/file.txt'}                                             | ${'E:/path/to/file.txt'.split('/').join(Path.sep)}
+        ${'file:///e:/user/test/project/deeper/'}                            | ${'E:/user/test/project/deeper/'.split('/').join(Path.sep)}
+        ${'vscode:///e:/user/test/project/'}                                 | ${'vscode:///e:/user/test/project/'}
+        ${Path.resolve(packageRoot, fixtureLongPath, longFilename209)}       | ${Path.resolve(packageRoot, fixtureLongPath, longFilename209)}
+        ${Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978)} | ${Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978)}
     `('urlToFilePathOrHref $filePath', ({ filePath, expected }) => {
         const builder = new FileUrlBuilder();
         expect(builder.urlToFilePathOrHref(builder.toFileURL(filePath))).toEqual(expected);
+    });
+
+    test.each`
+        filePath                                                                                   | expected
+        ${thisFilePath}                                                                            | ${new URL(import.meta.url).pathname}
+        ${Path.resolve(packageRoot, fixtureLongPath, longFilename209)}                             | ${pathToFileURL(Path.resolve(packageRoot, fixtureLongPath, longFilename209)).pathname}
+        ${Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978)}                       | ${pathToFileURL(Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978)).pathname}
+        ${addLongPathPrefix(Path.resolve(packageRoot, fixtureLongPath, longFilename209))}          | ${pathToFileURL(Path.resolve(packageRoot, fixtureLongPath, longFilename209)).pathname}
+        ${addLongPathPrefix(Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978))}    | ${pathToFileURL(Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978)).pathname}
+        ${addLongPathPrefixAlt(Path.resolve(packageRoot, fixtureLongPath, longFilename209))}       | ${pathToFileURL(Path.resolve(packageRoot, fixtureLongPath, longFilename209)).pathname}
+        ${addLongPathPrefixAlt(Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978))} | ${pathToFileURL(Path.resolve(packageRoot, fixtureLongPath, longFilenameIssue4978)).pathname}
+    `('toFileURL long unc prefix $filePath', async ({ filePath, expected }) => {
+        const builder = new FileUrlBuilder();
+        const url = builder.toFileURL(filePath);
+        expect(url.pathname).toEqual(expected);
     });
 
     test('ParsedPath matches Path.ParsedPath', () => {

--- a/packages/cspell-url/src/fileUrl.mts
+++ b/packages/cspell-url/src/fileUrl.mts
@@ -97,7 +97,7 @@ function addLongPathPrefixForce(path: string): string {
 
 /**
  * Add the long path prefix to a path if it is not already present. This is needed to access paths longer than 260 characters on Windows.
- * This function uses the alternative long path prefix (`\\?\UNC\` for UNC paths and `\\?\` for local paths).
+ * This function uses the standard long path prefix (`\\?\UNC\` for UNC paths and `\\?\` for local paths).
  *
  * For non-windows platforms, this function returns the path unchanged.
  * @param path

--- a/packages/cspell-url/src/fileUrl.mts
+++ b/packages/cspell-url/src/fileUrl.mts
@@ -65,3 +65,76 @@ const regExpWindowsFileUrl = /^file:\/\/\/[a-zA-Z]:\//;
 export function isWindowsFileUrl(url: URL | string): boolean {
     return regExpWindowsFileUrl.test(url.toString());
 }
+
+export const uncLongPathPrefix = '\\\\?\\';
+export const uncLongPathPrefixAlt = '\\\\.\\'; // Note this does not work in nodejs. But it is a valid long path prefix in Windows.
+
+const uncWithLongPathPrefix = uncLongPathPrefix + 'UNC\\';
+const uncWithLongPathPrefixAlt = uncLongPathPrefixAlt + 'UNC\\';
+
+export function isUncPath(path: string): boolean {
+    return path.startsWith('\\\\');
+}
+
+export function hasLongPathPrefix(path: string): boolean {
+    return path.startsWith(uncLongPathPrefix);
+}
+
+export function hasLongPathPrefixAlt(path: string): boolean {
+    return path.startsWith(uncLongPathPrefixAlt);
+}
+
+function addLongPathPrefixForce(path: string): string {
+    if (hasLongPathPrefix(path)) return path;
+    if (hasLongPathPrefixAlt(path)) {
+        return fixLongPathPrefix(path);
+    }
+    if (isUncPath(path)) {
+        return uncWithLongPathPrefix + path.slice(2);
+    }
+    return uncLongPathPrefix + path;
+}
+
+/**
+ * Add the long path prefix to a path if it is not already present. This is needed to access paths longer than 260 characters on Windows.
+ * This function uses the alternative long path prefix (`\\?\UNC\` for UNC paths and `\\?\` for local paths).
+ *
+ * For non-windows platforms, this function returns the path unchanged.
+ * @param path
+ * @returns the path with the long path prefix added if needed.
+ */
+export function addLongPathPrefix(path: string): string {
+    if (!isWindows) return path;
+    return addLongPathPrefixForce(path);
+}
+
+function addLongPathPrefixAltForce(path: string): string {
+    if (hasLongPathPrefix(path) || hasLongPathPrefixAlt(path)) return path;
+    if (isUncPath(path)) {
+        return uncWithLongPathPrefixAlt + path.slice(2);
+    }
+    return uncLongPathPrefixAlt + path;
+}
+
+/**
+ * Add the long path prefix to a path if it is not already present. This is needed to access paths longer than 260 characters on Windows.
+ * This function uses the alternative long path prefix (`\\.\UNC\` for UNC paths and `\\.\` for local paths).
+ *
+ * For non-windows platforms, this function returns the path unchanged.
+ * @param path
+ * @returns the path with the long path prefix added if needed.
+ */
+export function addLongPathPrefixAlt(path: string): string {
+    if (!isWindows) return path;
+    return addLongPathPrefixAltForce(path);
+}
+
+/**
+ * If the path has the long path unc prefix (`\\.\`), replace it with the standard long path prefix (`\\?\`). This is needed to access paths longer than 260 characters on Windows.
+ * @param path - any path that may or may not have the long path prefix.
+ * @returns the path with the standard long path prefix if needed.
+ */
+export function fixLongPathPrefix(path: string): string {
+    if (!hasLongPathPrefixAlt(path)) return path;
+    return uncLongPathPrefix + path.slice(uncLongPathPrefixAlt.length);
+}

--- a/packages/cspell-url/src/fileUrl.mts
+++ b/packages/cspell-url/src/fileUrl.mts
@@ -118,7 +118,7 @@ function addLongPathPrefixAltForce(path: string): string {
 
 /**
  * Add the long path prefix to a path if it is not already present. This is needed to access paths longer than 260 characters on Windows.
- * This function uses the alternative long path prefix (`\\.\UNC\` for UNC paths and `\\.\` for local paths).
+ * This function uses the alternative long path prefix (`\\.\UNC\` for UNC paths and `\\.\` for local paths). Note: Node.js does not support `\\.\` directly; call fixLongPathPrefix(...) before using the path with fs/pathToFileURL.
  *
  * For non-windows platforms, this function returns the path unchanged.
  * @param path

--- a/packages/cspell-url/src/fileUrl.mts
+++ b/packages/cspell-url/src/fileUrl.mts
@@ -67,7 +67,7 @@ export function isWindowsFileUrl(url: URL | string): boolean {
 }
 
 export const uncLongPathPrefix = '\\\\?\\';
-export const uncLongPathPrefixAlt = '\\\\.\\'; // Note this does not work in nodejs. But it is a valid long path prefix in Windows.
+export const uncLongPathPrefixAlt = '\\\\.\\'; // Note this does not work in Node.js, but it is a valid long path prefix in Windows.
 
 const uncWithLongPathPrefix = uncLongPathPrefix + 'UNC\\';
 const uncWithLongPathPrefixAlt = uncLongPathPrefixAlt + 'UNC\\';

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -172,13 +172,14 @@ describe('util', () => {
     });
 });
 
-describe('url with long paths', async () => {
+describe('url with long paths', () => {
     const urlWindowsFilePathFormats = 'https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats';
     const absoluteFixtureLongPath = Path.join(packageRoot, fixtureLongPath);
 
-    await ensureLongPathFileExists(longFilename209);
-    await ensureLongPathFileExists(longFilenameIssue4978);
-
+    beforeAll(async () => {
+        await ensureLongPathFileExists(longFilename209);
+        await ensureLongPathFileExists(longFilenameIssue4978);
+    });
     test.each`
         filename
         ${longFilename209}

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -198,7 +198,8 @@ describe('url with long paths', async () => {
     `('read long path files with prefix', async ({ filename }) => {
         const absFilename = Path.resolve(absoluteFixtureLongPath, filename);
         const absLongPathFilename = addLongPathPrefix(absFilename);
-        expect(absLongPathFilename.slice(0, uncLongPathPrefix.length)).toBe(uncLongPathPrefix);
+        const expectedAlt = isWindows ? uncLongPathPrefix : absFilename;
+        expect(absLongPathFilename.slice(0, isWindows ? uncLongPathPrefix.length : undefined)).toBe(expectedAlt);
         const contents = await fs.readFile(absLongPathFilename, 'utf8');
         expect(contents).toContain(filename);
 
@@ -213,7 +214,8 @@ describe('url with long paths', async () => {
         const absFilename = Path.resolve(absoluteFixtureLongPath, filename);
 
         const absLongPathFilenameAlt = addLongPathPrefixAlt(absFilename);
-        expect(absLongPathFilenameAlt.slice(0, uncLongPathPrefixAlt.length)).toBe(uncLongPathPrefixAlt);
+        const expectedAlt = isWindows ? uncLongPathPrefixAlt : absFilename;
+        expect(absLongPathFilenameAlt.slice(0, isWindows ? uncLongPathPrefixAlt.length : undefined)).toBe(expectedAlt);
         const absLongPathFilename = addLongPathPrefix(absLongPathFilenameAlt);
         const contents = await fs.readFile(absLongPathFilename, 'utf8');
         expect(contents).toContain(filename);

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -245,7 +245,9 @@ ${filename}
     async function readFileIfExists(path: string | URL): Promise<string | undefined> {
         try {
             return await fs.readFile(path, 'utf8');
-        } catch {
+        } catch (e) {
+            const err = e as NodeJS.ErrnoException;
+            if (err?.code !== 'ENOENT') throw e;
             return undefined;
         }
     }

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -230,9 +230,9 @@ Reference: ${urlWindowsFilePathFormats}
 The filename is:
 ${filename}
 `;
-        const absoluteFixtureLongPathFile = Path.join(absoluteFixtureLongPath, filename);
+        const absoluteFixtureLongPathFile = addLongPathPrefix(Path.join(absoluteFixtureLongPath, filename));
 
-        const found = await readFileIfExits(absoluteFixtureLongPathFile);
+        const found = await readFileIfExists(absoluteFixtureLongPathFile);
 
         if (found !== content) {
             await fs.mkdir(Path.dirname(absoluteFixtureLongPathFile), { recursive: true });
@@ -241,7 +241,7 @@ ${filename}
         }
     }
 
-    async function readFileIfExits(path: string | URL): Promise<string | undefined> {
+    async function readFileIfExists(path: string | URL): Promise<string | undefined> {
         try {
             return await fs.readFile(path, 'utf8');
         } catch {

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -237,7 +237,7 @@ ${filename}
 
         if (found !== content) {
             await fs.mkdir(Path.dirname(absoluteFixtureLongPathFile), { recursive: true });
-            console.log('Creating fixture file "%s"', absoluteFixtureLongPathFile);
+            // Fixture file created/updated.
             await fs.writeFile(absoluteFixtureLongPathFile, content, 'utf8');
         }
     }

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -29,9 +29,10 @@ const cwdURL = pathToFileURL('.');
 const packageRootUrl = new URL('../', import.meta.url);
 const packageRoot = fileURLToPath(packageRootUrl);
 const fixtureLongPath = 'fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats';
+// Note `.log` files are used to keep them out of the .git repository since git has issues with long paths on Windows.
 const longFilename209 = `\
 very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-\
-that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt\
+that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.log\
 `;
 // https://github.com/streetsidesoftware/vscode-spell-checker/issues/4978
 const longFilenameIssue4978 = `\

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -1,11 +1,21 @@
-import * as Path from 'node:path';
+import fs from 'node:fs/promises';
+import Path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { describe, expect, test } from 'vitest';
 
 import { urlBasename } from './dataUrl.mts';
 import { normalizeFilePathForUrl, toFileDirURL, toFileURL } from './defaultFileUrlBuilder.mts';
-import { isWindows, isWindowsFileUrl, pathWindowsDriveLetterToUpper, toFilePathOrHref } from './fileUrl.mts';
+import {
+    addLongPathPrefix,
+    addLongPathPrefixAlt,
+    isWindows,
+    isWindowsFileUrl,
+    pathWindowsDriveLetterToUpper,
+    toFilePathOrHref,
+    uncLongPathPrefix,
+    uncLongPathPrefixAlt,
+} from './fileUrl.mts';
 import { FileUrlBuilder } from './FileUrlBuilder.mts';
 import { isUrlLike, normalizeWindowsUrl, toURL, urlParent } from './url.mts';
 
@@ -15,6 +25,21 @@ const root = Path.join(__dirname, '../..');
 const sm = (m: string | RegExp) => expect.stringMatching(m);
 
 const cwdURL = pathToFileURL('.');
+
+const packageRootUrl = new URL('../', import.meta.url);
+const packageRoot = fileURLToPath(packageRootUrl);
+const fixtureLongPath = 'fixtures/unc-long-path/learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats';
+const longFilename209 = `\
+very-long-filename-to-test-url-handling-in-cspell-io-and-cspell-url-utilities-for-long-paths-on-windows-to-ensure-\
+that-these-tools-can-handle-long-paths-on-windows-without-issues-it-is-209-characters-long.txt\
+`;
+// https://github.com/streetsidesoftware/vscode-spell-checker/issues/4978
+const longFilenameIssue4978 = `\
+Engineering/Programming/Aerials/LCS Y2020/y2020_controller/local_builds/2512/251216/RNE_Aerial_Dev/162221_5cf5637b6_cmorris\
+/23461B-001_ID025_Aux_Control_Platform_Leveling_Y2020_TTC2310/23461B-001_ID025_Aux_Control_Platform_Leveling_Y2020_TTC2310_controller.log\
+`;
+
+// cspell:ignore cmorris
 
 describe('util', () => {
     test.each`
@@ -144,6 +169,82 @@ describe('util', () => {
     `('isWindowsFileUrl $url', ({ url, expected }) => {
         expect(isWindowsFileUrl(url)).toEqual(expected);
     });
+});
+
+describe('url with long paths', async () => {
+    const urlWindowsFilePathFormats = 'https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats';
+    const absoluteFixtureLongPath = Path.join(packageRoot, fixtureLongPath);
+
+    await ensureLongPathFileExists(longFilename209);
+    await ensureLongPathFileExists(longFilenameIssue4978);
+
+    test.each`
+        filename
+        ${longFilename209}
+        ${longFilenameIssue4978}
+    `('read long path files', async ({ filename }) => {
+        const absFilename = Path.resolve(absoluteFixtureLongPath, filename);
+        const contents = await fs.readFile(absFilename, 'utf8');
+        expect(contents).toContain(filename);
+
+        await expect(fs.readFile(pathToFileURL(absFilename), 'utf8')).resolves.toEqual(contents);
+    });
+
+    test.each`
+        filename
+        ${longFilename209}
+        ${longFilenameIssue4978}
+    `('read long path files with prefix', async ({ filename }) => {
+        const absFilename = Path.resolve(absoluteFixtureLongPath, filename);
+        const absLongPathFilename = addLongPathPrefix(absFilename);
+        expect(absLongPathFilename.slice(0, uncLongPathPrefix.length)).toBe(uncLongPathPrefix);
+        const contents = await fs.readFile(absLongPathFilename, 'utf8');
+        expect(contents).toContain(filename);
+
+        await expect(fs.readFile(pathToFileURL(absLongPathFilename), 'utf8')).resolves.toEqual(contents);
+    });
+
+    test.each`
+        filename
+        ${longFilename209}
+        ${longFilenameIssue4978}
+    `('read long path files with alt prefix', async ({ filename }) => {
+        const absFilename = Path.resolve(absoluteFixtureLongPath, filename);
+
+        const absLongPathFilenameAlt = addLongPathPrefixAlt(absFilename);
+        expect(absLongPathFilenameAlt.slice(0, uncLongPathPrefixAlt.length)).toBe(uncLongPathPrefixAlt);
+        const absLongPathFilename = addLongPathPrefix(absLongPathFilenameAlt);
+        const contents = await fs.readFile(absLongPathFilename, 'utf8');
+        expect(contents).toContain(filename);
+    });
+
+    async function ensureLongPathFileExists(filename: string) {
+        const content = `\
+This is a test file for testing long path handling in cspell-url and cspell-io utilities.
+
+Reference: ${urlWindowsFilePathFormats}
+
+The filename is:
+${filename}
+`;
+        const absoluteFixtureLongPathFile = Path.join(absoluteFixtureLongPath, filename);
+
+        const found = await readFileIfExits(absoluteFixtureLongPathFile);
+
+        if (found !== content) {
+            await fs.mkdir(Path.dirname(absoluteFixtureLongPathFile), { recursive: true });
+            console.log('Creating fixture file "%s"', absoluteFixtureLongPathFile);
+            await fs.writeFile(absoluteFixtureLongPathFile, content, 'utf8');
+        }
+    }
+
+    async function readFileIfExits(path: string | URL): Promise<string | undefined> {
+        try {
+            return await fs.readFile(path, 'utf8');
+        } catch {
+            return undefined;
+        }
+    }
 });
 
 function u(path: string, relativeURL?: string | URL) {

--- a/packages/cspell-url/src/fileUrl.test.mts
+++ b/packages/cspell-url/src/fileUrl.test.mts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import Path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { describe, expect, test } from 'vitest';
+import { beforeAll, describe, expect, test } from 'vitest';
 
 import { urlBasename } from './dataUrl.mts';
 import { normalizeFilePathForUrl, toFileDirURL, toFileURL } from './defaultFileUrlBuilder.mts';


### PR DESCRIPTION
## Pull request overview

This PR improves `cspell-url`’s handling of Windows long/UNC path formats by adding long-path prefix utilities and ensuring `FileUrlBuilder` can generate correct `file:` URLs for UNC/extended-length paths. It also adds fixtures and tests to exercise long-path behavior.

**Changes:**
- Add Windows long-path/UNC prefix helpers (`\\?\`, `\\?\UNC\`, `\\.\`) and normalization (`fixLongPathPrefix`) in `fileUrl.mts`.
- Update `FileUrlBuilder` to special-case UNC/extended-length paths when converting to `file:` URLs.
- Add long-path fixtures and new tests that read and convert long Windows paths/URLs.

Related to:
- https://github.com/streetsidesoftware/vscode-spell-checker/issues/5260
- https://github.com/streetsidesoftware/vscode-spell-checker/issues/4978
