### PR TITLE
fix: CSpell-Tools support replacements

### DIFF
--- a/packages/cspell-tools/cspell-tools.config.schema.json
+++ b/packages/cspell-tools/cspell-tools.config.schema.json
@@ -155,6 +155,13 @@
       ],
       "type": "object"
     },
+    "Replacements": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Replacement rules to apply to the words in the dictionary. The key is the pattern to match, and the value is the replacement string.",
+      "type": "object"
+    },
     "Target": {
       "additionalProperties": false,
       "properties": {
@@ -237,6 +244,10 @@
           "default": false,
           "description": "Remove duplicate words, favor lower case words over mixed case words. Combine compound prefixes where possible.",
           "type": "boolean"
+        },
+        "replacements": {
+          "$ref": "#/definitions/Replacements",
+          "description": "Replacement rules to apply to the words in the dictionary. The key is the pattern to match, and the value is the replacement string."
         },
         "sort": {
           "default": true,

--- a/packages/cspell-tools/fixtures/dicts/rep-words.txt
+++ b/packages/cspell-tools/fixtures/dicts/rep-words.txt
@@ -1,0 +1,12 @@
+# some words with replacements
+recoveries
+recovering
+recovers
+recovery
+recovery's
+recovery’s
+recrate
+recrated
+recuperation's
+recuperations
+recuperation’s

--- a/packages/cspell-tools/src/compiler/CompileOptions.ts
+++ b/packages/cspell-tools/src/compiler/CompileOptions.ts
@@ -1,4 +1,6 @@
-export interface CompileOptions {
+import type { CompileTargetOptions } from '../config/index.ts';
+
+export interface CompileOptions extends Omit<CompileTargetOptions, 'allowedSplitWords'> {
     /**
      * Sort the words in the resulting dictionary.
      * Does not apply to `trie` based formats.

--- a/packages/cspell-tools/src/compiler/__snapshots__/compile.test.ts.snap
+++ b/packages/cspell-tools/src/compiler/__snapshots__/compile.test.ts.snap
@@ -366,3 +366,160 @@ green
 purple
 "
 `;
+
+exports[`compile > compile fixture 'dicts/cities.txt' fmt: 'plaintext' gz: false alt: true 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+London
+Los Angeles
+Mexico City
+New Amsterdam
+New Delhi
+New York
+Paris
+San Francisco
+~london
+~los angeles
+~mexico city
+~new amsterdam
+~new delhi
+~new york
+~paris
+~san francisco
+"
+`;
+
+exports[`compile > compile fixture 'dicts/cities.txt' fmt: 'plaintext' gz: false alt: undefined 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+London
+Los Angeles
+Mexico City
+New Amsterdam
+New Delhi
+New York
+Paris
+San Francisco
+"
+`;
+
+exports[`compile > compile fixture 'dicts/cities.txt' fmt: 'plaintext' gz: true alt: true 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+London
+Los Angeles
+Mexico City
+New Amsterdam
+New Delhi
+New York
+Paris
+San Francisco
+~london
+~los angeles
+~mexico city
+~new amsterdam
+~new delhi
+~new york
+~paris
+~san francisco
+"
+`;
+
+exports[`compile > compile fixture 'dicts/cities.txt' fmt: 'plaintext' gz: true alt: undefined 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+London
+Los Angeles
+Mexico City
+New Amsterdam
+New Delhi
+New York
+Paris
+San Francisco
+"
+`;
+
+exports[`compile > compile fixture 'dicts/cities.txt' fmt: 'trie3' gz: false alt: undefined 1`] = `
+"#!/usr/bin/env cspell-trie reader
+TrieXv3
+base=10
+# Built by cspell-tools.
+# Data:
+__DATA__
+L
+o
+ndon$4s Angeles$9<2
+M
+e
+xico City$9<2
+N
+e
+w Amsterdam$9Delhi$5York$8
+P
+a
+ri#13;<4
+S
+a
+n Francisco$9<4
+"
+`;
+
+exports[`compile > compile fixture 'dicts/rep-words.txt' fmt: 'plaintext' gz: false alt: undefined 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+recoveries
+recovering
+recovers
+recovery
+recovery's
+recrate
+recrated
+recuperation's
+recuperations
+"
+`;
+
+exports[`compile > compile fixture 'dicts/sampleCodeDic.txt' fmt: 'plaintext' gz: false alt: true 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+!Codemsg
+!Errorerror
+!codecode
+!err
+*msg
++code*
++error*
+Café
+Code*
+Error*
+~!codemsg
+~!errorerror
+~cafe
+~café
+~code*
+~error*
+"
+`;
+
+exports[`compile > compile fixture 'dicts/sampleCodeDic.txt' fmt: 'plaintext' gz: false alt: undefined 1`] = `
+"
+# cspell-tools: keep-case no-split
+
+!Codemsg
+!Errorerror
+!codecode
+!err
+*msg
++code*
++error*
+Café
+Code*
+Error*
+"
+`;

--- a/packages/cspell-tools/src/compiler/compile.test.ts
+++ b/packages/cspell-tools/src/compiler/compile.test.ts
@@ -56,6 +56,44 @@ describe('compile', () => {
                 generateNonStrict,
                 trieBase: 10,
                 sort: true,
+                replacements: undefined,
+            };
+            const req: CompileRequest = {
+                targets: [target],
+            };
+
+            await compile(req);
+
+            const ext = (format === 'plaintext' ? '.txt' : '.trie') + ((compress && '.gz') || '');
+            const content = await readTextFile(`${targetDirectory}/myDictionary${ext}`);
+            expect(content).toMatchSnapshot();
+        },
+    );
+
+    test.each`
+        file                         | format         | compress | generateNonStrict
+        ${'dicts/cities.txt'}        | ${'plaintext'} | ${false} | ${true}
+        ${'dicts/cities.txt'}        | ${'plaintext'} | ${true}  | ${true}
+        ${'dicts/cities.txt'}        | ${'plaintext'} | ${false} | ${undefined}
+        ${'dicts/cities.txt'}        | ${'plaintext'} | ${true}  | ${undefined}
+        ${'dicts/cities.txt'}        | ${'trie3'}     | ${false} | ${undefined}
+        ${'dicts/sampleCodeDic.txt'} | ${'plaintext'} | ${false} | ${undefined}
+        ${'dicts/sampleCodeDic.txt'} | ${'plaintext'} | ${false} | ${true}
+        ${'dicts/rep-words.txt'}     | ${'plaintext'} | ${false} | ${undefined}
+    `(
+        'compile fixture $file fmt: $format gz: $compress alt: $generateNonStrict',
+        async ({ format, file, generateNonStrict, compress }) => {
+            const targetDirectory = t(`.`);
+            const target: Target = {
+                name: 'myDictionary',
+                targetDirectory,
+                format,
+                sources: [fix(file)],
+                compress,
+                generateNonStrict,
+                trieBase: 10,
+                sort: true,
+                replacements: { '’': "'" },
             };
             const req: CompileRequest = {
                 targets: [target],
@@ -91,6 +129,7 @@ describe('compile', () => {
                 generateNonStrict,
                 trieBase: 10,
                 sort: true,
+                replacements: undefined,
             };
             const req: CompileRequest = {
                 targets: [target],
@@ -127,6 +166,7 @@ describe('compile', () => {
             trieBase: 10,
             sort: true,
             excludeWordsFrom: excludeWordsFrom.map((f: string) => fix(f)),
+            replacements: undefined,
         };
         const req: CompileRequest = {
             targets: [target],
@@ -164,6 +204,7 @@ describe('compile', () => {
                 trieBase: 10,
                 sort: true,
                 excludeWordsNotFoundIn: excludeWordsNotFoundIn.map((f: string) => fix(f)),
+                replacements: undefined,
             };
             const req: CompileRequest = {
                 targets: [target],
@@ -203,6 +244,7 @@ describe('compile', () => {
                 trieBase: 10,
                 sort: true,
                 excludeWordsMatchingRegex,
+                replacements: undefined,
             };
             const req: CompileRequest = {
                 targets: [target],

--- a/packages/cspell-tools/src/compiler/compile.ts
+++ b/packages/cspell-tools/src/compiler/compile.ts
@@ -54,6 +54,7 @@ export async function compile(request: CompileRequest, options?: CompileOptions)
         sort: request.sort,
         generateNonStrict: request.generateNonStrict,
         removeDuplicates: request.removeDuplicates,
+        replacements: undefined,
     };
     const conditional = options?.conditionalBuild || false;
     const checksumFile = resolveChecksumFile(request.checksumFile || conditional, rootDir);
@@ -190,6 +191,7 @@ async function buildTargetDictionary(
         excludeWordsFrom = [],
         excludeWordsNotFoundIn = [],
         excludeWordsMatchingRegex,
+        replacements,
     } = target;
     const { filename, useTrie, generateOnlyCompressedDictionary, checksumRoot } = buildOptions;
     const dictionaryDirectives = target.dictionaryDirectives ?? compileOptions.dictionaryDirectives;
@@ -217,6 +219,7 @@ async function buildTargetDictionary(
         filter: excludeFilter,
         dictionaryDirectives,
         // removeDuplicates, // Add this in if we use it.
+        replacements,
     });
 
     const deps = [
@@ -248,6 +251,7 @@ async function buildTargetDictionary(
                   generateNonStrict,
                   dictionaryDirectives,
                   removeDuplicates,
+                  replacements,
               });
         const data = iterableToString(pipe(words, normalizer, compiler));
 

--- a/packages/cspell-tools/src/compiler/createCompileRequest.ts
+++ b/packages/cspell-tools/src/compiler/createCompileRequest.ts
@@ -47,6 +47,7 @@ function calcTargets(sources: DictionarySource[], options: CompileCommonAppOptio
             sort,
             trieBase: parseNumber(options.trieBase),
             generateNonStrict,
+            replacements: undefined,
         };
         return [target];
     }
@@ -62,6 +63,7 @@ function calcTargets(sources: DictionarySource[], options: CompileCommonAppOptio
             sort: options.sort,
             trieBase: parseNumber(options.trieBase),
             generateNonStrict,
+            replacements: undefined,
         };
         return target;
     });

--- a/packages/cspell-tools/src/compiler/wordListCompiler.test.ts
+++ b/packages/cspell-tools/src/compiler/wordListCompiler.test.ts
@@ -9,6 +9,7 @@ import { importTrie, isCircular, iteratorTrieWords, serializeTrie } from 'cspell
 import { uniqueFilter } from 'hunspell-reader';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { Replacements } from '../config/index.ts';
 import { spyOnConsole } from '../test/console.ts';
 import { createTestHelper } from '../test/TestHelper.ts';
 import type { CompileOptions } from './CompileOptions.ts';
@@ -264,8 +265,9 @@ function compileOpt(
     generateNonStrict = true,
     dictionaryDirectives: string[] | undefined = undefined,
     removeDuplicates = false,
+    replacements: Replacements | undefined = undefined,
 ): CompileOptions {
-    return { sort, generateNonStrict, dictionaryDirectives, removeDuplicates };
+    return { sort, generateNonStrict, dictionaryDirectives, removeDuplicates, replacements };
 }
 
 // const cities = `\

--- a/packages/cspell-tools/src/compiler/wordListParser.test.ts
+++ b/packages/cspell-tools/src/compiler/wordListParser.test.ts
@@ -21,7 +21,7 @@ describe('Validate the wordListCompiler', () => {
         ${'hello'}                                  | ${true}  | ${['hello']}
         ${'!Hello'}                                 | ${true}  | ${'!Hello'}
     `('createSortAndFilterOperation $lines $sort', ({ lines, expectedResult, sort }) => {
-        const normalizer = normalizeTargetWords({ sort, generateNonStrict: false });
+        const normalizer = normalizeTargetWords({ sort, generateNonStrict: false, replacements: undefined });
         const r = toArray(normalizer(s(lines)));
         expect(r).toEqual(s(expectedResult));
     });
@@ -31,9 +31,10 @@ describe('Validate the wordListCompiler', () => {
         ${'banana|Apple|Apple|apple'}        | ${true}  | ${'Apple|apple|banana|~apple'}
         ${'banana|Apple|Apple|apple|banana'} | ${false} | ${'banana|Apple|~apple|apple'}
         ${'hello'}                           | ${true}  | ${'hello'}
+        ${'recovery’s'}                      | ${true}  | ${"recovery's"}
         ${'!Hello'}                          | ${true}  | ${'!Hello|~!hello'}
     `('createSortAndFilterOperation $lines $sort', ({ lines, expectedResult, sort }) => {
-        const normalizer = normalizeTargetWords({ sort, generateNonStrict: true });
+        const normalizer = normalizeTargetWords({ sort, generateNonStrict: true, replacements: { '’': "'" } });
         const r = toArray(normalizer(s(lines)));
         expect(r).toEqual(s(expectedResult));
     });

--- a/packages/cspell-tools/src/compiler/wordListParser.ts
+++ b/packages/cspell-tools/src/compiler/wordListParser.ts
@@ -4,6 +4,7 @@ import { createDictionaryLineParser } from 'cspell-trie-lib';
 import { uniqueFilter } from 'hunspell-reader';
 
 import { defaultCompileSourceOptions } from '../config/configDefaults.ts';
+import type { Replacements } from '../config/index.ts';
 import type { CompileOptions } from './CompileOptions.ts';
 import { legacyLineToWords } from './legacyLineToWords.ts';
 import { splitCamelCaseIfAllowed } from './splitCamelCaseIfAllowed.ts';
@@ -21,6 +22,7 @@ export function normalizeTargetWords(options: CompileOptions): Operator<string> 
         options.sort ? createInlineBufferedSort(10_000) : undefined,
         opFilter<string>(uniqueFilter(10_000)),
         options.filter ? opFilter<string>(options.filter) : undefined,
+        replacementsToMapOperator(options.replacements),
     ].filter(isDefined);
     return opCombine(...operations);
 }
@@ -274,4 +276,14 @@ export function createParseFileLineMapper(options?: Partial<ParseFileOptions>): 
  */
 export function parseFileLines(lines: Iterable<string> | string, options: ParseFileOptions): Iterable<string> {
     return createParseFileLineMapper(options)(typeof lines === 'string' ? [lines] : lines);
+}
+
+function replacementsToMapOperator(replacements: Replacements | undefined): Operator<string, string> | undefined {
+    if (!replacements) return undefined;
+    return opMap((word) => {
+        for (const [pattern, replacement] of Object.entries(replacements)) {
+            word = word.replaceAll(pattern, replacement);
+        }
+        return word;
+    });
 }

--- a/packages/cspell-tools/src/config/config.ts
+++ b/packages/cspell-tools/src/config/config.ts
@@ -17,7 +17,7 @@ export interface RunConfig extends Partial<Omit<CompileRequest, 'targets'>> {
     rootDir?: string | undefined;
 }
 
-export interface CompileRequest extends CompileTargetOptions, CompileSourceOptions {
+export interface CompileRequest extends Omit<CompileTargetOptions, 'replacements'>, CompileSourceOptions {
     /**
      * Specify the directory where all relative paths will resolved against.
      * By default, all relative paths are relative to the current directory.
@@ -92,7 +92,19 @@ export interface CompileTargetOptions {
      * @default false
      */
     removeDuplicates?: boolean | undefined;
+
+    /**
+     * Replacement rules to apply to the words in the dictionary.
+     * The key is the pattern to match, and the value is the replacement string.
+     */
+    replacements: Replacements | undefined;
 }
+
+/**
+ * Replacement rules to apply to the words in the dictionary.
+ * The key is the pattern to match, and the value is the replacement string.
+ */
+export type Replacements = Record<string, string>;
 
 export interface Target extends CompileTargetOptions {
     /**

--- a/packages/cspell-tools/src/config/index.ts
+++ b/packages/cspell-tools/src/config/index.ts
@@ -7,6 +7,7 @@ export type {
     FileListSource,
     FilePath,
     FileSource,
+    Replacements,
     RunConfig,
     Target,
 } from './config.ts';


### PR DESCRIPTION
Support replacing word fragments before adding the word to the dictionary.

## **TL;DR**
Be able to replace `’` with `'`.

## Details

This pull request adds support for applying word replacement rules during dictionary compilation in `cspell-tools`. The main change is the introduction of a `replacements` option, allowing users to specify patterns and their replacements, which are then applied to all words in the dictionary. The changes include updates to the configuration schema, TypeScript interfaces, core compilation logic, and tests to support and verify this new feature.

**Add support for word replacements in dictionary compilation:**

* **Configuration and Schema Updates:**
  - Added a `Replacements` definition and a `replacements` property to the JSON schema and TypeScript interfaces, allowing users to specify replacement rules in config files and programmatic interfaces. [[1]](diffhunk://#diff-461485728e7d7363d70fa003d157b2fee76ebe81d66639fafbeef7aa6ee58b7cR158-R164) [[2]](diffhunk://#diff-461485728e7d7363d70fa003d157b2fee76ebe81d66639fafbeef7aa6ee58b7cR248-R251) [[3]](diffhunk://#diff-a5d02ba854b88e2e8b83197c4a15e410e10b931ebc8bbda6b777780c4448bb77R95-R108) [[4]](diffhunk://#diff-10cc7cfa8dee170e380d597cc6f37d0fe78a1b8b53bab0b9980d74e8f1dd8b99R10)

* **Compiler Logic Enhancements:**
  - Updated the core compilation pipeline (`compile.ts`, `wordListParser.ts`) to accept and apply the `replacements` option, mapping specified patterns to their replacements during normalization of dictionary words. [[1]](diffhunk://#diff-abbcc701a68b0b884bc77813c1be1e438f830466ead1b838f0dff1dd75eb5becR194) [[2]](diffhunk://#diff-1fa6211a0e9f939021351f0ed3cfdffe9b4c3209c92b369c328811c986e1140fR25) [[3]](diffhunk://#diff-1fa6211a0e9f939021351f0ed3cfdffe9b4c3209c92b369c328811c986e1140fR280-R289)

* **Testing and Fixtures:**
  - Extended and added tests to verify that replacements are correctly applied, including new test cases and fixtures (such as `rep-words.txt`) and snapshot updates. [[1]](diffhunk://#diff-a09bfea2415f93e38ba5d6b778e9e0204e4db8ac19ea06a019390e06587fed42R1-R12) [[2]](diffhunk://#diff-643cf9dbc1c82e07338902ef990406fabc2a4fd22da5d2694f5ab5f6115c2e08R59-R96) [[3]](diffhunk://#diff-643cf9dbc1c82e07338902ef990406fabc2a4fd22da5d2694f5ab5f6115c2e08R132) [[4]](diffhunk://#diff-643cf9dbc1c82e07338902ef990406fabc2a4fd22da5d2694f5ab5f6115c2e08R169) [[5]](diffhunk://#diff-643cf9dbc1c82e07338902ef990406fabc2a4fd22da5d2694f5ab5f6115c2e08R207) [[6]](diffhunk://#diff-643cf9dbc1c82e07338902ef990406fabc2a4fd22da5d2694f5ab5f6115c2e08R247) [[7]](diffhunk://#diff-a7f698e8f0adcfceb8260e1236de114c5fcbbd051b4e5f50837ae50f3b039954R34-R37)

* **Type and Interface Adjustments:**
  - Refactored relevant interfaces (`CompileOptions`, `CompileRequest`, etc.) to include or omit the new `replacements` property as appropriate, ensuring type safety and clarity throughout the codebase. [[1]](diffhunk://#diff-035305fe90cbce5bf3bd1ff6b32c44c4093b00bf9acfc08733671afbc9b1a05aL1-R3) [[2]](diffhunk://#diff-a5d02ba854b88e2e8b83197c4a15e410e10b931ebc8bbda6b777780c4448bb77L20-R20)

These changes collectively enable more flexible and accurate dictionary generation by allowing systematic normalization or correction of word forms via configurable replacement rules.