### PR TITLE
fix(ci): push release tag with GitHub App token so publish.yml triggers

### DIFF
--- a/.github/workflows/build-version-release.yml
+++ b/.github/workflows/build-version-release.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          persist-credentials: false
 
       - name: Setup Node and Pnpm
         uses: ./.github/actions/setup-node
@@ -58,12 +59,9 @@ jobs:
           echo version=$(jq -r .version .release.json) >> $GITHUB_OUTPUT
 
       - name: Setup Git
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name streetsidesoftware[bot]
           git config user.email streetsidesoftware[bot]@users.noreply.github.com
-          git remote add gh-token "https://${GITHUB_TOKEN}@github.com/streetsidesoftware/cspell.git"
 
       - name: Install and Build
         run: pnpm i
@@ -80,10 +78,16 @@ jobs:
 
       - name: Push Version
         # TODO: support --sign-git-tag --sign-git-commit
+        # Use the GitHub App token (not the default GITHUB_TOKEN) to push the
+        # version commit and tag: pushes made with the default GITHUB_TOKEN do
+        # not trigger other workflows, so the tag push would never fire
+        # publish.yml's `push: tags: v*` trigger.
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: pnpm lerna version "$VERSION" --no-private --sync-workspace-lock --no-changelog --yes $DRY_RUN
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/streetsidesoftware/cspell.git"
+          pnpm lerna version "$VERSION" --no-private --sync-workspace-lock --no-changelog --yes $DRY_RUN
 
       - name: Convert Draft Release to Published
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary

`publish.yml` (the NPM trusted-publishing workflow) is triggered by a `push: tags: v*` event, among other triggers. `build-version-release.yml` creates that tag via `pnpm lerna version`, but the tag was never actually triggering `publish.yml`.

Root cause: `lerna version` pushes the version commit/tag to the `origin` remote, and `origin`'s credentials were still the *default* `GITHUB_TOKEN` persisted by `actions/checkout` (the `Setup Git` step's `gh-token` remote was unused — `lerna` pushes to `origin`, not `gh-token` — and was seeded before the GitHub App token even existed). GitHub explicitly does not trigger downstream workflow runs for pushes authenticated with the default `GITHUB_TOKEN`, to avoid recursive triggering. So the tag got created, but `publish.yml` never fired.

## Changes

- `actions/checkout`: set `persist-credentials: false` so the default token isn't left wired into `origin`.
- `Setup Git`: drop the unused/misconfigured `gh-token` remote (it referenced the default token anyway, and nothing pushed to it).
- `Push Version`: before running `lerna version`, point `origin` at the already-generated GitHub App installation token (`x-access-token:${GITHUB_TOKEN}`) so the resulting tag push is authenticated as the GitHub App and correctly triggers `publish.yml`'s `push: tags: v*` trigger.

## Test plan

- [ ] YAML validated (`python3 -c "import yaml; yaml.safe_load(open(...))"` passes).
- [ ] Run `build-version-release.yml` via `workflow_dispatch` with `dry_run: false` (or the next real release) and confirm `publish.yml` fires automatically off the resulting tag push, without needing a manual `workflow_dispatch`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019uQbKT8r9tdmjLo3XfDnBa)_