### PR TITLE
chore: prevent auto major update of node types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,11 +21,10 @@ updates:
         update-types:
           - minor
           - patch
-    allow:
+    ignore:
       - dependency-name: '@types/node'
         update-types:
-          - version-update:semver-patch
-          - version-update:semver-minor
+          - version-update:semver-major
 
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
         update-types:
           - minor
           - patch
+    allow:
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-patch
+          - version-update:semver-minor
 
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the


### PR DESCRIPTION
This pull request updates the Dependabot configuration to allow more granular updates for the `@types/node` dependency. Specifically, it enables both patch and minor version updates for this package.

- **Dependabot configuration:**
  * Updated `.github/dependabot.yml` to explicitly allow patch and minor version updates for the `@types/node` dependency.