### PR TITLE
fix: Workaround for #9164

### DIFF
--- a/packages/cspell-lib/src/lib/util/wordSplitter/wordSplitter.test.ts
+++ b/packages/cspell-lib/src/lib/util/wordSplitter/wordSplitter.test.ts
@@ -326,8 +326,14 @@ describe('wordSplitter IntlSegmenter', async () => {
 describe('wordSplitter against dictionary', async () => {
     const s = await getDefaultSettings();
     s.ignoreWords = s.ignoreWords || [];
-    // cspell:ignore 5IAGEAcABwAHkAIABOAGUAdwAgAFkAZQBhAHIA NSURL
-    s.ignoreWords.push('5IAGEAcABwAHkAIABOAGUAdwAgAFkAZQBhAHIA', 'bool', 'NSURL');
+    // cspell:disable
+    s.ignoreWords.push(
+        '5IAGEAcABwAHkAIABOAGUAdwAgAFkAZQBhAHIA',
+        'QmFzZTY0IHN0cmluZyBvZiB0ZXh0IGhlcmU',
+        'bool',
+        'NSURL',
+    );
+    // cspell:enable
     const settings = calcSettingsForLanguageId(finalizeSettings(s), 'en,en-gb');
     const dict = await getDictionary(settings);
 
@@ -345,6 +351,7 @@ describe('wordSplitter against dictionary', async () => {
         ${'//5IAGEAcABwAHkAIABOAGUAdwAgAFkAZQBhAHIA'}           | ${'5IAGEAcABwAHkAIABOAGUAdwAgAFkAZQBhAHIA' /* cspell:disable-line */}
         ${'NSProgress_ffiVoidNSURLboolNSError_fnPtrTrampoline'} | ${'NS|Progress|<ffi>|Void|NSURL|bool|NS|Error|<fn>|<Ptr>|Trampoline' /* cspell:disable-line */}
         ${'To_EntityDto_And_To_DrivedEntityDto'}                | ${'To|Entity|<Dto>|And|To|<Drived>|Entity|<Dto>' /* cspell:disable-line */}
+        ${'QmFzZTY0IHN0cmluZyBvZiB0ZXh0IGhlcmU.access'}         | ${'QmFzZTY0IHN0cmluZyBvZiB0ZXh0IGhlcmU|access' /* cspell:disable-line */}
     `('validate against dictionary', ({ text, expected }) => {
         expected = typeof expected === 'string' ? expected.split('|') : expected;
         const line = {

--- a/packages/cspell-lib/src/lib/util/wordSplitter/wordSplitter.ts
+++ b/packages/cspell-lib/src/lib/util/wordSplitter/wordSplitter.ts
@@ -7,7 +7,8 @@ import { generateWordBreaks, softHyphen } from './generateWordBreaks.js';
 
 const ignoreBreak: BreakPairs = Object.freeze([]) as unknown as BreakPairs;
 
-const maxSkippedBreaks = 8; // Maximum number of breaks that can be skipped during word splitting.
+const maxSkippedBreaks = 16; // Maximum number of breaks that can be skipped during word splitting.
+const maxAttempts = 64_000; // Maximum number of attempts to split words.
 
 // Quote/backtick characters that `regExWordsAndDigits` treats as word characters, so a quoted
 // or templated string literal in source code gets scanned with its delimiters attached.
@@ -231,7 +232,6 @@ function splitIntoWords(
     checkTextRange: (start: number, end: number) => TextOffsetWithValid,
 ): TextOffsetWithValid[] {
     const maxIndex = lineSeg.relEnd;
-    const maxAttempts = 1000;
 
     /**
      * Map of known paths by their starting index in the text.


### PR DESCRIPTION
This pull request updates the word splitter to improve its handling of long or complex words and adds new test cases to ensure correct behavior. The main changes include increasing the allowed number of skipped breaks and attempts for word splitting, updating test cases to cover additional scenarios, and adjusting ignored words in the dictionary tests.

**Word splitting improvements:**
* Increased the maximum number of skipped breaks (`maxSkippedBreaks`) from 8 to 16 and set a new maximum number of attempts (`maxAttempts`) to 64,000 in `wordSplitter.ts` to better handle complex word splitting cases.
* Removed the local `maxAttempts` limit in the `splitIntoWords` function, relying instead on the new global constant.

**Test enhancements:**
* Updated the ignored words in the dictionary test to include a new Base64 string (`QmFzZTY0IHN0cmluZyBvZiB0ZXh0IGhlcmU`) and used `cspell:disable`/`cspell:enable` comments for clarity.
* Added a new test case to validate splitting of the string `'QmFzZTY0IHN0cmluZyBvZiB0ZXh0IGhlcmU.access'` in the word splitter tests.