### PR TITLE
feat: Support languages without word breaks (Part 1)

### DIFF
--- a/packages/cspell-lib/api/api.d.ts
+++ b/packages/cspell-lib/api/api.d.ts
@@ -6,6 +6,7 @@ import { CachingDictionary, SpellingDictionary, SpellingDictionaryCollection, Su
 import { CompoundWordsMethod, WeightMap } from "cspell-trie-lib";
 import { CSpellConfigFile, CSpellConfigFile as CSpellConfigFile$1, ICSpellConfigFile, ICSpellConfigFile as ICSpellConfigFile$1 } from "cspell-config-lib";
 import "@cspell/cspell-performance-monitor";
+import "@cspell/cspell-types/Parser";
 export * from "@cspell/cspell-types";
 //#endregion
 //#region src/lib/clearCachedFiles.d.ts
@@ -645,11 +646,18 @@ interface MatchRange {
 //#region src/lib/Transform/types.d.ts
 type SimpleRange = Readonly<Range>;
 //#endregion
+//#region src/lib/Transform/Transformer.d.ts
+interface TextTransformer {
+  transform(text: string | MappedText): MappedText;
+  transformAll(src: Iterable<string | MappedText>): Iterable<MappedText>;
+}
+//#endregion
 //#region src/lib/Transform/SubstitutionTransformer.d.ts
-declare class SubstitutionTransformer {
+declare class SubstitutionTransformer implements TextTransformer {
   #private;
   constructor(subMap: Map<string, string> | undefined);
   transform(text: string | MappedText): MappedText;
+  transformAll(src: Iterable<string | MappedText>): Iterable<MappedText>;
   transformString(text: string): MappedText;
 }
 //#endregion

--- a/packages/cspell-lib/src/lib/Settings/LanguageSettings.test.ts
+++ b/packages/cspell-lib/src/lib/Settings/LanguageSettings.test.ts
@@ -126,13 +126,18 @@ describe('Validate LanguageSettings', () => {
         expect([...localeSet]).toEqual(expected);
     });
 
+    // cspell:ignore Brai
     test.each`
-        locales                          | expected
-        ${''}                            | ${[]}
-        ${'en, en-GB, fr-fr, nl_NL'}     | ${['en', 'en-GB', 'fr-FR', 'nl-NL']}
-        ${['en, en-GB', 'fr-fr, nl_NL']} | ${['en', 'en-GB', 'fr-FR', 'nl-NL']}
+        locales                                 | expected
+        ${''}                                   | ${[]}
+        ${'en, en-GB, fr-fr, nl_NL'}            | ${['en', 'en-GB', 'fr-FR', 'nl-NL']}
+        ${['en, en-GB', 'fr-fr, nl_NL']}        | ${['en', 'en-GB', 'fr-FR', 'nl-NL']}
+        ${['enGB, ', 'fr-Brai-fr, ru-Cyrl-BY']} | ${['en-GB', 'fr-Brai-FR', 'ru-Cyrl-BY']}
+        ${'ru-cyrl-by'}                         | ${['ru-Cyrl-BY']}
     `('normalizeLocaleIntl $locales', ({ locales, expected }) => {
         const localeSet = LS.normalizeLocaleIntl(locales);
+        const regExValidLocale: RegExp = /^\w{2}(-\w{4})?(-\w{2,3})?$/;
+        expect([...localeSet].every((locale) => regExValidLocale.test(locale))).toBe(true);
         expect([...localeSet]).toEqual(expected);
     });
 

--- a/packages/cspell-lib/src/lib/Settings/LanguageSettings.ts
+++ b/packages/cspell-lib/src/lib/Settings/LanguageSettings.ts
@@ -63,11 +63,28 @@ export function normalizeLocale(locale: LocaleId | LocaleId[]): Set<LocaleId> {
 
 export function normalizeLocaleIntl(locale: LocaleId | LocaleId[]): Set<LocaleId> {
     const values = [...normalizeLocale(locale)].map((locale) =>
-        locale.replace(/^([a-z]{2})-?([a-z]{2})$/, (_, lang: string, locale?: string) =>
-            locale ? `${lang}-${locale.toUpperCase()}` : lang,
+        locale.replace(
+            /^([a-z]{2})(?:-?([a-z]{4}))?-?([a-z]{2})$/,
+            (_, lang: string, script?: string, region?: string) => toLocaleIntl(lang, script, region),
         ),
     );
     return new Set(values);
+}
+
+/**
+ * See: https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag
+ * @returns locale normalized to BCP_47
+ */
+function toLocaleIntl(lang: string, script?: string, region?: string): string {
+    const parts = [lang];
+    if (script) parts.push(firstUpper(script.toLowerCase()));
+    if (region) parts.push(region.toUpperCase());
+    return parts.join('-');
+}
+
+function firstUpper(str: string): string {
+    const [first, ...rest] = [...str];
+    return [first.toUpperCase(), ...rest].join('');
 }
 
 export function isLocaleInSet(locale: LocaleId | LocaleId[], setOfLocals: Set<LocaleId>): boolean {

--- a/packages/cspell-lib/src/lib/Transform/IntlSegmentTextTransformer.test.ts
+++ b/packages/cspell-lib/src/lib/Transform/IntlSegmentTextTransformer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import { IntlSegmentTextTransformer } from './IntlSegmentTextTransformer.js';
+
+describe('IntlSegmentTextTransformer', () => {
+    test.each`
+        locale                            | input                                  | expected
+        ${'en-US'}                        | ${'Hello world'}                       | ${'Hello world'}
+        ${'en-US'}                        | ${'Block(s) of text, 1234, sym $%.[]'} | ${'Block(s) of text, 1234, sym $%.[]'}
+        ${'en-US'}                        | ${'one.two.three-four_five'}           | ${'one.two.three-four_five'}
+        ${'fr-FR'}                        | ${'Bonjour le monde'}                  | ${'Bonjour le monde'}
+        ${'th-TH'}                        | ${'สวัสดีโลก'}                         | ${'สวัสดี โลก' /* cspell:disable-line */}
+        ${getSample('sampleThai').locale} | ${getSample('sampleThai').input}       | ${getSample('sampleThai').expected}
+    `('should segment text correctly $locale $input', ({ locale, input, expected }) => {
+        const t = new IntlSegmentTextTransformer(locale);
+        const result = t.transform(input);
+        expect(result.text).toBe(expected);
+    });
+});
+
+interface Sample {
+    locale: string;
+    input: string;
+    expected: string;
+}
+
+const samples = {
+    // cspell:words ความ ต ประสบ สำเร็จ เรียน ภาษา อดทน ฝึกฝน สม่ำเสมอ
+    // cspell:words ต้องการ อย่าง ต้อง
+    sampleThai: {
+        locale: 'th-TH',
+        input: 'ถ้าคุณต้องการที่จะประสบความสำเร็จในการเรียนภาษาไทย คุณต้องมีความอดทนและฝึกฝนทุกวันอย่างสม่ำเสมอ',
+        expected:
+            'ถ้า คุณ ต้องการ ที่ จะ ประสบ ความ สำเร็จ ใน การ เรียน ภาษา ไทย คุณ ต้อง มี ความ อดทน และ ฝึกฝน ทุก วัน อย่าง สม่ำเสมอ',
+    },
+} as const;
+
+function getSample(name: keyof typeof samples): Sample {
+    return samples[name];
+}

--- a/packages/cspell-lib/src/lib/Transform/IntlSegmentTextTransformer.ts
+++ b/packages/cspell-lib/src/lib/Transform/IntlSegmentTextTransformer.ts
@@ -1,0 +1,46 @@
+import type { MappedText } from '@cspell/cspell-types';
+
+import { normalizeLocaleIntl } from '../Settings/LanguageSettings.js';
+import { applyEditsToMappedText } from './TextMapEdit.js';
+import type { Edit, TextTransformer } from './Transformer.js';
+import { toMappedText } from './Transformer.js';
+
+const regExSplitWordCharacters: RegExp = /(?<=[\p{L}\p{M}])[\p{L}\p{M}]/uy;
+
+export class IntlSegmentTextTransformer implements TextTransformer {
+    #locale: string[];
+
+    constructor(locale: string | string[]) {
+        this.#locale = [...normalizeLocaleIntl(locale)];
+    }
+
+    transform(text: string | MappedText): MappedText {
+        // Implement the transformation logic here
+        text = toMappedText(text);
+        return segmentText(text, new Intl.Segmenter(this.#locale, { granularity: 'word' }));
+    }
+
+    *transformAll(src: Iterable<string | MappedText>): Iterable<MappedText> {
+        for (const item of src) {
+            yield this.transform(item);
+        }
+    }
+}
+
+function segmentText(mText: MappedText, segmenter: Intl.Segmenter): MappedText {
+    const edits: Edit[] = [];
+    let lastIndex = -1;
+    const reg = new RegExp(regExSplitWordCharacters);
+    const text = mText.text;
+    for (const { segment, index } of segmenter.segment(mText.text)) {
+        const endIndex = index + segment.length;
+        reg.lastIndex = index;
+        if (index === lastIndex && reg.test(text)) {
+            const edit: Edit = { text: ' ' + segment, range: [index, endIndex] };
+            edits.push(edit);
+        }
+        lastIndex = endIndex;
+    }
+
+    return applyEditsToMappedText(mText, edits);
+}

--- a/packages/cspell-lib/src/lib/Transform/SubstitutionTransformer.ts
+++ b/packages/cspell-lib/src/lib/Transform/SubstitutionTransformer.ts
@@ -1,9 +1,11 @@
 import type { MappedText, SubstitutionDefinition, SubstitutionDefinitions, Substitutions } from '@cspell/cspell-types';
-import type { Range, SourceMap } from '@cspell/cspell-types/Parser';
 import type { GTrieNode } from 'cspell-trie-lib';
 import { GTrie } from 'cspell-trie-lib';
 
-import { mapOffsetPairsToSourceMap, mergeSourceMaps } from './SourceMap.js';
+import { mergeSourceMaps } from './SourceMap.js';
+import { applyEditsToText } from './TextMapEdit.js';
+import type { Edit, TextTransformer } from './Transformer.js';
+import { toMappedText } from './Transformer.js';
 
 type DeepReadonly<T> = T extends object ? { readonly [K in keyof T]: DeepReadonly<T[K]> } : T;
 
@@ -16,7 +18,7 @@ export type ReadonlySubstitutionInfo = DeepReadonly<SubstitutionInfo>;
 
 type SubTrie = GTrie<string, string>;
 
-export class SubstitutionTransformer {
+export class SubstitutionTransformer implements TextTransformer {
     #trie: SubTrie | undefined;
 
     constructor(subMap: Map<string, string> | undefined) {
@@ -43,56 +45,18 @@ export class SubstitutionTransformer {
         return result;
     }
 
+    *transformAll(src: Iterable<string | MappedText>): Iterable<MappedText> {
+        for (const item of src) {
+            yield this.transform(item);
+        }
+    }
+
     transformString(text: string): MappedText {
         if (!this.#trie) {
-            return { text, range: [0, text.length], rawText: text };
+            return toMappedText(text);
         }
-
-        const map: SourceMap = [0, 0];
-        let repText = '';
-        let lastEnd = 0;
-
-        for (const edit of calcEdits(text, this.#trie)) {
-            if (edit.range[0] > lastEnd) {
-                repText += text.slice(lastEnd, edit.range[0]);
-                map.push(edit.range[0], repText.length);
-            }
-            repText += edit.text;
-            map.push(edit.range[1], repText.length);
-            lastEnd = edit.range[1];
-        }
-
-        if (lastEnd === 0) {
-            return { text, range: [0, text.length], rawText: text };
-        }
-
-        if (lastEnd < text.length) {
-            repText += text.slice(lastEnd);
-            map.push(text.length, repText.length);
-        }
-
-        const result: MappedText = {
-            text: repText,
-            range: [0, text.length],
-            map: mapOffsetPairsToSourceMap(map),
-            rawText: text,
-        };
-
-        return result;
+        return applyEditsToText(text, calcEdits(text, this.#trie));
     }
-}
-
-interface Edit {
-    /**
-     * The replacement text for the edit. This is the text that will replace the original text in the string.
-     */
-    text: string;
-    /**
-     * The range of the text to be replaced. This is a tuple of the form `[start, end]`,
-     * where start is the index of the first character to be replaced,
-     * and end is the index of the first character after the last character to be replaced.
-     */
-    range: Range;
 }
 
 function* calcEdits(text: string, subTrie: SubTrie): Iterable<Edit> {

--- a/packages/cspell-lib/src/lib/Transform/TextMapEdit.ts
+++ b/packages/cspell-lib/src/lib/Transform/TextMapEdit.ts
@@ -1,0 +1,53 @@
+import type { MappedText, SourceMap } from '@cspell/cspell-types';
+
+import { mapOffsetPairsToSourceMap, mergeSourceMaps } from './SourceMap.js';
+import type { Edit } from './Transformer.js';
+import { toMappedText } from './Transformer.js';
+
+export function applyEditsToMappedText(text: MappedText, edits: Iterable<Edit>): MappedText {
+    const transformed = applyEditsToText(text.text, edits);
+    const rawText = text.rawText ?? text.text;
+
+    const result: MappedText = {
+        ...text,
+        text: transformed.text,
+        map: mergeSourceMaps(text.map, transformed.map),
+        rawText,
+    };
+
+    return result;
+}
+
+export function applyEditsToText(text: string, edits: Iterable<Edit>): MappedText {
+    const map: SourceMap = [0, 0];
+    let repText = '';
+    let lastEnd = 0;
+
+    for (const edit of edits) {
+        if (edit.range[0] > lastEnd) {
+            repText += text.slice(lastEnd, edit.range[0]);
+            map.push(edit.range[0], repText.length);
+        }
+        repText += edit.text;
+        map.push(edit.range[1], repText.length);
+        lastEnd = edit.range[1];
+    }
+
+    if (lastEnd === 0) {
+        return toMappedText(text);
+    }
+
+    if (lastEnd < text.length) {
+        repText += text.slice(lastEnd);
+        map.push(text.length, repText.length);
+    }
+
+    const result: MappedText = {
+        text: repText,
+        range: [0, text.length],
+        map: mapOffsetPairsToSourceMap(map),
+        rawText: text,
+    };
+
+    return result;
+}

--- a/packages/cspell-lib/src/lib/Transform/Transformer.ts
+++ b/packages/cspell-lib/src/lib/Transform/Transformer.ts
@@ -1,0 +1,27 @@
+import type { MappedText } from '@cspell/cspell-types';
+import type { Range } from '@cspell/cspell-types/Parser';
+
+export interface TextTransformer {
+    transform(text: string | MappedText): MappedText;
+    transformAll(src: Iterable<string | MappedText>): Iterable<MappedText>;
+}
+
+export interface Edit {
+    /**
+     * The replacement text for the edit. This is the text that will replace the original text in the string.
+     */
+    text: string;
+    /**
+     * The range of the text to be replaced. This is a tuple of the form `[start, end]`,
+     * where start is the index of the first character to be replaced,
+     * and end is the index of the first character after the last character to be replaced.
+     */
+    range: Range;
+}
+
+export function toMappedText(text: string | MappedText): MappedText {
+    if (typeof text === 'string') {
+        return { text, range: [0, text.length], rawText: text };
+    }
+    return text;
+}


### PR DESCRIPTION
This pull request introduces a new `IntlSegmentTextTransformer` for locale-aware text segmentation, refactors text transformation infrastructure for better composability, and improves locale normalization to BCP 47 standards. It also adds comprehensive tests for these new features and refactors existing transformers for consistency.

### Locale normalization improvements
* Improved the `normalizeLocaleIntl` function in `LanguageSettings.ts` to support BCP 47 language tag normalization, including script and region subtags, and added tests for these cases. [[1]](diffhunk://#diff-8add39a2fb63a57375d818b7bc3a6add323be3b06883e55b457fbc9b61b5a563L66-R89) [[2]](diffhunk://#diff-f8304df429482ee7ec10e3c26d8d84ab5018b527c6b9dd5f524791717fa8fb9fR129-R140)

### New locale-aware text transformer
* Added the `IntlSegmentTextTransformer` class for locale-aware word segmentation using `Intl.Segmenter`, along with tests covering multiple locales (including Thai). [[1]](diffhunk://#diff-b03d87dd3ae4df592e9449eedf7da60987efe19e05a630ac889e305f47efbd03R1-R46) [[2]](diffhunk://#diff-7e6d66ba690aa3f4db0f427d48fa252440a3c77d4ea67061998610863cd348b8R1-R40)

### Transformer infrastructure and API improvements
* Introduced a generic `TextTransformer` interface and the `Edit` type in `Transformer.ts` to standardize text transformation operations.
* Added utility functions `applyEditsToMappedText` and `applyEditsToText` in `TextMapEdit.ts` for applying edits and maintaining source maps, used by all transformers.

### Refactoring and consistency
* Refactored `SubstitutionTransformer` to implement the new `TextTransformer` interface and use the new edit application utilities, simplifying and unifying its implementation. [[1]](diffhunk://#diff-e8f172cb83557b8eb1695bd0a1414d4a7dfe0d59a988223058764f7622998483L2-R8) [[2]](diffhunk://#diff-e8f172cb83557b8eb1695bd0a1414d4a7dfe0d59a988223058764f7622998483L19-R21) [[3]](diffhunk://#diff-e8f172cb83557b8eb1695bd0a1414d4a7dfe0d59a988223058764f7622998483L46-L95)

These changes collectively improve the flexibility, correctness, and internationalization support of the text transformation pipeline.