### PR TITLE
docs: Use images from cspell.org

### DIFF
--- a/static/sponsor.md
+++ b/static/sponsor.md
@@ -1,11 +1,11 @@
 If CSpell saves you time, please consider supporting its development.
 
 <p align="left">
-  <a href="https://github.com/sponsors/streetsidesoftware" title="GitHub Sponsor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/github-sponsor-dark.png" /><img alt="GitHub Sponsor" src="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/github-sponsor.png" width="180" /></picture></a>
+  <a href="https://github.com/sponsors/streetsidesoftware" title="GitHub Sponsor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cspell.org/img/sponsor/github-sponsor-dark.png" /><img alt="GitHub Sponsor" src="https://cspell.org/img/sponsor/github-sponsor.png" width="180" /></picture></a>
   &nbsp;
-  <a href="https://www.paypal.com/donate/?hosted_button_id=26LNBP2Q6MKCY" title="PayPal"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/paypal-dark.png" /><img alt="PayPal" src="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/paypal.png" width="180" /></picture></a>
+  <a href="https://www.paypal.com/donate/?hosted_button_id=26LNBP2Q6MKCY" title="PayPal"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cspell.org/img/sponsor/paypal-dark.png" /><img alt="PayPal" src="https://cspell.org/img/sponsor/paypal.png" width="180" /></picture></a>
   &nbsp;
-  <a href="https://opencollective.com/cspell" title="Open Collective"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/open-collective-dark.png" /><img alt="Open Collective" src="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/open-collective.png" width="180" /></picture></a>
+  <a href="https://opencollective.com/cspell" title="Open Collective"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cspell.org/img/sponsor/open-collective-dark.png" /><img alt="Open Collective" src="https://cspell.org/img/sponsor/open-collective.png" width="180" /></picture></a>
   &nbsp;
-  <a href="https://streetsidesoftware.com/sponsor/" title="Street Side Software"><picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/cspell-dark.png" /><img alt="CSpell" src="https://raw.githubusercontent.com/streetsidesoftware/cspell/main/static/sponsor/cspell.png" width="180" /></picture></a>
+  <a href="https://streetsidesoftware.com/sponsor/" title="Street Side Software"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cspell.org/img/sponsor/cspell-dark.png" /><img alt="CSpell" src="https://cspell.org/img/sponsor/cspell.png" width="180" /></picture></a>
 </p>


### PR DESCRIPTION
This pull request updates the sponsor images in the `static/sponsor.md` file to use image URLs hosted on `cspell.org` instead of GitHub's raw content URLs. This change ensures that sponsor images are loaded from a consistent and likely more reliable source.

- Updated all sponsor image URLs in `static/sponsor.md` to point to `cspell.org/img/sponsor/` instead of the GitHub repository.