### PR TITLE
fix: Reduce the size of cspell types when bundled

### DIFF
--- a/packages/cspell-types/src/merge.ts
+++ b/packages/cspell-types/src/merge.ts
@@ -81,16 +81,16 @@ function makeMergeFn<K extends keyof CSpellSettings>(key: K): MergeSettingsFn {
     return (settings) => fn(key, settings);
 }
 
-const mergeIndividualSettingsFns = Object.keys(mergeDefinitionFunctions).map((k) =>
-    makeMergeFn(k as keyof CSpellSettings),
-);
-
 export function mergeConfig(settings: CSpellSettings[]): CSpellSettings;
 export function mergeConfig(...settings: [CSpellSettings, ...CSpellSettings[]]): CSpellSettings;
 export function mergeConfig(...settings: [CSpellSettings[], ...CSpellSettings[]]): CSpellSettings;
 export function mergeConfig(first: CSpellSettings[] | CSpellSettings, ...configs: CSpellSettings[]): CSpellSettings {
     const settings = [first, ...configs].flat();
     if (settings.length === 1) return settings[0];
+
+    const mergeIndividualSettingsFns = Object.keys(mergeDefinitionFunctions).map((k) =>
+        makeMergeFn(k as keyof CSpellSettings),
+    );
 
     const result = Object.assign(Object.create(null), ...settings);
     Object.assign(result, ...mergeIndividualSettingsFns.map((fn) => fn(settings)));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1362,6 +1362,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/cspell-types
 
+  test-packages/cspell-types/test-cspell-types-define-config:
+    devDependencies:
+      '@cspell/cspell-types':
+        specifier: workspace:*
+        version: link:../../../packages/cspell-types
+
   test-packages/cspell-types/test-cspell-types-esbuild:
     dependencies:
       '@cspell/cspell-types':

--- a/test-packages/cspell-types/test-cspell-types-define-config/CHANGELOG.md
+++ b/test-packages/cspell-types/test-cspell-types-define-config/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/test-packages/cspell-types/test-cspell-types-define-config/package.json
+++ b/test-packages/cspell-types/test-cspell-types-define-config/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "test-cspell-types-define-config",
+  "version": "9.0.2",
+  "description": "Pure testing package to ensure the size of defineConfig when bundled.",
+  "bin": {
+    "test-bin": "test-bin.mjs"
+  },
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "clean": "shx rm -rf dist temp coverage \"*.tsbuildInfo\"",
+    "build": "pnpm build:tsdown",
+    "build:tsdown": "tsdown",
+    "clean-build": "pnpm run clean && pnpm run build",
+    "test": "node ./test-bin.mjs"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@cspell/cspell-types": "workspace:*"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "cspell": {
+    "words": [
+      "outfile",
+      "tsbuild"
+    ]
+  },
+  "keywords": []
+}

--- a/test-packages/cspell-types/test-cspell-types-define-config/src/index.ts
+++ b/test-packages/cspell-types/test-cspell-types-define-config/src/index.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+
+import { defineConfig } from '@cspell/cspell-types';
+
+assert(typeof defineConfig === 'function');
+
+const sampleConfig = defineConfig({});
+assert(defineConfig(sampleConfig) === sampleConfig);

--- a/test-packages/cspell-types/test-cspell-types-define-config/test-bin.mjs
+++ b/test-packages/cspell-types/test-cspell-types-define-config/test-bin.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import './dist/index.js';
+
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+
+let failed = 0;
+
+async function test(name, fn) {
+    try {
+        console.error(`Testing: ${name}`);
+        await fn();
+    } catch (e) {
+        console.error(`Failed: ${name}`);
+        console.error(e);
+        failed += 1;
+    }
+}
+
+function assertLessThan(a, b) {
+    assert(a < b, `assert that ${a} is less than ${b}`);
+}
+
+await test('filesize index.cjs', async () => {
+    const stats = await fs.stat('dist/index.cjs');
+    assert(stats.size > 0, 'File size is greater than 0');
+    assertLessThan(stats.size, 3096);
+});
+
+await test('filesize index.js', async () => {
+    const stats = await fs.stat('dist/index.js');
+    assert(stats.size > 0, 'File size is greater than 0');
+    assertLessThan(stats.size, 2048);
+});
+
+if (failed) {
+    process.exitCode = 1;
+}

--- a/test-packages/cspell-types/test-cspell-types-define-config/tsconfig.json
+++ b/test-packages/cspell-types/test-cspell-types-define-config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../tsconfig.esm.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "./src",
+        "outDir": "dist"
+    },
+    "include": ["src"]
+}

--- a/test-packages/cspell-types/test-cspell-types-define-config/tsdown.config.ts
+++ b/test-packages/cspell-types/test-cspell-types-define-config/tsdown.config.ts
@@ -1,0 +1,13 @@
+import type { UserConfig } from '@internal/tsdown';
+import { createConfig } from '@internal/tsdown';
+
+const config: UserConfig = createConfig({
+    entry: ['src/index.ts'],
+    outDir: 'dist',
+    format: ['esm', 'cjs'],
+    fixedExtension: false,
+    dts: true,
+    sourcemap: true,
+});
+
+export default config;


### PR DESCRIPTION
This pull request introduces a new test package, `test-cspell-types-define-config`, designed to verify the size and correct bundling of the `defineConfig` function from `@cspell/cspell-types`. It also includes minor internal refactoring in the `mergeConfig` logic. The main themes are the addition of the test package and improvements to configuration merging.

**New test package: `test-cspell-types-define-config`**

* Added the `test-cspell-types-define-config` package with configuration files (`package.json`, `tsconfig.json`, `tsdown.config.ts`) and a basic test harness to ensure the `defineConfig` utility is small when bundled and functions as expected. The tests check that the output files remain below specified size thresholds and that `defineConfig` is a function returning the same config object when called twice. [[1]](diffhunk://#diff-88e499e22179cc3a3ab1d9c892deedcef8c3390fd76fa23e7d773d70d1cc1341R1-R32) [[2]](diffhunk://#diff-c65a4d2ab754abde9448f8d22da99d4ff6a1baa50830d44dc857345652e3fcf6R1-R9) [[3]](diffhunk://#diff-a34c883564d2baee3dcf13f515665a44aa11befd3d2b7c212446109dda0fae85R1-R13) [[4]](diffhunk://#diff-ec66f0ad585f357c27c81fa3e62f7d0653e67998ebc7a4b1d1a768ef200214e4R1-R4) [[5]](diffhunk://#diff-5f690b6ff167e605d5b9e7a2601e9701887702417ab8131b3e02ce081d04fb93R1-R8) [[6]](diffhunk://#diff-9e74122672eb3e69b76b2b79f9d92c9f6c9834b666a50b1055c5f9cd7c6ff53aR1-R39)

* Updated `pnpm-lock.yaml` to add the new test package to the workspace and ensure it depends on the local `@cspell/cspell-types` package.

**Internal refactoring**

* Moved the creation of the `mergeIndividualSettingsFns` array inside the `mergeConfig` function in `merge.ts` to avoid unnecessary computation and improve encapsulation.