### PR TITLE
chore: Change app-id to client-id for create-github-app-token

### DIFF
--- a/.github/actions/pr/action.yaml
+++ b/.github/actions/pr/action.yaml
@@ -52,7 +52,7 @@ runs:
       if: env.git_status == 'dirty'
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
       with:
-        app-id: ${{ inputs.app_id }}
+        client-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}
 
     - name: Create Pull Request

--- a/.github/workflows/update-dictionaries.yml
+++ b/.github/workflows/update-dictionaries.yml
@@ -345,7 +345,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
         with:
-          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          client-id: ${{ secrets.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
       - name: Create Pull Request


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change modifies the way the app ID is passed to the `actions/create-github-app-token` action.

- Changed the input parameter from `app-id` to `client-id` when invoking the `actions/create-github-app-token` action in `.github/actions/pr/action.yaml`, likely to match the updated requirements of the action.

See: https://github.com/actions/create-github-app-token/pull/353 
