### PR TITLE
fix: Find the nearest `.git` when a worktree is inside a clone

### DIFF
--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -23,6 +23,7 @@ exonum
 flatpack
 Flatpacked
 gimu
+gitdir
 globby
 globstar
 gzipped
@@ -68,5 +69,7 @@ walk-throughs
 webdeveric
 wireapp
 workdir
+worktree
+worktrees
 zulip
 zulipchat

--- a/packages/cspell-gitignore/src/findRepoRoot.test.ts
+++ b/packages/cspell-gitignore/src/findRepoRoot.test.ts
@@ -1,8 +1,13 @@
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { describe, expect, test } from 'vitest';
+import { beforeAll, describe, expect, test } from 'vitest';
 
 import { findRepoRoot } from './findRepoRoot.js';
+
+const pathTemp = path.join(__dirname, '../temp/findRepoRoot');
+const pathClone = path.join(pathTemp, 'clone');
+const pathWorktree = path.join(pathClone, 'worktrees/wt');
 
 describe('helpers', () => {
     test.each`
@@ -15,5 +20,25 @@ describe('helpers', () => {
     `('findRepoRoot $dir', async ({ dir, expected }) => {
         const f = await findRepoRoot(dir);
         expect(f ? path.join(f, '.') : f).toEqual(expected);
+    });
+
+    describe('git worktrees', () => {
+        // A worktree marks its root with a `.git` file, while the clone it belongs to has a
+        // `.git` directory. A worktree checked out inside its own clone has both above it.
+        beforeAll(async () => {
+            await fs.rm(pathTemp, { force: true, recursive: true });
+            await fs.mkdir(path.join(pathClone, '.git'), { recursive: true });
+            await fs.mkdir(pathWorktree, { recursive: true });
+            await fs.writeFile(path.join(pathWorktree, '.git'), 'gitdir: ../../.git/worktrees/wt\n');
+        });
+
+        test.each`
+            dir             | expected
+            ${pathWorktree} | ${pathWorktree}
+            ${pathClone}    | ${pathClone}
+        `('findRepoRoot $dir', async ({ dir, expected }) => {
+            const f = await findRepoRoot(dir);
+            expect(f ? path.join(f, '.') : f).toEqual(expected);
+        });
     });
 });

--- a/packages/cspell-gitignore/src/findRepoRoot.ts
+++ b/packages/cspell-gitignore/src/findRepoRoot.ts
@@ -8,11 +8,27 @@ import { getDefaultVirtualFs } from 'cspell-io';
  * @returns resolves to `.git` root or undefined
  */
 export async function findRepoRoot(directory: string | URL, vfs?: VFileSystem): Promise<string | undefined> {
-    directory = toFileDirURL(directory);
-    vfs = vfs || getDefaultVirtualFs().getFS(directory);
-    const foundDir = await vfs.findUp('.git', directory, { type: 'directory' });
-    const foundFile = await vfs.findUp('.git', directory, { type: 'file' });
-    const found = foundDir || foundFile;
+    const from = toFileDirURL(directory);
+    const fs = vfs || getDefaultVirtualFs().getFS(from);
+    const found = await fs.findUp((dir) => findDotGit(fs, dir), from);
     if (!found) return undefined;
     return toFilePathOrHref(new URL('.', found));
+}
+
+/**
+ * Look for `.git` in a single directory, without caring whether it is a file or a directory.
+ *
+ * A clone marks its root with a `.git` directory and a worktree marks its root with a `.git` file,
+ * so both have to count. A worktree checked out inside its own clone has one of each above it,
+ * which is why the nearest match has to win rather than one type of match.
+ * @param fs - file system to stat with.
+ * @param dir - directory to look in.
+ * @returns resolves to the url of `.git`, or undefined when the directory does not have one.
+ */
+function findDotGit(fs: VFileSystem, dir: URL): Promise<URL | undefined> {
+    const url = new URL('.git', dir);
+    return fs.stat(url).then(
+        () => url,
+        () => undefined,
+    );
 }


### PR DESCRIPTION
Fixes #8975.

`findRepoRoot` runs two independent `findUp` searches and prefers the directory result, so a clone further up wins over a worktree's own `.git` file:

```ts
const foundDir = await vfs.findUp('.git', directory, { type: 'directory' });
const foundFile = await vfs.findUp('.git', directory, { type: 'file' });
const found = foundDir || foundFile;
```

With `useGitignore: true` the clone's `.gitignore` is then applied to the worktree's files, so a worktree kept in a gitignored folder inside its own clone — the `.worktrees` layout this repository uses itself — has every file treated as ignored and `cspell` reports `Files checked: 0`.

This searches once for a `.git` of either kind, via a predicate, so the nearest one marks the root. That also drops one full walk up the tree.

Note that omitting `type` is not an alternative: `findUpFromUrl` defaults it to `'file'`, so a plain `findUp('.git', directory)` stops finding normal clones.

The new test builds a clone with a worktree nested inside it under `temp/` and checks both roots resolve to themselves. It fails on `main` with the worktree resolving to the clone.

Verified with the built CLI on a scratch repository, run from a subdirectory of the worktree so that the `findRepoRoot(cwd) || cwd` fallback in `generateGitIgnore` cannot mask the result: before, `Files checked: 0`; after, the misspellings are reported.