### PR TITLE
fix: Add dictionary kind: suggest-words

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -356,8 +356,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -425,8 +425,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -501,8 +501,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -837,8 +837,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -1009,10 +1009,13 @@
         },
         {
           "$ref": "#/definitions/DictionaryKindIgnoreWords"
+        },
+        {
+          "$ref": "#/definitions/DictionaryKindSuggestWords"
         }
       ],
-      "description": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore.",
-      "markdownDescription": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore."
+      "description": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore.\n- `suggest-words` - A dictionary containing suggested word corrections.",
+      "markdownDescription": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore.\n- `suggest-words` - A dictionary containing suggested word corrections."
     },
     "DictionaryKindFlagWords": {
       "const": "flag-words",
@@ -1020,6 +1023,10 @@
     },
     "DictionaryKindIgnoreWords": {
       "const": "ignore-words",
+      "type": "string"
+    },
+    "DictionaryKindSuggestWords": {
+      "const": "suggest-words",
       "type": "string"
     },
     "DictionaryKindWords": {

--- a/packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.test.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.test.ts
@@ -1,6 +1,7 @@
+import { createTrieRootFromList, serializeTrie } from 'cspell-trie-lib';
 import { describe, expect, test } from 'vitest';
 
-import { createSuggestDictionary } from './SuggestDictionary.js';
+import { createSuggestDictionary, createSuggestDictionaryFromTrieFile } from './SuggestDictionary.js';
 
 // const oc = <T>(obj: T) => expect.objectContaining(obj);
 const isPreferred = true;
@@ -155,5 +156,23 @@ describe('SuggestDictionary 2', () => {
     `('mapWord "$word"', async ({ word, expected }) => {
         expect(dict.mapWord).toBe(undefined);
         expect(dict.mapWord?.(word)).toEqual(expected);
+    });
+});
+
+describe('createSuggestDictionaryFromTrieFile', () => {
+    test('provides no suggestions for words found in the trie file', async () => {
+        const words = ['english:English', 'red->green', 'blue:purple', 'yellow->white', 'apple:Apple', 'apple:Fruit'];
+
+        const trie = createTrieRootFromList(words);
+        const data = [...serializeTrie(trie, { version: 4, base: 10 })].join('\n');
+        const dict = createSuggestDictionaryFromTrieFile(data, 'suggest_words_trie', 'test');
+
+        expect(dict.has('english')).toBe(false);
+        expect(dict.isForbidden('english')).toBe(false);
+        expect(dict.getPreferredSuggestions('english')).toEqual([{ word: 'English', cost: 1, isPreferred: true }]);
+        expect(dict.getPreferredSuggestions('apple')).toEqual([
+            { word: 'Apple', cost: 1, isPreferred: true },
+            { word: 'Fruit', cost: 2, isPreferred: true },
+        ]);
     });
 });

--- a/packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.test.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.test.ts
@@ -164,7 +164,7 @@ describe('createSuggestDictionaryFromTrieFile', () => {
         const words = ['english:English', 'red->green', 'blue:purple', 'yellow->white', 'apple:Apple', 'apple:Fruit'];
 
         const trie = createTrieRootFromList(words);
-        const data = [...serializeTrie(trie, { version: 4, base: 10 })].join('\n');
+        const data = [...serializeTrie(trie)].join('\n');
         const dict = createSuggestDictionaryFromTrieFile(data, 'suggest_words_trie', 'test');
 
         expect(dict.has('english')).toBe(false);

--- a/packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.ts
@@ -1,5 +1,6 @@
 import { pipe } from '@cspell/cspell-pipe/sync';
 import type { CompoundWordsMethod, SuggestionCollector, SuggestionResult } from 'cspell-trie-lib';
+import { decodeTrie } from 'cspell-trie-lib';
 
 import { createAutoResolveWeakCache } from '../util/AutoResolve.js';
 import { mapperRemoveCaseAndAccents } from '../util/textMappers.js';
@@ -146,4 +147,20 @@ export function createSuggestDictionary(
         const def = processEntriesToTyposDef(entries);
         return new SuggestDictionaryImpl(name, source, def);
     });
+}
+
+/**
+ * Create a suggestion dictionary from the contents of a trie file.
+ * @param data - contents of a trie file.
+ * @param name - name of dictionary
+ * @param source - filename or uri
+ * @returns SuggestDictionary
+ */
+export function createSuggestDictionaryFromTrieFile(
+    data: string | Uint8Array<ArrayBuffer>,
+    name: string,
+    source: string,
+): SuggestDictionary {
+    const trie = decodeTrie(data);
+    return createSuggestDictionary([...trie.words()], name, source);
 }

--- a/packages/cspell-dictionary/src/SpellingDictionary/index.ts
+++ b/packages/cspell-dictionary/src/SpellingDictionary/index.ts
@@ -20,7 +20,7 @@ export type {
 } from './SpellingDictionary.js';
 export { createCollection, SpellingDictionaryCollection } from './SpellingDictionaryCollection.js';
 export { createSpellingDictionaryFromTrieFile } from './SpellingDictionaryFromTrie.js';
-export { createSuggestDictionary } from './SuggestDictionary.js';
+export { createSuggestDictionary, createSuggestDictionaryFromTrieFile } from './SuggestDictionary.js';
 export type { SuggestOptions } from './SuggestOptions.js';
 export { createSuggestOptions } from './SuggestOptions.js';
 export { createTyposDictionary } from './TyposDictionary.js';

--- a/packages/cspell-dictionary/src/__snapshots__/index.test.ts.snap
+++ b/packages/cspell-dictionary/src/__snapshots__/index.test.ts.snap
@@ -13,6 +13,7 @@ exports[`index > verify api 1`] = `
   "createSpellingDictionary",
   "createSpellingDictionaryFromTrieFile",
   "createSuggestDictionary",
+  "createSuggestDictionaryFromTrieFile",
   "createSuggestOptions",
   "dictionaryCacheClearLog",
   "dictionaryCacheEnableLogging",

--- a/packages/cspell-dictionary/src/index.ts
+++ b/packages/cspell-dictionary/src/index.ts
@@ -30,5 +30,6 @@ export {
     createSpellingDictionary,
     createSpellingDictionaryFromTrieFile,
     createSuggestDictionary,
+    createSuggestDictionaryFromTrieFile,
     createSuggestOptions,
 } from './SpellingDictionary/index.js';

--- a/packages/cspell-lib/samples/ignore-words.txt
+++ b/packages/cspell-lib/samples/ignore-words.txt
@@ -1,0 +1,4 @@
+# this file contains some words that can be ignore with suggestions
+# cspell:ignoreRegExp ^.*[:#]
+recieve:receive
+colour:color

--- a/packages/cspell-lib/samples/words.txt
+++ b/packages/cspell-lib/samples/words.txt
@@ -1,3 +1,4 @@
+# cspell:ignoreRegExp ^!.*([:]|$)
 apple
 pie
 banana
@@ -9,3 +10,5 @@ Geschäft
 two words
 aujourd’hui
 class:name
+!colour:color
+!forbid

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.test.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.test.ts
@@ -186,6 +186,34 @@ describe('Validate DictionaryLoader', () => {
             expect(d.find('apple')).toEqual(oc({ found: 'apple', forbidden: false, noSuggest: true }));
         });
 
+        test('kind: words with suggestions.', async () => {
+            const def = dDef({ name: 'words', path: sample('words.txt'), kind: 'words', ignoreForbiddenWords: true });
+            const d = await dictionaryLoader.loadDictionary(def);
+            expect(d.has('apple')).toBe(true);
+            expect(d.isForbidden('apple')).toBe(false);
+            expect(d.find('apple')).toEqual(oc({ found: 'apple', forbidden: false, noSuggest: false }));
+            expect(d.isForbidden('colour')).toBe(false);
+            expect(d.getPreferredSuggestions?.('colour')).toEqual([{ cost: 1, isPreferred: true, word: 'color' }]);
+            expect(d.find('colour')).toEqual(undefined);
+        });
+
+        test('kind: ignore-words will suggest fixes', async () => {
+            const def = dDef({ name: 'ignore-words', path: sample('ignore-words.txt'), kind: 'ignore-words' });
+            const d = await dictionaryLoader.loadDictionary(def);
+            // cspell:ignore colour:color
+            expect(d.getPreferredSuggestions?.('colour')).toEqual([{ cost: 1, isPreferred: true, word: 'color' }]);
+        });
+
+        test('kind: suggest-words provides suggestions without adding words', async () => {
+            const def = dDef({ name: 'suggest-words', path: sample('ignore-words.txt'), kind: 'suggest-words' });
+            const d = await dictionaryLoader.loadDictionary(def);
+            expect(d.has('colour')).toBe(false);
+            expect(d.isForbidden('colour')).toBe(false);
+            expect(d.find('colour')).toEqual(undefined);
+            // cspell:ignore colour:color
+            expect(d.getPreferredSuggestions?.('colour')).toEqual([{ cost: 1, isPreferred: true, word: 'color' }]);
+        });
+
         test('kind: flag-words $type uses FlagWordsDictionary', async () => {
             const def = dDef({ name: 'flag-words', path: sample('flag-words.txt'), kind: 'flag-words' });
             const d = await dictionaryLoader.loadDictionary(def);
@@ -202,12 +230,31 @@ describe('Validate DictionaryLoader', () => {
             expect(d.has('English')).toBe(false);
         });
 
+        test('kind: flag-words $type uses FlagWordsDictionary ignoreForbiddenWords', async () => {
+            const def = dDef({
+                name: 'flag-words',
+                path: sample('flag-words.txt'),
+                kind: 'flag-words',
+                ignoreForbiddenWords: true,
+            });
+            const d = await dictionaryLoader.loadDictionary(def);
+            expect(d.isForbidden('english')).toBe(true);
+            expect(d.getPreferredSuggestions?.('english')?.map((p) => p.word)).toEqual(['English']);
+        });
+
         test('kind: flag-words $type uses FlagWordsDictionary trie', async () => {
             const def = dDef({ name: 'flag-cities', path: dict('cities.trie.gz'), kind: 'flag-words' });
             const d = await dictionaryLoader.loadDictionary(def);
             expect(d.isForbidden('London')).toBe(true);
             expect(d.isForbidden('Paris')).toBe(true);
             expect(d.isForbidden('Berlin')).toBe(false);
+        });
+
+        test('kind: suggest-words $type uses SuggestDictionary trie', async () => {
+            const def = dDef({ name: 'suggest-cities', path: dict('cities.trie.gz'), kind: 'suggest-words' });
+            const d = await dictionaryLoader.loadDictionary(def);
+            expect(d.has('London')).toBe(false);
+            expect(d.isForbidden('London')).toBe(false);
         });
     });
 

--- a/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
+++ b/packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts
@@ -9,6 +9,8 @@ import {
     createInlineSpellingDictionary,
     createSpellingDictionary,
     createSpellingDictionaryFromTrieFile,
+    createSuggestDictionary,
+    createSuggestDictionaryFromTrieFile,
 } from 'cspell-dictionary';
 import type { Stats, TextFileResource, VFileSystem } from 'cspell-io';
 import { compareStats, toFileURL, urlBasename } from 'cspell-io';
@@ -293,6 +295,9 @@ async function legacyWordList(reader: Reader, filename: URL, options: LoadOption
     if (options.kind === 'flag-words') {
         return createFlagWordsDictionary([...words], options.name, filename.toString());
     }
+    if (options.kind === 'suggest-words') {
+        return createSuggestDictionary([...words], options.name, filename.toString());
+    }
     return createSpellingDictionary(words, options.name, filename.toString(), applyKind(options), true);
 }
 
@@ -310,6 +315,9 @@ async function wordsPerLineWordList(reader: Reader, filename: URL, options: Load
     if (options.kind === 'flag-words') {
         return createFlagWordsDictionary([...words], options.name, filename.href);
     }
+    if (options.kind === 'suggest-words') {
+        return createSuggestDictionary([...words], options.name, filename.href);
+    }
     return createSpellingDictionary(words, options.name, filename.href, applyKind(options), true);
 }
 
@@ -318,6 +326,9 @@ async function loadSimpleWordList(reader: Reader, filename: URL, options: LoadOp
     using _ = measurePerf('loadSimpleWordList');
     if (options.kind === 'flag-words') {
         return createFlagWordsDictionary(lines, options.name, filename.href);
+    }
+    if (options.kind === 'suggest-words') {
+        return createSuggestDictionary(lines, options.name, filename.href);
     }
     return createSpellingDictionary(lines, options.name, filename.href, applyKind(options));
 }
@@ -328,12 +339,16 @@ async function loadTrie(reader: Reader, filename: URL, options: LoadOptions) {
     if (options.kind === 'flag-words') {
         return createFlagWordsDictionaryFromTrieFile(content, options.name, filename.href);
     }
+    if (options.kind === 'suggest-words') {
+        return createSuggestDictionaryFromTrieFile(content, options.name, filename.href);
+    }
     return createSpellingDictionaryFromTrieFile(content, options.name, filename.href, applyKind(options));
 }
 
 /**
  * Apply the effect of `kind` on the options passed to a normal `words` dictionary loader.
- * `flag-words` is handled by the callers directly since it uses a different dictionary implementation.
+ * `flag-words` and `suggest-words` are handled by the callers directly since they use a different
+ * dictionary implementation.
  */
 function applyKind(options: LoadOptions): LoadOptions {
     return options.kind === 'ignore-words' && !options.noSuggest ? { ...options, noSuggest: true } : options;

--- a/packages/cspell-types/api/index.d.mts
+++ b/packages/cspell-types/api/index.d.mts
@@ -790,6 +790,8 @@ interface DictionaryDefinitionBase {
    * - `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.
    * - `ignore-words` - A dictionary containing words to ignore.
    *    This is the same as setting `noSuggest` to `true`.
+   * - `suggest-words` - A dictionary containing suggested word corrections. Words found in the
+   *    dictionary will be treated like `suggestWords`.
    * @since 10.3.0
    */
   kind?: DictionaryKind | undefined;
@@ -1107,6 +1109,7 @@ type DictionaryNegRef = string;
 type DictionaryKindWords = "words";
 type DictionaryKindFlagWords = "flag-words";
 type DictionaryKindIgnoreWords = "ignore-words";
+type DictionaryKindSuggestWords = "suggest-words";
 /**
  * The kind of dictionary.
  *
@@ -1116,8 +1119,9 @@ type DictionaryKindIgnoreWords = "ignore-words";
  * - `words` - A dictionary containing words.
  * - `flag-words` - A dictionary containing flag words.
  * - `ignore-words` - A dictionary containing words to ignore.
+ * - `suggest-words` - A dictionary containing suggested word corrections.
  */
-type DictionaryKind = DictionaryKindWords | DictionaryKindFlagWords | DictionaryKindIgnoreWords;
+type DictionaryKind = DictionaryKindWords | DictionaryKindFlagWords | DictionaryKindIgnoreWords | DictionaryKindSuggestWords;
 //#endregion
 //#region src/features.d.ts
 /**

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -356,8 +356,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -425,8 +425,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -501,8 +501,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -837,8 +837,8 @@
         },
         "kind": {
           "$ref": "#/definitions/DictionaryKind",
-          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.",
-          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.",
+          "description": "Used to specify the type of dictionary being referenced. Values:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.    This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the    dictionary will be treated like `suggestWords`.",
+          "markdownDescription": "Used to specify the type of dictionary being referenced.\nValues:\n- `words` - (default) A dictionary containing words.\n- `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.\n- `ignore-words` - A dictionary containing words to ignore.\n   This is the same as setting `noSuggest` to `true`.\n- `suggest-words` - A dictionary containing suggested word corrections. Words found in the\n   dictionary will be treated like `suggestWords`.",
           "since": "10.3.0"
         },
         "name": {
@@ -1009,10 +1009,13 @@
         },
         {
           "$ref": "#/definitions/DictionaryKindIgnoreWords"
+        },
+        {
+          "$ref": "#/definitions/DictionaryKindSuggestWords"
         }
       ],
-      "description": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore.",
-      "markdownDescription": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore."
+      "description": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore.\n- `suggest-words` - A dictionary containing suggested word corrections.",
+      "markdownDescription": "The kind of dictionary.\n\nUsed to specify the type of dictionary being referenced.\n\nValues:\n- `words` - A dictionary containing words.\n- `flag-words` - A dictionary containing flag words.\n- `ignore-words` - A dictionary containing words to ignore.\n- `suggest-words` - A dictionary containing suggested word corrections."
     },
     "DictionaryKindFlagWords": {
       "const": "flag-words",
@@ -1020,6 +1023,10 @@
     },
     "DictionaryKindIgnoreWords": {
       "const": "ignore-words",
+      "type": "string"
+    },
+    "DictionaryKindSuggestWords": {
+      "const": "suggest-words",
       "type": "string"
     },
     "DictionaryKindWords": {

--- a/packages/cspell-types/src/DictionaryDefinition.ts
+++ b/packages/cspell-types/src/DictionaryDefinition.ts
@@ -54,6 +54,8 @@ export interface DictionaryDefinitionBase {
      * - `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.
      * - `ignore-words` - A dictionary containing words to ignore.
      *    This is the same as setting `noSuggest` to `true`.
+     * - `suggest-words` - A dictionary containing suggested word corrections. Words found in the
+     *    dictionary will be treated like `suggestWords`.
      * @since 10.3.0
      */
     kind?: DictionaryKind | undefined;
@@ -426,6 +428,7 @@ export type DictionaryNegRef = string;
 export type DictionaryKindWords = 'words';
 export type DictionaryKindFlagWords = 'flag-words';
 export type DictionaryKindIgnoreWords = 'ignore-words';
+export type DictionaryKindSuggestWords = 'suggest-words';
 
 /**
  * The kind of dictionary.
@@ -436,5 +439,7 @@ export type DictionaryKindIgnoreWords = 'ignore-words';
  * - `words` - A dictionary containing words.
  * - `flag-words` - A dictionary containing flag words.
  * - `ignore-words` - A dictionary containing words to ignore.
+ * - `suggest-words` - A dictionary containing suggested word corrections.
  */
-export type DictionaryKind = DictionaryKindWords | DictionaryKindFlagWords | DictionaryKindIgnoreWords;
+export type DictionaryKind =
+    DictionaryKindWords | DictionaryKindFlagWords | DictionaryKindIgnoreWords | DictionaryKindSuggestWords;

--- a/website/docs/Configuration/auto_properties.md
+++ b/website/docs/Configuration/auto_properties.md
@@ -3284,6 +3284,8 @@ Values:
 - `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.
 - `ignore-words` - A dictionary containing words to ignore.
    This is the same as setting `noSuggest` to `true`.
+- `suggest-words` - A dictionary containing suggested word corrections. Words found in the
+   dictionary will be treated like `suggestWords`.
 
 </dd>
 
@@ -3652,6 +3654,8 @@ Values:
 - `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.
 - `ignore-words` - A dictionary containing words to ignore.
    This is the same as setting `noSuggest` to `true`.
+- `suggest-words` - A dictionary containing suggested word corrections. Words found in the
+   dictionary will be treated like `suggestWords`.
 
 </dd>
 
@@ -4028,6 +4032,8 @@ Values:
 - `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.
 - `ignore-words` - A dictionary containing words to ignore.
    This is the same as setting `noSuggest` to `true`.
+- `suggest-words` - A dictionary containing suggested word corrections. Words found in the
+   dictionary will be treated like `suggestWords`.
 
 </dd>
 
@@ -5402,6 +5408,8 @@ Values:
 - `flag-words` - A dictionary containing flag words. Words found in the dictionary will be treated like `flagWords`.
 - `ignore-words` - A dictionary containing words to ignore.
    This is the same as setting `noSuggest` to `true`.
+- `suggest-words` - A dictionary containing suggested word corrections. Words found in the
+   dictionary will be treated like `suggestWords`.
 
 </dd>
 
@@ -5976,13 +5984,14 @@ Values:
 - `words` - A dictionary containing words.
 - `flag-words` - A dictionary containing flag words.
 - `ignore-words` - A dictionary containing words to ignore.
+- `suggest-words` - A dictionary containing suggested word corrections.
 
 </dd>
 
 <dt>Type</dt>
 <dd>
 
-[`DictionaryKindWords`](#dictionarykindwords)<br />[`DictionaryKindFlagWords`](#dictionarykindflagwords)<br />[`DictionaryKindIgnoreWords`](#dictionarykindignorewords)
+[`DictionaryKindWords`](#dictionarykindwords)<br />[`DictionaryKindFlagWords`](#dictionarykindflagwords)<br />[`DictionaryKindIgnoreWords`](#dictionarykindignorewords)<br />[`DictionaryKindSuggestWords`](#dictionarykindsuggestwords)
 
 </dd>
 
@@ -6015,6 +6024,26 @@ Values:
 ---
 
 ## DictionaryKindIgnoreWords {#dictionarykindignorewords}
+
+
+<dl>
+
+<dt>Type</dt>
+<dd>
+
+`string`
+
+</dd>
+
+</dl>
+
+
+
+
+
+---
+
+## DictionaryKindSuggestWords {#dictionarykindsuggestwords}
 
 
 <dl>


### PR DESCRIPTION
This pull request adds support for a new dictionary kind, `suggest-words`, which allows dictionaries to provide suggested word corrections without treating the words as valid or forbidden. The changes include updates to the JSON schema, implementation of the `SuggestDictionary` for this new kind (including support for loading from trie files), and comprehensive tests to ensure correct behavior. Additionally, the API is extended to expose the new functionality.

**Support for "suggest-words" dictionary kind**

* [`cspell.schema.json`](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL359-R360): Added the `suggest-words` type to the `DictionaryKind` definition and updated descriptions/documentation throughout the schema to reflect this new kind. [[1]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL359-R360) [[2]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL428-R429) [[3]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL504-R505) [[4]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL840-R841) [[5]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cR1012-R1018) [[6]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cR1028-R1031)

**Implementation of SuggestDictionary for "suggest-words"**

* [`packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.ts`](diffhunk://#diff-0ef0e8042a78662ed7798a839e2acaaaba36f84f43cee47691cf0da5527512f7R3): Added `createSuggestDictionaryFromTrieFile`, enabling creation of suggestion dictionaries from trie file contents. [[1]](diffhunk://#diff-0ef0e8042a78662ed7798a839e2acaaaba36f84f43cee47691cf0da5527512f7R3) [[2]](diffhunk://#diff-0ef0e8042a78662ed7798a839e2acaaaba36f84f43cee47691cf0da5527512f7R151-R166)
* `packages/cspell-dictionary/src/SpellingDictionary/index.ts`, `packages/cspell-dictionary/src/index.ts`: Exported the new `createSuggestDictionaryFromTrieFile` function from the package API. [[1]](diffhunk://#diff-88ab425aebdb40b0de4f3d847e37602f47fd5ef2ad71b0c07ded58634a82b0b9L23-R23) [[2]](diffhunk://#diff-7d72bee0f62b6e247b5a59aa6add20496cac0d3007fd4370c8324f9f8d2e81f1R33)
* [`packages/cspell-dictionary/src/__snapshots__/index.test.ts.snap`](diffhunk://#diff-3c53de7765d44a629523ad4f0ca1a25ee56961c7e6b1cf07ca348387fc0a6715R16): Updated API snapshot to include the new export.

**Dictionary loading and integration**

* [`packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.ts`](diffhunk://#diff-c6ea5963a21891d1145b0febf601f1d09d67ffd8e9a95e993493960d677293e0R12-R13): Updated loader to handle `suggest-words` kind for both legacy and words-per-line formats, using the appropriate factory. [[1]](diffhunk://#diff-c6ea5963a21891d1145b0febf601f1d09d67ffd8e9a95e993493960d677293e0R12-R13) [[2]](diffhunk://#diff-c6ea5963a21891d1145b0febf601f1d09d67ffd8e9a95e993493960d677293e0R298-R300) [[3]](diffhunk://#diff-c6ea5963a21891d1145b0febf601f1d09d67ffd8e9a95e993493960d677293e0R318-R320)

**Testing and validation**

* [`packages/cspell-dictionary/src/SpellingDictionary/SuggestDictionary.test.ts`](diffhunk://#diff-6ed6ff78b238680cd5b120ad98774b1181aa261b26700367d7f9a8b30caffc63R1-R4): Added tests for `createSuggestDictionaryFromTrieFile` to ensure suggestions are provided as expected. [[1]](diffhunk://#diff-6ed6ff78b238680cd5b120ad98774b1181aa261b26700367d7f9a8b30caffc63R1-R4) [[2]](diffhunk://#diff-6ed6ff78b238680cd5b120ad98774b1181aa261b26700367d7f9a8b30caffc63R161-R178)
* [`packages/cspell-lib/src/lib/SpellingDictionary/DictionaryController/DictionaryLoader.test.ts`](diffhunk://#diff-c29257264530048b2c751d506584bbf8a5324bbca6095e8307bc7cc547983ff0R189-R216): Added tests for the new `suggest-words` kind, including loading from both text and trie files, and verifying correct suggestion and lookup behavior. [[1]](diffhunk://#diff-c29257264530048b2c751d506584bbf8a5324bbca6095e8307bc7cc547983ff0R189-R216) [[2]](diffhunk://#diff-c29257264530048b2c751d506584bbf8a5324bbca6095e8307bc7cc547983ff0R233-R258)

**Sample data updates**

* `packages/cspell-lib/samples/ignore-words.txt`, `packages/cspell-lib/samples/words.txt`: Updated sample dictionary files to include entries relevant for testing the new kind and its suggestion behavior. [[1]](diffhunk://#diff-7d31a455a84dc5891ebe79c10dde43ff8a534a9495119be21c1d06413cde00a9R1-R4) [[2]](diffhunk://#diff-0e49e6682b2ab85e823f9ced3b6da4029a7c9093c6bcc1290a119ee2824b1ac0R1) [[3]](diffhunk://#diff-0e49e6682b2ab85e823f9ced3b6da4029a7c9093c6bcc1290a119ee2824b1ac0R13-R14)