### PR TITLE
fix: Update documentation and schema for recent improvements

### DIFF
--- a/cspell.schema.json
+++ b/cspell.schema.json
@@ -88,9 +88,9 @@
         },
         "cacheStrategy": {
           "$ref": "#/definitions/CacheStrategy",
-          "default": "metadata",
-          "description": "Strategy to use for detecting changed files, default: metadata",
-          "markdownDescription": "Strategy to use for detecting changed files, default: metadata"
+          "default": "content",
+          "description": "Strategy to use for detecting changed files, default: content",
+          "markdownDescription": "Strategy to use for detecting changed files, default: content"
         },
         "useCache": {
           "default": false,
@@ -1417,8 +1417,8 @@
           "since": "9.1.0"
         },
         "useIntlWordSegmentation": {
-          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "description": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "markdownDescription": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
           "since": "10.2.0",
           "type": "boolean"
         },
@@ -1491,11 +1491,11 @@
           "type": "array"
         },
         "enableFiletypes": {
-          "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+          "description": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
           "items": {
             "$ref": "#/definitions/LanguageIdSingle"
           },
-          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
           "scope": "resource",
           "title": "Enable File Types",
           "type": "array",
@@ -1727,8 +1727,8 @@
           "since": "9.1.0"
         },
         "useIntlWordSegmentation": {
-          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "description": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "markdownDescription": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
           "since": "10.2.0",
           "type": "boolean"
         },
@@ -2198,11 +2198,11 @@
       "type": "array"
     },
     "enableFiletypes": {
-      "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+      "description": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
       "items": {
         "$ref": "#/definitions/LanguageIdSingle"
       },
-      "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+      "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
       "scope": "resource",
       "title": "Enable File Types",
       "type": "array",
@@ -2291,8 +2291,8 @@
     },
     "globRoot": {
       "$ref": "#/definitions/FSPathResolvable",
-      "description": "The root to use for glob patterns found in this configuration. Default: location of the configuration file.   For compatibility reasons, config files with version 0.1, the glob root will   default to be `${cwd}`.\n\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot, does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file.",
-      "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: location of the configuration file.\n  For compatibility reasons, config files with version 0.1, the glob root will\n  default to be `${cwd}`.\n\nUse `globRoot` to define a different location.\n`globRoot` can be relative to the location of this configuration file.\nDefining globRoot, does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file."
+      "description": "The root to use for glob patterns found in this configuration. Default: location of the configuration file.   For compatibility reasons, for config files with version 0.1, the glob root will   default to be `${cwd}`.\n\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file.",
+      "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: location of the configuration file.\n  For compatibility reasons, for config files with version 0.1, the glob root will\n  default to be `${cwd}`.\n\nUse `globRoot` to define a different location.\n`globRoot` can be relative to the location of this configuration file.\nDefining globRoot does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file."
     },
     "id": {
       "description": "Optional identifier.",
@@ -2354,8 +2354,8 @@
     },
     "languageId": {
       "$ref": "#/definitions/MatchingFileType",
-      "description": "Forces the spell checker to assume a give language id. Used mainly as an Override.",
-      "markdownDescription": "Forces the spell checker to assume a give language id. Used mainly as an Override."
+      "description": "Forces the spell checker to assume a given language id. Used mainly as an Override.",
+      "markdownDescription": "Forces the spell checker to assume a given language id. Used mainly as an Override."
     },
     "languageSettings": {
       "description": "Additional settings for individual languages.\n\nSee [Language Settings](https://cspell.org/configuration/language-settings/) for more details.",
@@ -2544,8 +2544,8 @@
       "type": "boolean"
     },
     "useIntlWordSegmentation": {
-      "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-      "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+      "description": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+      "markdownDescription": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
       "since": "10.2.0",
       "type": "boolean"
     },

--- a/packages/cspell-types/api/index.d.mts
+++ b/packages/cspell-types/api/index.d.mts
@@ -1402,7 +1402,7 @@ type Serializable = number | string | boolean | null | object;
 //#region src/WordSegmentation.d.ts
 interface WordSegmentationSettings {
   /**
-   * Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.
+   * Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.
    * The locale used for the segmentation is based on the {@link language} setting.
    *
    * @since 10.2.0
@@ -1565,12 +1565,12 @@ interface FileSettings extends ExtendableSettings, CommandLineSettings {
   /**
    * The root to use for glob patterns found in this configuration.
    * Default: location of the configuration file.
-   *   For compatibility reasons, config files with version 0.1, the glob root will
+   *   For compatibility reasons, for config files with version 0.1, the glob root will
    *   default to be `${cwd}`.
    *
    * Use `globRoot` to define a different location.
    * `globRoot` can be relative to the location of this configuration file.
-   * Defining globRoot, does not impact imported configurations.
+   * Defining globRoot does not impact imported configurations.
    *
    * Special Values:
    * - `${cwd}` - will be replaced with the current working directory.
@@ -1711,8 +1711,8 @@ interface SpellCheckerExtensionSettings {
   /**
    * Enable / Disable checking file types (languageIds).
    *
-   * These are in additional to the file types specified by {@link Settings.enabledLanguageIds}.
-   * To disable a language, prefix with `!` as in `!json`,
+   * These are in addition to the file types specified by {@link Settings.enabledLanguageIds}.
+   * To disable a language, prefix with `!` as in `!json`.
    *
    *
    * **Example: individual file types**
@@ -1777,7 +1777,7 @@ interface Settings extends ReportingConfiguration, BaseSetting, PnPSettings, Spe
    *
    */
   languageSettings?: LanguageSetting[];
-  /** Forces the spell checker to assume a give language id. Used mainly as an Override. */
+  /** Forces the spell checker to assume a given language id. Used mainly as an Override. */
   languageId?: MatchingFileType;
   /**
    * By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false`
@@ -1855,8 +1855,8 @@ interface CacheSettings {
    */
   cacheLocation?: FSPathResolvable;
   /**
-   * Strategy to use for detecting changed files, default: metadata
-   * @default 'metadata'
+   * Strategy to use for detecting changed files, default: content
+   * @default 'content'
    */
   cacheStrategy?: CacheStrategy;
   /**

--- a/packages/cspell-types/cspell.schema.json
+++ b/packages/cspell-types/cspell.schema.json
@@ -88,9 +88,9 @@
         },
         "cacheStrategy": {
           "$ref": "#/definitions/CacheStrategy",
-          "default": "metadata",
-          "description": "Strategy to use for detecting changed files, default: metadata",
-          "markdownDescription": "Strategy to use for detecting changed files, default: metadata"
+          "default": "content",
+          "description": "Strategy to use for detecting changed files, default: content",
+          "markdownDescription": "Strategy to use for detecting changed files, default: content"
         },
         "useCache": {
           "default": false,
@@ -1417,8 +1417,8 @@
           "since": "9.1.0"
         },
         "useIntlWordSegmentation": {
-          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "description": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "markdownDescription": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
           "since": "10.2.0",
           "type": "boolean"
         },
@@ -1491,11 +1491,11 @@
           "type": "array"
         },
         "enableFiletypes": {
-          "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+          "description": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
           "items": {
             "$ref": "#/definitions/LanguageIdSingle"
           },
-          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
           "scope": "resource",
           "title": "Enable File Types",
           "type": "array",
@@ -1727,8 +1727,8 @@
           "since": "9.1.0"
         },
         "useIntlWordSegmentation": {
-          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "description": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "markdownDescription": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
           "since": "10.2.0",
           "type": "boolean"
         },
@@ -2198,11 +2198,11 @@
       "type": "array"
     },
     "enableFiletypes": {
-      "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+      "description": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
       "items": {
         "$ref": "#/definitions/LanguageIdSingle"
       },
-      "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+      "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in addition to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`.\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
       "scope": "resource",
       "title": "Enable File Types",
       "type": "array",
@@ -2291,8 +2291,8 @@
     },
     "globRoot": {
       "$ref": "#/definitions/FSPathResolvable",
-      "description": "The root to use for glob patterns found in this configuration. Default: location of the configuration file.   For compatibility reasons, config files with version 0.1, the glob root will   default to be `${cwd}`.\n\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot, does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file.",
-      "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: location of the configuration file.\n  For compatibility reasons, config files with version 0.1, the glob root will\n  default to be `${cwd}`.\n\nUse `globRoot` to define a different location.\n`globRoot` can be relative to the location of this configuration file.\nDefining globRoot, does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file."
+      "description": "The root to use for glob patterns found in this configuration. Default: location of the configuration file.   For compatibility reasons, for config files with version 0.1, the glob root will   default to be `${cwd}`.\n\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file.",
+      "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: location of the configuration file.\n  For compatibility reasons, for config files with version 0.1, the glob root will\n  default to be `${cwd}`.\n\nUse `globRoot` to define a different location.\n`globRoot` can be relative to the location of this configuration file.\nDefining globRoot does not impact imported configurations.\n\nSpecial Values:\n- `${cwd}` - will be replaced with the current working directory.\n- `.` - will be the location of the containing configuration file."
     },
     "id": {
       "description": "Optional identifier.",
@@ -2354,8 +2354,8 @@
     },
     "languageId": {
       "$ref": "#/definitions/MatchingFileType",
-      "description": "Forces the spell checker to assume a give language id. Used mainly as an Override.",
-      "markdownDescription": "Forces the spell checker to assume a give language id. Used mainly as an Override."
+      "description": "Forces the spell checker to assume a given language id. Used mainly as an Override.",
+      "markdownDescription": "Forces the spell checker to assume a given language id. Used mainly as an Override."
     },
     "languageSettings": {
       "description": "Additional settings for individual languages.\n\nSee [Language Settings](https://cspell.org/configuration/language-settings/) for more details.",
@@ -2544,8 +2544,8 @@
       "type": "boolean"
     },
     "useIntlWordSegmentation": {
-      "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-      "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+      "description": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+      "markdownDescription": "Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
       "since": "10.2.0",
       "type": "boolean"
     },

--- a/packages/cspell-types/src/CSpellSettingsDef.ts
+++ b/packages/cspell-types/src/CSpellSettingsDef.ts
@@ -62,12 +62,12 @@ export interface FileSettings extends ExtendableSettings, CommandLineSettings {
     /**
      * The root to use for glob patterns found in this configuration.
      * Default: location of the configuration file.
-     *   For compatibility reasons, config files with version 0.1, the glob root will
+     *   For compatibility reasons, for config files with version 0.1, the glob root will
      *   default to be `${cwd}`.
      *
      * Use `globRoot` to define a different location.
      * `globRoot` can be relative to the location of this configuration file.
-     * Defining globRoot, does not impact imported configurations.
+     * Defining globRoot does not impact imported configurations.
      *
      * Special Values:
      * - `${cwd}` - will be replaced with the current working directory.
@@ -229,8 +229,8 @@ export interface SpellCheckerExtensionSettings {
     /**
      * Enable / Disable checking file types (languageIds).
      *
-     * These are in additional to the file types specified by {@link Settings.enabledLanguageIds}.
-     * To disable a language, prefix with `!` as in `!json`,
+     * These are in addition to the file types specified by {@link Settings.enabledLanguageIds}.
+     * To disable a language, prefix with `!` as in `!json`.
      *
      *
      * **Example: individual file types**
@@ -299,7 +299,7 @@ export interface Settings extends ReportingConfiguration, BaseSetting, PnPSettin
      */
     languageSettings?: LanguageSetting[];
 
-    /** Forces the spell checker to assume a give language id. Used mainly as an Override. */
+    /** Forces the spell checker to assume a given language id. Used mainly as an Override. */
     languageId?: MatchingFileType;
 
     /**
@@ -387,8 +387,8 @@ export interface CacheSettings {
     cacheLocation?: FSPathResolvable;
 
     /**
-     * Strategy to use for detecting changed files, default: metadata
-     * @default 'metadata'
+     * Strategy to use for detecting changed files, default: content
+     * @default 'content'
      */
     cacheStrategy?: CacheStrategy;
 

--- a/packages/cspell-types/src/WordSegmentation.ts
+++ b/packages/cspell-types/src/WordSegmentation.ts
@@ -1,6 +1,6 @@
 export interface WordSegmentationSettings {
     /**
-     * Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.
+     * Enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.
      * The locale used for the segmentation is based on the {@link language} setting.
      *
      * @since 10.2.0

--- a/packages/cspell/README.md
+++ b/packages/cspell/README.md
@@ -641,7 +641,7 @@ export default defineConfig({
 
   will cause cspell to ignore anything in the `node_modules` directory.
 
-- `maxNumberOfProblems` - defaults to **_100_** per file.
+- `maxNumberOfProblems` - defaults to **_10,000_** per file.
 
 - `minWordLength` - defaults to **_4_** - the minimum length of a word before it is checked.
 


### PR DESCRIPTION
This pull request updates documentation and default values in both the `cspell.schema.json` and TypeScript type definitions to improve clarity and accuracy. The main changes include updating the default cache strategy, fixing typos and grammatical errors, and clarifying descriptions for several configuration options.

**Configuration behavior changes:**

* The default value for `cacheStrategy` is now `"content"` instead of `"metadata"`, and the descriptions have been updated accordingly in both the schema and type definitions. [[1]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL91-R93) [[2]](diffhunk://#diff-14f40e062c024a63c555a8565984f3d45268e79b41d2dbea8960eab1473be840L1858-R1859) [[3]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL91-R93)

**Documentation and description improvements:**

* Fixed typos and clarified grammar in descriptions for `useIntlWordSegmentation`, `enableFiletypes`, `globRoot`, and `languageId` across both the schema and type definitions. These changes ensure consistency and make the documentation easier to understand. [[1]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL1420-R1421) [[2]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL1494-R1498) [[3]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL1730-R1731) [[4]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL2201-R2205) [[5]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL2294-R2295) [[6]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL2357-R2358) [[7]](diffhunk://#diff-ad9ad04ccf6ebafd4ec4d6b18ad6b3338e9262d9c29b0d780e27ac73e84c9f4cL2547-R2548) [[8]](diffhunk://#diff-14f40e062c024a63c555a8565984f3d45268e79b41d2dbea8960eab1473be840L1405-R1405) [[9]](diffhunk://#diff-14f40e062c024a63c555a8565984f3d45268e79b41d2dbea8960eab1473be840L1568-R1573) [[10]](diffhunk://#diff-14f40e062c024a63c555a8565984f3d45268e79b41d2dbea8960eab1473be840L1714-R1715) [[11]](diffhunk://#diff-14f40e062c024a63c555a8565984f3d45268e79b41d2dbea8960eab1473be840L1780-R1780)

No functional code changes were made; all updates are to documentation, default values, and descriptions to improve developer experience and reduce ambiguity.