### PR TITLE
fix: Split words on soft hyphens

### DIFF
--- a/packages/cspell-lib/src/lib/util/text.test.ts
+++ b/packages/cspell-lib/src/lib/util/text.test.ts
@@ -9,7 +9,12 @@ import { describe, expect, test } from 'vitest';
 
 import * as Text from './text.js';
 import { splitCamelCaseWord } from './text.js';
-import { regExSplitWords, regExSplitWords2, regExUpperSOrIng } from './textRegex.js';
+import {
+    regExpCamelCaseWordBreaksWithEnglishSuffix,
+    regExSplitWords,
+    regExSplitWords2,
+    regExUpperSOrIng,
+} from './textRegex.js';
 
 // cSpell:ignore Ápple DBAs ctrip γάμμα
 
@@ -30,15 +35,16 @@ describe('Util Text', () => {
     });
 
     test.each`
-        word                | expected
-        ${'hello'}          | ${'hello'.split('|')}
-        ${'helloThere'}     | ${['hello', 'There']}
-        ${'HelloThere'}     | ${['Hello', 'There']}
-        ${'BigÁpple'}       | ${['Big', 'Ápple']}
-        ${'ASCIIToUTF16'}   | ${['ASCII', 'To', 'UTF16']}
-        ${'URLsAndDBAs'}    | ${['URLs', 'And', 'DBAs']}
-        ${'WALKingRUNning'} | ${['WALKing', 'RUNning']}
-        ${'c0de'}           | ${['c0de']}
+        word                  | expected
+        ${'hello'}            | ${'hello'.split('|')}
+        ${'helloThere'}       | ${['hello', 'There']}
+        ${'HelloThere'}       | ${['Hello', 'There']}
+        ${'hello\u00ADthere'} | ${['hello', 'there']}
+        ${'BigÁpple'}         | ${['Big', 'Ápple']}
+        ${'ASCIIToUTF16'}     | ${['ASCII', 'To', 'UTF16']}
+        ${'URLsAndDBAs'}      | ${['URLs', 'And', 'DBAs']}
+        ${'WALKingRUNning'}   | ${['WALKing', 'RUNning']}
+        ${'c0de'}             | ${['c0de']}
     `('splitCamelCaseWord $word', ({ word, expected }) => {
         expect(splitCamelCaseWord(word)).toEqual(expected);
     });
@@ -334,6 +340,42 @@ describe('Test the text matching functions', () => {
         expect(Text.camelToSnake('first_name')).toBe('first_name');
         expect(Text.camelToSnake('FIRSTName')).toBe('first_name');
         expect(Text.camelToSnake('FIRSTNAME')).toBe('firstname');
+    });
+});
+
+describe('splitCamelCaseWordWithOffset', () => {
+    test.each`
+        word                  | expected
+        ${'hello'}            | ${[{ text: 'hello', offset: 0 }]}
+        ${'helloThere'}       | ${[{ text: 'hello', offset: 0 }, { text: 'There', offset: 5 }]}
+        ${'HelloThere'}       | ${[{ text: 'Hello', offset: 0 }, { text: 'There', offset: 5 }]}
+        ${'hello\u00ADthere'} | ${[{ text: 'hello', offset: 0 }, { text: 'there', offset: 6 }]}
+        ${'BigÁpple'}         | ${[{ text: 'Big', offset: 0 }, { text: 'Ápple', offset: 3 }]}
+        ${'ASCIIToUTF16'}     | ${[{ text: 'ASCII', offset: 0 }, { text: 'To', offset: 5 }, { text: 'UTF16', offset: 7 }]}
+        ${'URLsAndDBAs'}      | ${[{ text: 'URLs', offset: 0 }, { text: 'And', offset: 4 }, { text: 'DBAs', offset: 7 }]}
+        ${'WALKingRUNning'}   | ${[{ text: 'WALKing', offset: 0 }, { text: 'RUNning', offset: 7 }]}
+        ${'c0de'}             | ${[{ text: 'c0de', offset: 0 }]}
+    `('splitCamelCaseWordWithOffset `$word`', ({ word, expected }) => {
+        const result = Text.splitCamelCaseWordWithOffset({ text: word, offset: 0 });
+        expect(result).toEqual(expected);
+    });
+});
+
+describe('splitWordWithOffset', () => {
+    test.each`
+        word                  | expected
+        ${'hello'}            | ${[{ text: 'hello', offset: 0 }]}
+        ${'helloThere'}       | ${[{ text: 'hello', offset: 0 }, { text: 'There', offset: 5 }]}
+        ${'HelloThere'}       | ${[{ text: 'Hello', offset: 0 }, { text: 'There', offset: 5 }]}
+        ${'hello\u00ADthere'} | ${[{ text: 'hello', offset: 0 }, { text: 'there', offset: 6 }]}
+        ${'BigÁpple'}         | ${[{ text: 'Big', offset: 0 }, { text: 'Ápple', offset: 3 }]}
+        ${'ASCIIToUTF16'}     | ${[{ text: 'ASCII', offset: 0 }, { text: 'To', offset: 5 }, { text: 'UTF16', offset: 7 }]}
+        ${'URLsAndDBAs'}      | ${[{ text: 'URLs', offset: 0 }, { text: 'And', offset: 4 }, { text: 'DBAs', offset: 7 }]}
+        ${'WALKingRUNning'}   | ${[{ text: 'WALKing', offset: 0 }, { text: 'RUNning', offset: 7 }]}
+        ${'c0de'}             | ${[{ text: 'c0de', offset: 0 }]}
+    `('splitWordWithOffset `$word`', ({ word, expected }) => {
+        const result = Text.splitWordWithOffset({ text: word, offset: 0 }, regExpCamelCaseWordBreaksWithEnglishSuffix);
+        expect(result).toEqual(expected);
     });
 });
 

--- a/packages/cspell-lib/src/lib/util/text.ts
+++ b/packages/cspell-lib/src/lib/util/text.ts
@@ -40,7 +40,7 @@ export function splitWordWithOffset(wo: TextOffset, regExpWordBreaks: RegExp): T
     for (const m of wText.matchAll(r)) {
         const text = wText.slice(lastRelOffset, m.index);
         const offset = absOffset + lastRelOffset;
-        lastRelOffset = m.index! + m[0].length;
+        lastRelOffset = m.index + m[0].length;
         words.push({ text, offset });
     }
 

--- a/packages/cspell-lib/src/lib/util/text.ts
+++ b/packages/cspell-lib/src/lib/util/text.ts
@@ -14,19 +14,13 @@ import {
     regExWordsAndDigits,
 } from './textRegex.js';
 import { toUri } from './Uri.js';
-import { scanMap } from './util.js';
 
 export { stringToRegExp } from './textRegex.js';
 
 // CSpell:ignore ings ning gimuy tsmerge
 
 export function splitCamelCaseWordWithOffset(wo: TextOffset): TextOffset[] {
-    return splitCamelCaseWord(wo.text).map(
-        scanMap<string, TextOffset>((last, text) => ({ text, offset: last.offset + last.text.length }), {
-            text: '',
-            offset: wo.offset,
-        }),
-    );
+    return splitWordWithOffset(wo, regExpCamelCaseWordBreaksWithEnglishSuffix);
 }
 
 /**

--- a/packages/cspell-lib/src/lib/util/text.ts
+++ b/packages/cspell-lib/src/lib/util/text.ts
@@ -37,12 +37,25 @@ export function splitCamelCaseWord(word: string): string[] {
 }
 
 export function splitWordWithOffset(wo: TextOffset, regExpWordBreaks: RegExp): TextOffset[] {
-    return splitWord(wo.text, regExpWordBreaks).map(
-        scanMap<string, TextOffset>((last, text) => ({ text, offset: last.offset + last.text.length }), {
-            text: '',
-            offset: wo.offset,
-        }),
-    );
+    const wText = wo.text;
+    const absOffset = wo.offset;
+    const words: TextOffset[] = [];
+    let lastRelOffset = 0;
+    const r = new RegExp(regExpWordBreaks);
+
+    for (const m of wText.matchAll(r)) {
+        const text = wText.slice(lastRelOffset, m.index);
+        const offset = absOffset + lastRelOffset;
+        lastRelOffset = m.index! + m[0].length;
+        words.push({ text, offset });
+    }
+
+    if (lastRelOffset < wText.length) {
+        const text = wText.slice(lastRelOffset);
+        const offset = absOffset + lastRelOffset;
+        words.push({ text, offset });
+    }
+    return words;
 }
 
 /**

--- a/packages/cspell-lib/src/lib/util/textRegex.ts
+++ b/packages/cspell-lib/src/lib/util/textRegex.ts
@@ -1,8 +1,8 @@
 // cspell:ignore ings ning gimuy anrvtbf gimuxy
 
 export const regExUpperSOrIng: RegExp = /([\p{Lu}\p{M}]+(?:\\?['’])?(?:s|ing|ies|es|ings|ed|ning))(?!\p{Ll})/gu;
-export const regExSplitWords: RegExp = /(\p{Ll}\p{M}?)(\p{Lu})/dgu;
-export const regExSplitWords2: RegExp = /(\p{Lu}\p{M}?)((\p{Lu}\p{M}?)\p{Ll})/dgu;
+export const regExSplitWords: RegExp = /(\p{Ll}\p{M}?)(\p{Lu})/gu;
+export const regExSplitWords2: RegExp = /(\p{Lu}\p{M}?)((\p{Lu}\p{M}?)\p{Ll})/gu;
 export const regExpCamelCaseWordBreaksWithEnglishSuffix: RegExp =
     /(?<=\p{Ll}\p{M}?)(?=\p{Lu})|(?<=\p{Lu}\p{M}?)(?=\p{Lu}\p{M}?\p{Ll})(?!\p{Lu}\p{M}?(?:s|ing|ies|es|ings|ed|ning)(?!\p{Ll}))|\u00AD/gu;
 export const regExpCamelCaseWordBreaks_NOT_USED: RegExp =

--- a/packages/cspell-lib/src/lib/util/textRegex.ts
+++ b/packages/cspell-lib/src/lib/util/textRegex.ts
@@ -1,10 +1,10 @@
 // cspell:ignore ings ning gimuy anrvtbf gimuxy
 
 export const regExUpperSOrIng: RegExp = /([\p{Lu}\p{M}]+(?:\\?['’])?(?:s|ing|ies|es|ings|ed|ning))(?!\p{Ll})/gu;
-export const regExSplitWords: RegExp = /(\p{Ll}\p{M}?)(\p{Lu})/gu;
-export const regExSplitWords2: RegExp = /(\p{Lu}\p{M}?)((\p{Lu}\p{M}?)\p{Ll})/gu;
+export const regExSplitWords: RegExp = /(\p{Ll}\p{M}?)(\p{Lu})/dgu;
+export const regExSplitWords2: RegExp = /(\p{Lu}\p{M}?)((\p{Lu}\p{M}?)\p{Ll})/dgu;
 export const regExpCamelCaseWordBreaksWithEnglishSuffix: RegExp =
-    /(?<=\p{Ll}\p{M}?)(?=\p{Lu})|(?<=\p{Lu}\p{M}?)(?=\p{Lu}\p{M}?\p{Ll})(?!\p{Lu}\p{M}?(?:s|ing|ies|es|ings|ed|ning)(?!\p{Ll}))/gu;
+    /(?<=\p{Ll}\p{M}?)(?=\p{Lu})|(?<=\p{Lu}\p{M}?)(?=\p{Lu}\p{M}?\p{Ll})(?!\p{Lu}\p{M}?(?:s|ing|ies|es|ings|ed|ning)(?!\p{Ll}))|\u00AD/gu;
 export const regExpCamelCaseWordBreaks_NOT_USED: RegExp =
     /(?<=\p{Ll}\p{M}?)(?=\p{Lu})|(?<=\p{Lu}\p{M}?)(?=\p{Lu}\p{M}?\p{Ll})/gu;
 export const regExpAllPossibleWordBreaks_NOT_USED: RegExp =


### PR DESCRIPTION
This pull request enhances the word splitting utilities in the `cspell-lib` package, particularly improving how camelCase and compound words are split, especially when soft hyphens are present. It also introduces and tests new utility functions that return word segments along with their offsets, and refactors the implementation for better accuracy and maintainability.

**Key changes:**

### Feature enhancements and bug fixes

* Improved the regular expression `regExpCamelCaseWordBreaksWithEnglishSuffix` to handle soft hyphens (`\u00AD`), ensuring words like `'hello\u00ADthere'` are split correctly.
* Refactored `splitWordWithOffset` to compute word splits and their offsets more accurately, replacing the previous use of `scanMap` with a custom implementation.
* Updated `splitCamelCaseWordWithOffset` to use the new `splitWordWithOffset` implementation, improving consistency and correctness.

### Testing improvements

* Added comprehensive tests for both `splitCamelCaseWordWithOffset` and `splitWordWithOffset`, covering a variety of word forms, including those with soft hyphens and mixed casing.
* Expanded test cases for word splitting to include words with soft hyphens, ensuring the new logic is properly validated.

### Dependency and import updates

* Updated imports in `text.test.ts` to include the new or modified regular expressions used for word splitting.